### PR TITLE
v8.1.13: P1-3 DoLoginAsync — eliminate ThreadPool starvation

### DIFF
--- a/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo/_Admin/Controllers/AccountController.cs
+++ b/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo/_Admin/Controllers/AccountController.cs
@@ -32,7 +32,7 @@ namespace WalkingTec.Mvvm.Admin.Api
         public async Task<IActionResult> Login([FromForm] string account, [FromForm] string password, [FromForm] string tenant = null, [FromForm] bool rememberLogin = false)
         {
 
-            var user = Wtm.DoLogin(account, password, tenant);
+            var user = await Wtm.DoLoginAsync(account, password, tenant);
             if (user == null)
             {
                 return BadRequest(Localizer["Sys.LoginFailed"].Value);
@@ -62,7 +62,7 @@ namespace WalkingTec.Mvvm.Admin.Api
         [HttpPost("LoginJwt")]
         public async Task<IActionResult> LoginJwt(SimpleLogin loginInfo)
         {
-            var user = Wtm.DoLogin(loginInfo.Account, loginInfo.Password, loginInfo.Tenant);
+            var user = await Wtm.DoLoginAsync(loginInfo.Account, loginInfo.Password, loginInfo.Tenant);
             if (user == null)
             {
                 ModelState.AddModelError(" ", Localizer["Sys.LoginFailed"]);

--- a/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/ApiControllers/AccountController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/ApiControllers/AccountController.cs
@@ -32,7 +32,7 @@ namespace WalkingTec.Mvvm.Admin.Api
         public async Task<IActionResult> Login([FromForm] string account, [FromForm] string password, [FromForm] string tenant = null, [FromForm] bool rememberLogin = false)
         {
 
-            var user = Wtm.DoLogin(account, password, tenant);
+            var user = await Wtm.DoLoginAsync(account, password, tenant);
             if (user == null)
             {
                 return BadRequest(Localizer["Sys.LoginFailed"].Value);
@@ -62,7 +62,7 @@ namespace WalkingTec.Mvvm.Admin.Api
         [HttpPost("LoginJwt")]
         public async Task<IActionResult> LoginJwt(SimpleLogin loginInfo)
         {
-            var user = Wtm.DoLogin(loginInfo.Account, loginInfo.Password, loginInfo.Tenant);
+            var user = await Wtm.DoLoginAsync(loginInfo.Account, loginInfo.Password, loginInfo.Tenant);
             if (user == null)
             {
                 ModelState.AddModelError(" ", Localizer["Sys.LoginFailed"]);

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/LoginController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/LoginController.cs
@@ -47,7 +47,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                     return View(vm);
                 }
             }
-            var user = Wtm.DoLogin(vm.ITCode, vm.Password, vm.Tenant);
+            var user = await Wtm.DoLoginAsync(vm.ITCode, vm.Password, vm.Tenant);
             if (user == null)
             {
                 vm.MSD.AddModelError("", Localizer["Sys.LoginFailed"]);

--- a/demo/WalkingTec.Mvvm.ReactDemo/Areas/_Admin/Controllers/AccountController.cs
+++ b/demo/WalkingTec.Mvvm.ReactDemo/Areas/_Admin/Controllers/AccountController.cs
@@ -32,7 +32,7 @@ namespace WalkingTec.Mvvm.Admin.Api
         public async Task<IActionResult> Login([FromForm] string account, [FromForm] string password, [FromForm] string tenant = null, [FromForm] bool rememberLogin = false)
         {
 
-            var user = Wtm.DoLogin(account, password, tenant);
+            var user = await Wtm.DoLoginAsync(account, password, tenant);
             if (user == null)
             {
                 return BadRequest(Localizer["Sys.LoginFailed"].Value);
@@ -62,7 +62,7 @@ namespace WalkingTec.Mvvm.Admin.Api
         [HttpPost("LoginJwt")]
         public async Task<IActionResult> LoginJwt(SimpleLogin loginInfo)
         {
-            var user = Wtm.DoLogin(loginInfo.Account, loginInfo.Password, loginInfo.Tenant);
+            var user = await Wtm.DoLoginAsync(loginInfo.Account, loginInfo.Password, loginInfo.Tenant);
             if (user == null)
             {
                 ModelState.AddModelError(" ", Localizer["Sys.LoginFailed"]);

--- a/demo/WalkingTec.Mvvm.Vue3Demo/Areas/_Admin/Controllers/AccountController.cs
+++ b/demo/WalkingTec.Mvvm.Vue3Demo/Areas/_Admin/Controllers/AccountController.cs
@@ -32,7 +32,7 @@ namespace WalkingTec.Mvvm.Admin.Api
         public async Task<IActionResult> Login([FromForm] string account, [FromForm] string password, [FromForm] string tenant = null, [FromForm] bool rememberLogin = false)
         {
 
-            var user = Wtm.DoLogin(account, password, tenant);
+            var user = await Wtm.DoLoginAsync(account, password, tenant);
             if (user == null)
             {
                 return BadRequest(Localizer["Sys.LoginFailed"].Value);
@@ -62,7 +62,7 @@ namespace WalkingTec.Mvvm.Admin.Api
         [HttpPost("LoginJwt")]
         public async Task<IActionResult> LoginJwt(SimpleLogin loginInfo)
         {
-            var user = Wtm.DoLogin(loginInfo.Account, loginInfo.Password, loginInfo.Tenant);
+            var user = await Wtm.DoLoginAsync(loginInfo.Account, loginInfo.Password, loginInfo.Tenant);
             if (user == null)
             {
                 ModelState.AddModelError(" ", Localizer["Sys.LoginFailed"]);

--- a/demo/WalkingTec.Mvvm.VueDemo/Areas/_Admin/Controllers/AccountController.cs
+++ b/demo/WalkingTec.Mvvm.VueDemo/Areas/_Admin/Controllers/AccountController.cs
@@ -32,7 +32,7 @@ namespace WalkingTec.Mvvm.Admin.Api
         public async Task<IActionResult> Login([FromForm] string account, [FromForm] string password, [FromForm] string tenant = null, [FromForm] bool rememberLogin = false)
         {
 
-            var user = Wtm.DoLogin(account, password, tenant);
+            var user = await Wtm.DoLoginAsync(account, password, tenant);
             if (user == null)
             {
                 return BadRequest(Localizer["Sys.LoginFailed"].Value);
@@ -62,7 +62,7 @@ namespace WalkingTec.Mvvm.Admin.Api
         [HttpPost("LoginJwt")]
         public async Task<IActionResult> LoginJwt(SimpleLogin loginInfo)
         {
-            var user = Wtm.DoLogin(loginInfo.Account, loginInfo.Password, loginInfo.Tenant);
+            var user = await Wtm.DoLoginAsync(loginInfo.Account, loginInfo.Password, loginInfo.Tenant);
             if (user == null)
             {
                 ModelState.AddModelError(" ", Localizer["Sys.LoginFailed"]);

--- a/src/WalkingTec.Mvvm.Core/WTMContext.cs
+++ b/src/WalkingTec.Mvvm.Core/WTMContext.cs
@@ -287,7 +287,7 @@ namespace WalkingTec.Mvvm.Core
             {
                 return null;
             }
-            var user = DoLogin(itcode, null, null);
+            var user = DoLoginAsync(itcode, null, null).GetAwaiter().GetResult();
             return user;
         }
 
@@ -365,11 +365,11 @@ namespace WalkingTec.Mvvm.Core
             this._serviceProvider = sp;
         }
 
-        public LoginUserInfo DoLogin(string username, string password, string tenant)
+        public async Task<LoginUserInfo> DoLoginAsync(string username, string password, string tenant)
         {
             if(string.IsNullOrEmpty(tenant))
             {
-                tenant = DC.TenantCode;               
+                tenant = DC.TenantCode;
             }
             if (tenant == null && HttpContext.User.Identity.IsAuthenticated)
             {
@@ -382,12 +382,12 @@ namespace WalkingTec.Mvvm.Core
                 {
                     remoteToken = HttpContext.User.Claims.Where(x => x.Type == AuthConstants.JwtClaimTypes.RToken).Select(x => x.Value).FirstOrDefault();
                 }
-                    LoginUserInfo rv = null;
+                LoginUserInfo rv = null;
                 if (string.IsNullOrEmpty(remoteToken) == false)
                 {
                     Dictionary<string, string> headers = new Dictionary<string, string>();
                     headers.Add("Authorization", "Bearer " + remoteToken);
-                    var user = CallAPI<LoginUserInfo>("mainhost", "/api/_account/checkuserinfo?IsApi=false", HttpMethodEnum.GET, new { }, 10, headers: headers).Result;
+                    var user = await CallAPI<LoginUserInfo>("mainhost", "/api/_account/checkuserinfo?IsApi=false", HttpMethodEnum.GET, new { }, 10, headers: headers);
                     rv = user.Data;
                     if (rv != null)
                     {
@@ -396,13 +396,13 @@ namespace WalkingTec.Mvvm.Core
                 }
                 else if(string.IsNullOrEmpty(password)==false)
                 {
-                    var loginjwt = CallAPI<Token>("mainhost", "/api/_account/loginjwt", HttpMethodEnum.POST, new { Account = username, Password = password }, 10).Result;
+                    var loginjwt = await CallAPI<Token>("mainhost", "/api/_account/loginjwt", HttpMethodEnum.POST, new { Account = username, Password = password }, 10);
                     if (string.IsNullOrEmpty(loginjwt?.Data?.AccessToken) == false)
                     {
                         remoteToken = loginjwt?.Data?.AccessToken;
                         Dictionary<string, string> headers = new Dictionary<string, string>();
                         headers.Add("Authorization", "Bearer " + remoteToken);
-                        var user = CallAPI<LoginUserInfo>("mainhost", "/api/_account/checkuserinfo?IsApi=false", HttpMethodEnum.GET, new { }, 10, headers: headers).Result;
+                        var user = await CallAPI<LoginUserInfo>("mainhost", "/api/_account/checkuserinfo?IsApi=false", HttpMethodEnum.GET, new { }, 10, headers: headers);
                         rv = user.Data;
                         if (rv != null)
                         {
@@ -412,16 +412,7 @@ namespace WalkingTec.Mvvm.Core
                 }
                 if (rv != null)
                 {
-                    //var cacheKey = $"{GlobalConstants.CacheKey.UserInfo}:{rv.ITCode + "$`$" + rv.TenantCode}";
-                    //var cacheuser = Cache.Get<LoginUserInfo>(cacheKey);
-                    //if (cacheuser != null && cacheuser.TimeTick >= rv.TimeTick)
-                    //{
-                    //    rv = cacheuser;
-                    //}
-                    //else
-                    //{
-                        rv.LoadBasicInfoAsync(this).Wait();
-                    //}
+                    await rv.LoadBasicInfoAsync(this);
                 }
                 return rv;
             }
@@ -430,7 +421,6 @@ namespace WalkingTec.Mvvm.Core
                 bool exist = false;
                 username = HttpContext.User.Claims.Where(x => x.Type == AuthConstants.JwtClaimTypes.Subject).Select(x => x.Value).FirstOrDefault() ?? username;
                 var ct = GlobaInfo.AllTenant.Where(x => x.TCode == tenant).FirstOrDefault();
-                //如果找不到指定的tenant，说明租户不存在，直接返回null
                 if(ct == null && string.IsNullOrEmpty(tenant) == false)
                 {
                     return null;
@@ -462,7 +452,6 @@ namespace WalkingTec.Mvvm.Core
                         else
                         {
                             exist = true;
-                            // Auto-upgrade: if old MD5 hash, rehash on successful login
                             if (verifyResult == PasswordVerifyResult.SuccessRehashNeeded)
                             {
                                 var fullUser = BaseUserQuery.IgnoreQueryFilters()
@@ -471,7 +460,7 @@ namespace WalkingTec.Mvvm.Core
                                 if (fullUser != null)
                                 {
                                     fullUser.Password = PasswordHashHelper.HashPassword(password);
-                                    DC.SaveChanges();
+                                    await DC.SaveChangesAsync();
                                 }
                             }
                         }
@@ -487,22 +476,19 @@ namespace WalkingTec.Mvvm.Core
                     ITCode = username,
                     TenantCode = tenant
                 };
-                //var cacheKey = $"{GlobalConstants.CacheKey.UserInfo}:{username + "$`$" + tenant}";
-                //var cacheuser = Cache.Get<LoginUserInfo>(cacheKey);
-                //if (cacheuser != null)
-                //{
-                //    user = cacheuser;
-                //}
-                //else
-                //{
-                    user.LoadBasicInfoAsync(this).Wait();
-                //}
+                await user.LoadBasicInfoAsync(this);
                 user.RemoteToken = null;
                 var authService = HttpContext.RequestServices.GetService(typeof(ITokenService)) as ITokenService;
-                var token = authService.IssueTokenAsync(user).Result;
+                var token = await authService.IssueTokenAsync(user);
                 user.RemoteToken = token.AccessToken;
                 return user;
             }
+        }
+
+        [Obsolete("Use DoLoginAsync to avoid ThreadPool starvation. DoLogin blocks threads on every auth request.")]
+        public LoginUserInfo DoLogin(string username, string password, string tenant)
+        {
+            return DoLoginAsync(username, password, tenant).GetAwaiter().GetResult();
         }
 
         public Token RefreshToken()


### PR DESCRIPTION
## Summary

- **P1-3 (Issue #5):** Add `DoLoginAsync` to `WTMContext` — fully async implementation replacing 6 `.Result`/`.Wait()` blocking calls on every authentication request.
- Mark `DoLogin` as `[Obsolete]`, kept as a `GetAwaiter().GetResult()` backward-compat wrapper.
- `DC.SaveChanges()` → `DC.SaveChangesAsync()` in the PBKDF2 auto-rehash path.
- Update all 5 demo `AccountController` + `LoginController` callers to `await DoLoginAsync(...)`.

## Test plan

- [x] 16/16 tests passing
- [x] CI: ✅ https://github.com/cct08311github/WTM/actions/runs/22633944705

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)