### PR TITLE
fix: 8.1.16 bug-fix batch (BUG-1 to BUG-8)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/ConfigOptions/CS.cs
+++ b/src/WalkingTec.Mvvm.Core/ConfigOptions/CS.cs
@@ -16,6 +16,13 @@ namespace WalkingTec.Mvvm.Core
         public string Version { get; set; }
         public string DbContext { get; set; }
 
+        /// <summary>
+        /// Whether this connection is active. Defaults to true for backward compatibility.
+        /// Set to false in appsettings.json to disable a connection without removing it —
+        /// useful for graceful degradation when a secondary database (e.g. Oracle) is unreachable.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
         public ConstructorInfo DcConstructor;
         private static List<ConstructorInfo> _cis;
         public static List<ConstructorInfo> Cis

--- a/src/WalkingTec.Mvvm.Core/Extensions/SystemExtensions/TypeExtension.cs
+++ b/src/WalkingTec.Mvvm.Core/Extensions/SystemExtensions/TypeExtension.cs
@@ -204,6 +204,7 @@ namespace WalkingTec.Mvvm.Core.Extensions
                 string val = "";
                 var notmapped = pro.GetCustomAttribute<NotMappedAttribute>();
                 if (notmapped == null &&
+                    pro.SetMethod != null &&
                     pro.PropertyType.IsList() == false &&
                     pro.PropertyType.IsSubclassOf(typeof(TopBasePoco)) == false &&
                     skipFields.Contains(key) == false

--- a/src/WalkingTec.Mvvm.Core/Support/DbConnectionWarmupService.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/DbConnectionWarmupService.cs
@@ -1,0 +1,74 @@
+#nullable disable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace WalkingTec.Mvvm.Core
+{
+    /// <summary>
+    /// Background service that pre-warms database connection pools on app startup.
+    /// Moves the cold-start latency (especially Oracle's ~60s first-query delay)
+    /// from the first user request to the app boot phase — runs in background,
+    /// does not block startup.
+    ///
+    /// For Oracle specifically, eliminates delay caused by:
+    /// - TNS name resolution and caching
+    /// - Connection pool creation (ODP.NET default Min Pool Size=0)
+    /// - ODP.NET internal metadata loading and self-tuning calibration
+    ///
+    /// The service is fault-tolerant: a connection failure is logged as a warning,
+    /// never crashes the app.
+    /// </summary>
+    public class DbConnectionWarmupService : BackgroundService
+    {
+        private readonly Configs _configs;
+        private readonly ILogger<DbConnectionWarmupService> _logger;
+
+        public DbConnectionWarmupService(
+            Microsoft.Extensions.Options.IOptionsMonitor<Configs> configs,
+            ILogger<DbConnectionWarmupService> logger)
+        {
+            _configs = configs.CurrentValue;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // Small delay to let the rest of the app finish starting
+            await Task.Delay(TimeSpan.FromSeconds(2), stoppingToken);
+
+            var enabledConnections = _configs.Connections?.Where(x => x.Enabled).ToList();
+            if (enabledConnections == null || enabledConnections.Count == 0)
+            {
+                return;
+            }
+
+            _logger.LogInformation("[WTM] Starting database connection warm-up for {Count} connection(s)...", enabledConnections.Count);
+
+            foreach (var cs in enabledConnections)
+            {
+                if (stoppingToken.IsCancellationRequested) break;
+                try
+                {
+                    using var dc = cs.CreateDC();
+                    var dbContext = dc as Microsoft.EntityFrameworkCore.DbContext;
+                    if (dbContext != null)
+                    {
+                        await dbContext.Database.CanConnectAsync(stoppingToken);
+                        _logger.LogInformation("[WTM] Warm-up OK: connection '{Key}' ({DbType})", cs.Key, cs.DbType);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("[WTM] Warm-up failed for connection '{Key}' ({DbType}): {Message}. First user query may experience delay.",
+                        cs.Key, cs.DbType, ex.Message);
+                }
+            }
+
+            _logger.LogInformation("[WTM] Database connection warm-up completed.");
+        }
+    }
+}

--- a/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmFileProvider.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmFileProvider.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using WalkingTec.Mvvm.Core.Extensions;
 using WalkingTec.Mvvm.Core.Models;
@@ -142,7 +143,7 @@ namespace WalkingTec.Mvvm.Core.Support.FileHandlers
             {
                 dc = _wtm.CreateDC();
             }
-            rv = dc.Set<FileAttachment>().CheckID(id).Select(x => new FileAttachment
+            rv = dc.Set<FileAttachment>().IgnoreQueryFilters().CheckID(id).Select(x => new FileAttachment
             {
                 ID = x.ID,
                 ExtraInfo = x.ExtraInfo,
@@ -175,7 +176,7 @@ namespace WalkingTec.Mvvm.Core.Support.FileHandlers
             {
                 dc = _wtm.CreateDC();
             }
-            file = dc.Set<FileAttachment>().CheckID(id)
+            file = dc.Set<FileAttachment>().IgnoreQueryFilters().CheckID(id)
                 .Select(x => new FileAttachment
                 {
                     ID = x.ID,
@@ -210,7 +211,7 @@ namespace WalkingTec.Mvvm.Core.Support.FileHandlers
             {
                 dc = _wtm.CreateDC();
             }
-            rv = dc.Set<FileAttachment>().CheckID(id).Select(x => x.FileName).FirstOrDefault();
+            rv = dc.Set<FileAttachment>().IgnoreQueryFilters().CheckID(id).Select(x => x.FileName).FirstOrDefault();
             if(rv == null)
             {
                 rv = "unknown";

--- a/src/WalkingTec.Mvvm.Core/Utils.cs
+++ b/src/WalkingTec.Mvvm.Core/Utils.cs
@@ -612,7 +612,7 @@ namespace WalkingTec.Mvvm.Core
                 return null;
             }
 
-            if (config.Connections.Any(x => x.Key.ToLower() == cs.ToLower()) == false)
+            if (config.Connections.Any(x => x.Key.ToLower() == cs.ToLower() && x.Enabled) == false)
             {
                 cs = "default";
             }
@@ -623,7 +623,7 @@ namespace WalkingTec.Mvvm.Core
             }
             if (mode?.ToLower() == "read")
             {
-                var reads = config.Connections.Where(x => x.Key.StartsWith(cs + "_")).Select(x => x.Key).ToList();
+                var reads = config.Connections.Where(x => x.Key.StartsWith(cs + "_") && x.Enabled).Select(x => x.Key).ToList();
                 if (reads.Count > 0)
                 {
                     Random r = new Random();

--- a/src/WalkingTec.Mvvm.Core/WTMContext.cs
+++ b/src/WalkingTec.Mvvm.Core/WTMContext.cs
@@ -742,7 +742,12 @@ params string[] groupcode)
             {
                 cs = "default";
             }
-            var rv = ConfigInfo.Connections.Where(x => x.Key.ToLower() == cs.ToLower()).FirstOrDefault().CreateDC();
+            var csConfig = ConfigInfo.Connections.Where(x => x.Key.ToLower() == cs.ToLower()).FirstOrDefault();
+            if (csConfig != null && !csConfig.Enabled)
+            {
+                throw new InvalidOperationException($"Database connection '{csConfig.Key}' ({csConfig.DbType}) is disabled. Enable it in appsettings.json (set Enabled: true).");
+            }
+            var rv = csConfig.CreateDC();
             rv.IsDebug = ConfigInfo.IsQuickDebug;
             rv.SetTenantCode(tenantCode);
             if (logerror == true)

--- a/src/WalkingTec.Mvvm.Mvc/CodeGenVM.cs
+++ b/src/WalkingTec.Mvvm.Mvc/CodeGenVM.cs
@@ -1212,6 +1212,7 @@ namespace WalkingTec.Mvvm.Mvc
                     if (pro.Value == "$fk$")
                     {
                         var fktype = modelType.GetSingleProperty(pro.Key[0..^2])?.PropertyType;
+                        if (fktype == null) continue;
                         cpros += $@"
             v.{pro.Key} = Add{fktype.Name}();";
                         pros += $@"
@@ -1301,6 +1302,7 @@ namespace WalkingTec.Mvvm.Mvc
 
         private string GenerateAddFKModel(string keyname, Type t, List<Type> exist)
         {
+            if (t == null) return "";
             if (exist == null)
             {
                 exist = new List<Type>();
@@ -1319,7 +1321,7 @@ namespace WalkingTec.Mvvm.Mvc
                 if (pro.Value == "$fk$")
                 {
                     var fktype = t.GetSingleProperty(pro.Key[0..^2])?.PropertyType;
-                    if (fktype != t)
+                    if (fktype != null && fktype != t)
                     {
                         rv += GenerateAddFKModel(pro.Key[0..^2], fktype, exist);
                     }
@@ -1332,7 +1334,7 @@ namespace WalkingTec.Mvvm.Mvc
                 if (pro.Value == "$fk$")
                 {
                     var fktype = t.GetSingleProperty(pro.Key[0..^2])?.PropertyType;
-                    if (fktype != t)
+                    if (fktype != null && fktype != t)
                     {
                         cpros += $@"
                 v.{pro.Key} = Add{fktype.Name}();";

--- a/src/WalkingTec.Mvvm.Mvc/CodeGenVM.cs
+++ b/src/WalkingTec.Mvvm.Mvc/CodeGenVM.cs
@@ -76,10 +76,21 @@ namespace WalkingTec.Mvvm.Mvc
                     int? index = EntryDir?.IndexOf($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}Debug{Path.DirectorySeparatorChar}");
                     if (index == null || index < 0)
                     {
-                        index = EntryDir?.IndexOf($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}") ?? 0;
+                        index = EntryDir?.IndexOf($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}");
                     }
 
-                    _mainDir = EntryDir?.Substring(0, index.Value);
+                    if (index == null || index < 0)
+                    {
+                        // BaseDirectory does not contain \bin\Debug\ or \bin\Release\
+                        // (e.g. dotnet run from repo root, or published app).
+                        // Fall back to the current working directory, which is typically
+                        // the project source root in development.
+                        _mainDir = Directory.GetCurrentDirectory();
+                    }
+                    else
+                    {
+                        _mainDir = EntryDir!.Substring(0, index.Value);
+                    }
                 }
                 return _mainDir;
             }

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -542,11 +542,19 @@ namespace WalkingTec.Mvvm.Mvc
                 y.MultipartBodyLengthLimit = conf.FileUploadOptions.UploadLimit;
             });
             services.AddHostedService<QuartzHostService>();
-            var cs = conf.Connections;
+            services.AddHostedService<DbConnectionWarmupService>();
+            var cs = conf.Connections.Where(x => x.Enabled).ToList();
             foreach (var item in cs)
             {
-                var dc = item.CreateDC();
-                dc.EnsureCreate();
+                try
+                {
+                    var dc = item.CreateDC();
+                    dc.EnsureCreate();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[WTM] Warning: could not initialize database connection '{item.Key}' ({item.DbType}): {ex.Message}");
+                }
             }
             services.AddVersionedApiExplorer(o=>
             {

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmElsaContext.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmElsaContext.cs
@@ -13,7 +13,10 @@ namespace WalkingTec.Mvvm.Mvc.Helper
         {
             get
             {
-                if (Database.IsOracle())
+                // MySQL and Oracle do not support schemas the way SQL Server does.
+                // MySQL treats schema = database, so returning a schema prefix like "Elsa"
+                // would cause EF Core to look for a different database and fail to create tables.
+                if (Database.IsOracle() || Database.ProviderName?.Contains("MySql") == true)
                 {
                     return null;
                 }

--- a/src/WalkingTec.Mvvm.Mvc/_CodeGenController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_CodeGenController.cs
@@ -131,7 +131,9 @@ namespace WalkingTec.Mvvm.Mvc
             var models = new List<Type>();
             
             //获取所有模型
-            var pros = Wtm.ConfigInfo.Connections.SelectMany(x => x.DcConstructor.DeclaringType.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance));
+            var pros = Wtm.ConfigInfo.Connections
+                .Where(x => x.Enabled && x.DcConstructor != null)
+                .SelectMany(x => x.DcConstructor.DeclaringType.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance));
             if (pros != null)
             {
                 foreach (var pro in pros)

--- a/src/WalkingTec.Mvvm.Mvc/_FrameworkController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_FrameworkController.cs
@@ -352,10 +352,14 @@ namespace WalkingTec.Mvvm.Mvc
             }
             var FileData = Request.Form.Files[0];
 
-            Image oimage = Image.Load(FileData.OpenReadStream());
-            if (oimage == null)
+            Image oimage;
+            try
             {
-                return JsonMore(new { Id = string.Empty, Name = string.Empty }, StatusCodes.Status404NotFound);
+                oimage = Image.Load(FileData.OpenReadStream());
+            }
+            catch (Exception)
+            {
+                return JsonMore(new { Id = string.Empty, Name = string.Empty }, StatusCodes.Status400BadRequest);
             }
             if (width == null)
             {

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/Form/ComboBoxTagHelper.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/Form/ComboBoxTagHelper.cs
@@ -214,15 +214,11 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
                         {
                             listItems = (Items.Model as IEnumerable<ComboSelectListItem>).ToList();
                         }
-                        foreach (var item in listItems)
+                        if (selectVal.Count > 0)
                         {
-                            if (selectVal.Contains(item.Value?.ToString()))
+                            foreach (var item in listItems)
                             {
-                                item.Selected = true;
-                            }
-                            else
-                            {
-                                item.Selected = false;
+                                item.Selected = selectVal.Contains(item.Value?.ToString());
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

8-bug stabilization batch for 8.1.16, all P0/P1 issues from the spec.

- **BUG-1** `fix(codegen)`: Prevent NullRef in `GenerateAddFKModel`; skip readonly fields in test gen
- **BUG-2** `fix(upload)`: Handle non-image files in `UploadImage` — return 400 instead of 500
- **BUG-3** `fix(tenant)`: File access bypasses tenant query filter via `IgnoreQueryFilters()`
- **BUG-4** `fix(workflow)`: Elsa workflow tables not auto-created in MySQL (null schema fix)
- **BUG-5** `fix(codegen)`: CodeGen path fails in non-standard environments (`\bin\Debug\` not found)
- **BUG-6** `fix(ui)`: ComboBox respects `item.Selected` when no `DefaultValue` is set
- **BUG-7** `feat(multidb)`: Add `Enabled` toggle per database connection in `appsettings.json`
- **BUG-8** `perf(oracle)`: Add `DbConnectionWarmupService` to pre-warm connection pools at startup

Closes #14, #15, #16

## Test plan

- [ ] Build passes on CI
- [ ] CodeGen: open a model with a FK navigation property — no NullRef thrown
- [ ] CodeGen: generated test code compiles (no assignment to read-only properties)
- [ ] Upload: POST a non-image file to `/File/UploadImage` → 400 returned
- [ ] Multi-tenant: system admin uploads file; tenant user can download it by UUID
- [ ] Workflow: MySQL deployment auto-creates Elsa schema tables on first run
- [ ] Oracle: set `Enabled: false` on a connection → app starts without waiting for that DB
- [ ] Oracle: connection pool pre-warm log appears within 5s of startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)