### PR TITLE
fix(analysis): address PR review findings — C-1 to C-4, I-2 to I-11

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -40,13 +40,19 @@ jobs:
           fi
 
       - name: Pack WalkingTec.Mvvm.Core
-        run: dotnet pack src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj -c Release -o nupkgs
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: dotnet pack src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj -c Release -o nupkgs /p:Version=$PKG_VERSION
 
       - name: Pack WalkingTec.Mvvm.TagHelpers.LayUI
-        run: dotnet pack src/WalkingTec.Mvvm.TagHelpers.LayUI/WalkingTec.Mvvm.TagHelpers.LayUI.csproj -c Release -o nupkgs
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: dotnet pack src/WalkingTec.Mvvm.TagHelpers.LayUI/WalkingTec.Mvvm.TagHelpers.LayUI.csproj -c Release -o nupkgs /p:Version=$PKG_VERSION
 
       - name: Pack WalkingTec.Mvvm.Mvc
-        run: dotnet pack src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj -c Release -o nupkgs
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: dotnet pack src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj -c Release -o nupkgs /p:Version=$PKG_VERSION
 
       - name: List packages
         run: ls -lh nupkgs/

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -14,6 +14,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
     public class AnalysisQueryEngine
     {
         private const int MaxRows = 10_000;
+        // 防止全表載入造成記憶體耗盡（C-1）
+        private const int MaxMaterializeRows = 50_000;
 
         /// <summary>
         /// 執行分析查詢，回傳聚合結果。
@@ -28,6 +30,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
             var filtered = ApplyFilters(baseQuery, req.Filters, wl);
             var rows = ExecuteGroupBy(filtered, req, wl);
+            int totalCount = rows.Count;   // 截斷前的真實筆數（I-3）
             bool truncated = rows.Count > MaxRows;
             if (truncated) rows = rows.Take(MaxRows).ToList();
 
@@ -39,7 +42,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
             {
                 Columns = columns,
                 Rows = rows,
-                TotalCount = rows.Count,
+                TotalCount = totalCount,
                 Truncated = truncated,
                 QueryHash = ComputeHash(req)
             };
@@ -116,6 +119,9 @@ namespace WalkingTec.Mvvm.Core.Analysis
                         body = Expression.LessThanOrEqual(prop, constant);
                         break;
                     case FilterOperator.Contains:
+                        if (meta.ClrType != typeof(string))
+                            throw new InvalidOperationException(
+                                $"Contains 只適用於字串欄位，'{filter.Field}' 的型別為 {meta.ClrType.Name}。");
                         body = Expression.Call(prop,
                             typeof(string).GetMethod(nameof(string.Contains), new[] { typeof(string) }),
                             constant);
@@ -136,9 +142,9 @@ namespace WalkingTec.Mvvm.Core.Analysis
             {
                 return Convert.ChangeType(value, underlying);
             }
-            catch
+            catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException)
             {
-                throw new InvalidOperationException($"Cannot convert '{value}' to {underlying.Name}.");
+                throw new InvalidOperationException($"Cannot convert '{value}' to {underlying.Name}.", ex);
             }
         }
 
@@ -148,8 +154,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
             Dictionary<string, AnalysisFieldMeta> wl)
         {
             // Phase 1: materialise then group in-process (SQLite + InMemory safe)
-            // Production note: verify actual SQL with ToQueryString() to ensure server-side execution
-            var items = query.ToList();
+            // 限制載入筆數防止 OOM（C-1）；超出上限時查詢結果可能不完整，由呼叫端決策
+            var items = query.Take(MaxMaterializeRows).ToList();
 
             return items
                 .GroupBy(row => BuildGroupKey(row, req.Dimensions))
@@ -164,15 +170,20 @@ namespace WalkingTec.Mvvm.Core.Analysis
                     foreach (var m in req.Measures)
                     {
                         var propInfo = typeof(TModel).GetProperty(m.Field);
-                        var values = g.Select(row => Convert.ToDecimal(propInfo.GetValue(row))).ToList();
+                        // 過濾 null 值，避免 nullable 型別的 Convert.ToDecimal 例外（I-10）
+                        var values = g
+                            .Select(row => propInfo.GetValue(row))
+                            .Where(v => v != null)
+                            .Select(v => Convert.ToDecimal(v))
+                            .ToList();
                         decimal aggValue;
                         switch (m.Func)
                         {
-                            case AggregateFunc.Sum:   aggValue = values.Sum(); break;
-                            case AggregateFunc.Count: aggValue = values.Count; break;
-                            case AggregateFunc.Avg:   aggValue = values.Average(); break;
-                            case AggregateFunc.Max:   aggValue = values.Max(); break;
-                            case AggregateFunc.Min:   aggValue = values.Min(); break;
+                            case AggregateFunc.Sum:   aggValue = values.Count == 0 ? 0m : values.Sum(); break;
+                            case AggregateFunc.Count: aggValue = g.Count(); break;
+                            case AggregateFunc.Avg:   aggValue = values.Count == 0 ? 0m : values.Average(); break;
+                            case AggregateFunc.Max:   aggValue = values.Count == 0 ? 0m : values.Max(); break;
+                            case AggregateFunc.Min:   aggValue = values.Count == 0 ? 0m : values.Min(); break;
                             default: throw new NotSupportedException($"Unsupported func {m.Func}");
                         }
                         dict[$"{m.Field}_{m.Func}"] = aggValue;

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace WalkingTec.Mvvm.Core.Analysis
@@ -21,7 +22,18 @@ namespace WalkingTec.Mvvm.Core.Analysis
             _whitelist.Clear();
             foreach (var asm in assemblies)
             {
-                foreach (var type in asm.GetTypes())
+                Type[] types;
+                try
+                {
+                    types = asm.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    // 部分型別載入失敗（常見於 plugin 或依賴版本衝突），取回已成功載入的型別繼續掃描
+                    types = ex.Types.Where(t => t != null).ToArray();
+                }
+
+                foreach (var type in types)
                 {
                     if (!type.IsAbstract
                         && IsBasePagedListVm(type)

--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -85,6 +85,10 @@ namespace WalkingTec.Mvvm.Mvc
         public IActionResult Export([FromBody] AnalysisQueryRequest req,
                                     [FromQuery] string format = "xlsx")
         {
+            // 與 Query 端點一致的維度/度量上限驗證（I-5）
+            if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
+            if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");
+
             Type vmType;
             try { vmType = _registry.Resolve(req.ListVmType); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
@@ -114,9 +118,18 @@ namespace WalkingTec.Mvvm.Mvc
 
         private BaseVM CreateAnalysisVm(Type vmType)
         {
-            var vm = (BaseVM)Activator.CreateInstance(vmType);
-            vm.Wtm = Wtm;
-            return vm;
+            // Activator.CreateInstance 在 VM 無 public parameterless constructor 時拋 MissingMethodException（I-7）
+            try
+            {
+                var vm = (BaseVM)Activator.CreateInstance(vmType);
+                vm.Wtm = Wtm;
+                return vm;
+            }
+            catch (MissingMethodException)
+            {
+                throw new InvalidOperationException(
+                    $"VM 型別 '{vmType.FullName}' 必須有 public parameterless constructor 才能用於 Analysis Mode。");
+            }
         }
 
         private BaseVM CreateAndBindVm(Type vmType, string searcherFormData)
@@ -128,11 +141,19 @@ namespace WalkingTec.Mvvm.Mvc
                 var searcherProp = vmType.GetProperty("Searcher");
                 if (searcherProp != null)
                 {
-                    var searcher = JsonSerializer.Deserialize(
-                        searcherFormData,
-                        searcherProp.PropertyType,
-                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                    searcherProp.SetValue(vm, searcher);
+                    // JsonException → 400（I-8）
+                    try
+                    {
+                        var searcher = JsonSerializer.Deserialize(
+                            searcherFormData,
+                            searcherProp.PropertyType,
+                            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                        searcherProp.SetValue(vm, searcher);
+                    }
+                    catch (JsonException ex)
+                    {
+                        throw new InvalidOperationException($"搜尋條件格式錯誤：{ex.Message}", ex);
+                    }
                 }
             }
 
@@ -141,14 +162,48 @@ namespace WalkingTec.Mvvm.Mvc
 
         private static IEnumerable<AnalysisFieldMeta> InvokeGetAnalysisFields(BaseVM vm, Type vmType)
         {
-            var method = vmType.GetMethod("GetAnalysisFields");
-            return (IEnumerable<AnalysisFieldMeta>)method.Invoke(vm, null);
+            // 明確指定 binding flags 與無參數多載，避免 null 或 AmbiguousMatchException（C-3）
+            var method = vmType.GetMethod(
+                "GetAnalysisFields",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+                null,
+                Type.EmptyTypes,
+                null);
+            if (method == null)
+                throw new InvalidOperationException(
+                    $"VM 型別 '{vmType.FullName}' 找不到 GetAnalysisFields() 方法。");
+            try
+            {
+                return (IEnumerable<AnalysisFieldMeta>)method.Invoke(vm, null);
+            }
+            catch (System.Reflection.TargetInvocationException ex)
+            {
+                throw ex.InnerException ?? ex;
+            }
         }
 
         private static System.Linq.IQueryable InvokeGetSearchQuery(BaseVM vm, Type vmType)
         {
-            var method = vmType.GetMethod("GetSearchQuery");
-            return method?.Invoke(vm, null) as System.Linq.IQueryable;
+            // 明確指定無參數多載，避免 AmbiguousMatchException（C-4）
+            var method = vmType.GetMethod(
+                "GetSearchQuery",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+                null,
+                Type.EmptyTypes,
+                null);
+            if (method == null) return null;
+            try
+            {
+                var result = method.Invoke(vm, null);
+                if (result == null) return null;
+                if (result is System.Linq.IQueryable q) return q;
+                throw new InvalidOperationException(
+                    $"VM 型別 '{vmType.FullName}' 的 GetSearchQuery() 未回傳 IQueryable。");
+            }
+            catch (System.Reflection.TargetInvocationException ex)
+            {
+                throw ex.InnerException ?? ex;
+            }
         }
 
         private static string[] GetAllowedFuncNames(AggregateFunc funcs)
@@ -160,19 +215,26 @@ namespace WalkingTec.Mvvm.Mvc
         private static string BuildCsv(AnalysisQueryResponse result)
         {
             var sb = new StringBuilder();
-            sb.AppendLine(string.Join(",", result.Columns));
+            sb.AppendLine(string.Join(",", result.Columns.Select(EscapeCsvCell)));
             foreach (var row in result.Rows)
             {
                 var values = result.Columns.Select(c =>
-                {
-                    var val = row.GetValueOrDefault(c)?.ToString() ?? "";
-                    // 包含逗號或換行時用引號包圍
-                    return val.Contains(',') || val.Contains('\n')
-                        ? $"\"{val.Replace("\"", "\"\"")}\"" : val;
-                });
+                    EscapeCsvCell(row.GetValueOrDefault(c)?.ToString() ?? ""));
                 sb.AppendLine(string.Join(",", values));
             }
             return sb.ToString();
+        }
+
+        private static string EscapeCsvCell(string val)
+        {
+            if (string.IsNullOrEmpty(val)) return "";
+            // 防 CSV formula injection（I-2）：以公式字元開頭時前置 tab
+            if (val[0] is '=' or '+' or '-' or '@' or '\t' or '\r')
+                val = "\t" + val;
+            // 包含逗號、換行或引號時用 RFC 4180 引號包圍
+            if (val.Contains(',') || val.Contains('\n') || val.Contains('"'))
+                val = $"\"{val.Replace("\"", "\"\"")}\"";
+            return val;
         }
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -78,7 +78,7 @@
             headers: { 'Content-Type': 'application/json' }
         })
         .then(function (res) {
-            if (!res.ok) throw new Error('HTTP ' + res.status);
+            if (!res.ok) return res.text().then(function (t) { throw new Error(t || 'HTTP ' + res.status); });
             return res.json();
         })
         .then(function (fields) {
@@ -345,7 +345,7 @@
             })
         })
         .then(function (res) {
-            if (!res.ok) throw new Error('HTTP ' + res.status);
+            if (!res.ok) return res.text().then(function (t) { throw new Error(t || 'HTTP ' + res.status); });
             return res.blob();
         })
         .then(function (blob) {


### PR DESCRIPTION
## Summary

Addresses all **Critical** and **Important** findings from the 4-agent Opus code review of the Analysis Mode implementation (issues #20–28).

### Critical fixes
- **#20 (C-1)**: Add `MaxMaterializeRows = 50,000` cap before `ToList()` to prevent OOM/DoS on large tables
- **#21 (C-2)**: Catch `ReflectionTypeLoadException` in `AnalysisVmRegistry.Build()` — recover partial type list, prevent startup crash
- **#22 (C-3/C-4)**: Fix both reflection helpers in controller — explicit `BindingFlags` + parameter types to avoid `AmbiguousMatchException`; null guard on `GetMethod()`; unwrap `TargetInvocationException`

### Important fixes
- **#25 (I-2)**: `EscapeCsvCell()` — neutralize CSV formula injection (values starting with `=`, `+`, `-`, `@`)
- **#26 (I-3)**: Capture `totalCount` before truncation so `TotalCount` reflects true pre-truncation group count
- **#27 (I-4)**: Pass computed version to `dotnet pack` via `PKG_VERSION` env var (version_suffix was ignored)
- **#26 (I-5)**: Add dimension/measure count guard to `Export` endpoint (was only in `Query`)
- **#26 (I-6)**: Replace bare `catch {}` in `ConvertValue` with typed `when`-filter; preserve inner exception
- **#26 (I-7)**: Catch `MissingMethodException` in `CreateAnalysisVm` with actionable error message
- **#26 (I-8)**: Catch `JsonException` in `CreateAndBindVm` → 400 instead of 500
- **#28 (I-9)**: `exportData()` and `loadMeta()` now read server error body before throwing (matches existing `query()` pattern)
- **#28 (I-10)**: Filter null values before `Convert.ToDecimal`; guard empty list for `Avg`/`Max`/`Min`
- **#28 (I-11)**: Validate `ClrType == string` before building `Contains` expression

### Out of scope (tracked separately)
- **#23 (C-5)**: Controller test coverage — tracked separately
- **#24 (I-1)**: `FilterOperator.In` not implemented — tracked separately
- **#29 (I-12)**: JS test coverage expansion — tracked separately

## Test plan
- [ ] CI build passes
- [ ] All existing MSTest + Jest tests pass
- [ ] Manually verify: query on large table does not OOM (capped at 50k rows)
- [ ] Manually verify: CSV export values starting with `=` are prefixed with tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)