### PR TITLE
v8.2.0 Phase 2-4: Audit Interceptor, Rate Limiting, Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@
 
 * **新增（結構化日誌）：** Opt-in Serilog 整合，透過 `AddWtmSerilog()` / `UseWtmSerilog()` 啟用。支援 Console + JSON 檔案 Sink，每日滾動、30 天保留、HTTP 請求記錄、自訂 Sink 擴充。與現有 WTMLogger / ActionLog 並存不衝突
 * **新增（ProblemDetails）：** Opt-in RFC 7807 錯誤回應，透過 `UseWtmProblemDetails()` 啟用。API 路由（`/api/*` 或 `Accept: application/json`）回傳結構化 JSON 錯誤含 traceId 串聯。MVC 頁面行為不受影響
+* **新增（審計攔截器）：** `EmptyContext.SaveChanges` 自動填入 `CreateBy`/`CreateTime`/`UpdateBy`/`UpdateTime`。僅填空值不覆寫，與現有 VM 手動設定完全相容。透過 `IDataContext.CurrentUserCode` 傳遞當前用戶，`WTMContext.DC` getter 自動注入
+* **新增（Rate Limiting）：** Opt-in IP 限流，透過 `AddWtmRateLimiting()` / `UseWtmRateLimiting()` 啟用。預設 100 次/60 秒固定窗口，超限回 429。支援自訂 `PermitLimit`、`WindowSeconds`、`QueueLimit` 及 `CustomConfig` 完整覆寫
+* **清理：** 移除 `SearchPanelTagHelper.cs` 未使用的 `using Newtonsoft.Json.Schema`
 * **文件：** 新增 `docs/structured-logging.md` — 完整使用手冊，含設定、生產環境建議、log 查詢技巧、前端整合範例
 * **依賴：** 新增 `Serilog.AspNetCore` 8.0.3
-* **測試：** Serilog 6 tests + ProblemDetails 7 tests，全部 CI ✅
+* **測試：** Serilog 6 tests + ProblemDetails 7 tests + AuditInterceptor 6 tests + RateLimiting 3 tests，全部 CI ✅
 
 ## 8.1.17 (2026-03-05)
 

--- a/src/WalkingTec.Mvvm.Core/DataContext.cs
+++ b/src/WalkingTec.Mvvm.Core/DataContext.cs
@@ -372,6 +372,7 @@ namespace WalkingTec.Mvvm.Core
             }
         }
         public bool IsDebug { get; set; }
+        public string CurrentUserCode { get; set; }
         /// <summary>
         /// CSName
         /// </summary>
@@ -806,6 +807,58 @@ namespace WalkingTec.Mvvm.Core
             return rv;
         }
 
+        private void ApplyAuditFields()
+        {
+            if (ChangeTracker == null) return;
+
+            foreach (var entry in ChangeTracker.Entries())
+            {
+                if (entry.Entity is IBasePoco entity)
+                {
+                    switch (entry.State)
+                    {
+                        case EntityState.Added:
+                            if (entity.CreateTime == null)
+                                entity.CreateTime = DateTime.Now;
+                            if (string.IsNullOrEmpty(entity.CreateBy))
+                                entity.CreateBy = CurrentUserCode;
+                            break;
+
+                        case EntityState.Modified:
+                            if (entity.UpdateTime == null)
+                                entity.UpdateTime = DateTime.Now;
+                            if (string.IsNullOrEmpty(entity.UpdateBy))
+                                entity.UpdateBy = CurrentUserCode;
+                            break;
+                    }
+                }
+            }
+        }
+
+        public override int SaveChanges()
+        {
+            ApplyAuditFields();
+            return base.SaveChanges();
+        }
+
+        public override int SaveChanges(bool acceptAllChangesOnSuccess)
+        {
+            ApplyAuditFields();
+            return base.SaveChanges(acceptAllChangesOnSuccess);
+        }
+
+        public override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+        {
+            ApplyAuditFields();
+            return base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+        }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            ApplyAuditFields();
+            return base.SaveChangesAsync(cancellationToken);
+        }
+
         public void EnsureCreate()
         {
             this.Database.EnsureCreated();
@@ -826,6 +879,7 @@ namespace WalkingTec.Mvvm.Core
         public string CSName { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DBTypeEnum DBType { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public bool IsDebug { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string CurrentUserCode { get; set; }
 
         public void AddEntity<T>(T entity) where T : TopBasePoco
         {

--- a/src/WalkingTec.Mvvm.Core/IDataContext.cs
+++ b/src/WalkingTec.Mvvm.Core/IDataContext.cs
@@ -23,6 +23,7 @@ namespace WalkingTec.Mvvm.Core
         bool IsFake { get; set; }
 
         bool IsDebug { get; set; }
+        string CurrentUserCode { get; set; }
         string TenantCode { get; }
         DBTypeEnum DBType { get; set; }
         /// <summary>

--- a/src/WalkingTec.Mvvm.Core/WTMContext.cs
+++ b/src/WalkingTec.Mvvm.Core/WTMContext.cs
@@ -137,6 +137,8 @@ namespace WalkingTec.Mvvm.Core
                 if (_dc == null)
                 {
                     _dc = this.CreateDC();
+                    if (_dc != null)
+                        _dc.CurrentUserCode = LoginUserInfo?.ITCode;
                 }
                 return _dc;
             }
@@ -727,7 +729,9 @@ params string[] groupcode)
                 //如果租户指定了数据库，则返回
                 if (string.IsNullOrEmpty(cs) && item?.IsUsingDB == true)
                 {
-                    return item.CreateDC(this);
+                    var tenantDc = item.CreateDC(this);
+                    tenantDc.CurrentUserCode = LoginUserInfo?.ITCode;
+                    return tenantDc;
                 }
             }
 
@@ -750,6 +754,7 @@ params string[] groupcode)
             var rv = csConfig.CreateDC();
             rv.IsDebug = ConfigInfo.IsQuickDebug;
             rv.SetTenantCode(tenantCode);
+            rv.CurrentUserCode = LoginUserInfo?.ITCode;
             if (logerror == true)
             {
                 rv.SetLoggerFactory(_loggerFactory);

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmRateLimitingExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmRateLimitingExtension.cs
@@ -1,7 +1,9 @@
+#nullable enable
 using System;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace WalkingTec.Mvvm.Mvc

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmRateLimitingExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmRateLimitingExtension.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace WalkingTec.Mvvm.Mvc
+{
+    public class WtmRateLimitingOptions
+    {
+        public int PermitLimit { get; set; } = 100;
+        public int WindowSeconds { get; set; } = 60;
+        public int QueueLimit { get; set; } = 0;
+        public Action<RateLimiterOptions>? CustomConfig { get; set; }
+    }
+
+    public static class WtmRateLimitingExtension
+    {
+        public static IServiceCollection AddWtmRateLimiting(
+            this IServiceCollection services,
+            Action<WtmRateLimitingOptions>? configure = null)
+        {
+            var options = new WtmRateLimitingOptions();
+            configure?.Invoke(options);
+
+            services.AddRateLimiter(limiterOptions =>
+            {
+                limiterOptions.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+                limiterOptions.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(
+                    httpContext =>
+                    {
+                        var clientIp = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+                        return RateLimitPartition.GetFixedWindowLimiter(clientIp, _ =>
+                            new FixedWindowRateLimiterOptions
+                            {
+                                PermitLimit = options.PermitLimit,
+                                Window = TimeSpan.FromSeconds(options.WindowSeconds),
+                                QueueLimit = options.QueueLimit
+                            });
+                    });
+
+                options.CustomConfig?.Invoke(limiterOptions);
+            });
+
+            return services;
+        }
+
+        public static IApplicationBuilder UseWtmRateLimiting(this IApplicationBuilder app)
+        {
+            app.UseRateLimiter();
+            return app;
+        }
+    }
+}

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmSerilogExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmSerilogExtension.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/Form/SearchPanelTagHelper.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/Form/SearchPanelTagHelper.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json.Schema;
 using System;
 using System.Threading.Tasks;
 using WalkingTec.Mvvm.Core;

--- a/test/WalkingTec.Mvvm.Core.Test/AuditInterceptorTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/AuditInterceptorTests.cs
@@ -1,0 +1,158 @@
+#nullable disable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Core.Test
+{
+    [TestClass]
+    public class AuditInterceptorTests : IDisposable
+    {
+        private SqliteConnection _keepAlive;
+        private TestAuditContext _dc;
+
+        private class AuditTestModel : BasePoco
+        {
+            public string Name { get; set; }
+        }
+
+        private class TestAuditContext : EmptyContext
+        {
+            public DbSet<AuditTestModel> AuditTestModels { get; set; }
+
+            public TestAuditContext(string cs, DBTypeEnum dbtype) : base(cs, dbtype) { }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder.UseSqlite($"DataSource={CSName}?mode=memory&cache=shared");
+            }
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var seed = $"AuditTest_{Guid.NewGuid():N}";
+            _keepAlive = new SqliteConnection($"DataSource={seed}?mode=memory&cache=shared");
+            _keepAlive.Open();
+            _dc = new TestAuditContext(seed, DBTypeEnum.SQLite);
+            _dc.Database.EnsureCreated();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _dc?.Dispose();
+            _keepAlive?.Close();
+            _keepAlive?.Dispose();
+        }
+
+        public void Dispose()
+        {
+            Cleanup();
+        }
+
+        [TestMethod]
+        public void SaveChanges_fills_CreateBy_and_CreateTime_on_add()
+        {
+            _dc.CurrentUserCode = "admin";
+            var entity = new AuditTestModel { Name = "Test" };
+            _dc.Set<AuditTestModel>().Add(entity);
+            _dc.SaveChanges();
+
+            Assert.AreEqual("admin", entity.CreateBy);
+            Assert.IsNotNull(entity.CreateTime);
+        }
+
+        [TestMethod]
+        public void SaveChanges_does_not_overwrite_existing_CreateBy()
+        {
+            _dc.CurrentUserCode = "admin";
+            var entity = new AuditTestModel
+            {
+                Name = "Test",
+                CreateBy = "custom_user",
+                CreateTime = new DateTime(2020, 1, 1)
+            };
+            _dc.Set<AuditTestModel>().Add(entity);
+            _dc.SaveChanges();
+
+            Assert.AreEqual("custom_user", entity.CreateBy,
+                "Interceptor should not overwrite explicitly set CreateBy");
+            Assert.AreEqual(new DateTime(2020, 1, 1), entity.CreateTime,
+                "Interceptor should not overwrite explicitly set CreateTime");
+        }
+
+        [TestMethod]
+        public void SaveChanges_fills_UpdateBy_and_UpdateTime_on_modify()
+        {
+            _dc.CurrentUserCode = "admin";
+            var entity = new AuditTestModel { Name = "Original" };
+            _dc.Set<AuditTestModel>().Add(entity);
+            _dc.SaveChanges();
+
+            // Clear update fields set during add
+            entity.UpdateBy = null;
+            entity.UpdateTime = null;
+
+            // Modify
+            entity.Name = "Modified";
+            _dc.Entry(entity).State = EntityState.Modified;
+            _dc.SaveChanges();
+
+            Assert.AreEqual("admin", entity.UpdateBy);
+            Assert.IsNotNull(entity.UpdateTime);
+        }
+
+        [TestMethod]
+        public void SaveChanges_does_not_overwrite_existing_UpdateBy()
+        {
+            _dc.CurrentUserCode = "admin";
+            var entity = new AuditTestModel { Name = "Test" };
+            _dc.Set<AuditTestModel>().Add(entity);
+            _dc.SaveChanges();
+
+            // Set update fields manually (VM pattern)
+            entity.UpdateBy = "vm_user";
+            entity.UpdateTime = new DateTime(2025, 6, 15);
+            entity.Name = "Updated";
+            _dc.Entry(entity).State = EntityState.Modified;
+            _dc.SaveChanges();
+
+            Assert.AreEqual("vm_user", entity.UpdateBy,
+                "Interceptor should not overwrite explicitly set UpdateBy");
+            Assert.AreEqual(new DateTime(2025, 6, 15), entity.UpdateTime,
+                "Interceptor should not overwrite explicitly set UpdateTime");
+        }
+
+        [TestMethod]
+        public async Task SaveChangesAsync_fills_audit_fields()
+        {
+            _dc.CurrentUserCode = "async_user";
+            var entity = new AuditTestModel { Name = "AsyncTest" };
+            _dc.Set<AuditTestModel>().Add(entity);
+            await _dc.SaveChangesAsync();
+
+            Assert.AreEqual("async_user", entity.CreateBy);
+            Assert.IsNotNull(entity.CreateTime);
+        }
+
+        [TestMethod]
+        public void SaveChanges_works_without_CurrentUserCode()
+        {
+            // CurrentUserCode is null — should still set CreateTime but not CreateBy
+            _dc.CurrentUserCode = null;
+            var entity = new AuditTestModel { Name = "NoUser" };
+            _dc.Set<AuditTestModel>().Add(entity);
+            _dc.SaveChanges();
+
+            Assert.IsNotNull(entity.CreateTime,
+                "CreateTime should be set even without a current user");
+            Assert.IsNull(entity.CreateBy,
+                "CreateBy should remain null when CurrentUserCode is null");
+        }
+    }
+}

--- a/test/WalkingTec.Mvvm.Core.Test/RateLimitingTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/RateLimitingTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Mvc;
+
+namespace WalkingTec.Mvvm.Core.Test
+{
+    [TestClass]
+    public class RateLimitingTests
+    {
+        [TestMethod]
+        public async Task requests_within_limit_succeed()
+        {
+            using var host = new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder.UseTestServer();
+                    webBuilder.ConfigureServices(services =>
+                    {
+                        services.AddWtmRateLimiting(opt =>
+                        {
+                            opt.PermitLimit = 5;
+                            opt.WindowSeconds = 60;
+                        });
+                    });
+                    webBuilder.Configure(app =>
+                    {
+                        app.UseWtmRateLimiting();
+                        app.Run(async ctx => await ctx.Response.WriteAsync("OK"));
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+            var client = host.GetTestClient();
+
+            for (int i = 0; i < 5; i++)
+            {
+                var response = await client.GetAsync("/api/test");
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
+                    $"Request {i + 1} should succeed within rate limit");
+            }
+        }
+
+        [TestMethod]
+        public async Task requests_over_limit_return_429()
+        {
+            using var host = new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder.UseTestServer();
+                    webBuilder.ConfigureServices(services =>
+                    {
+                        services.AddWtmRateLimiting(opt =>
+                        {
+                            opt.PermitLimit = 2;
+                            opt.WindowSeconds = 60;
+                        });
+                    });
+                    webBuilder.Configure(app =>
+                    {
+                        app.UseWtmRateLimiting();
+                        app.Run(async ctx => await ctx.Response.WriteAsync("OK"));
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+            var client = host.GetTestClient();
+
+            // First 2 should succeed
+            await client.GetAsync("/api/test");
+            await client.GetAsync("/api/test");
+
+            // Third should be rate-limited
+            var response = await client.GetAsync("/api/test");
+            Assert.AreEqual(HttpStatusCode.TooManyRequests, (HttpStatusCode)response.StatusCode,
+                "Request exceeding rate limit should return 429");
+        }
+
+        [TestMethod]
+        public async Task not_calling_AddWtmRateLimiting_has_no_effect()
+        {
+            using var host = new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder.UseTestServer();
+                    webBuilder.Configure(app =>
+                    {
+                        // NOT calling UseWtmRateLimiting
+                        app.Run(async ctx => await ctx.Response.WriteAsync("OK"));
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+            var client = host.GetTestClient();
+
+            // 100 requests should all succeed without rate limiting
+            for (int i = 0; i < 100; i++)
+            {
+                var response = await client.GetAsync("/api/test");
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #38

- **Audit Interceptor**: `EmptyContext.SaveChanges` auto-fills `CreateBy`/`CreateTime`/`UpdateBy`/`UpdateTime` (additive only, never overwrites VM-set values). `IDataContext.CurrentUserCode` propagated from `WTMContext.LoginUserInfo`
- **Rate Limiting**: `AddWtmRateLimiting()` / `UseWtmRateLimiting()` opt-in IP-based fixed window (100 req/60s default, configurable). Returns 429 on limit exceeded
- **Cleanup**: Remove unused `using Newtonsoft.Json.Schema` from `SearchPanelTagHelper.cs`
- **Build fix**: Add `#nullable enable` + missing `using Microsoft.AspNetCore.RateLimiting` for Mvc extensions

## Test plan
- [x] AuditInterceptor 6 tests (add/modify/async/null-user/no-overwrite)
- [x] RateLimiting 3 tests (within-limit/over-limit 429/no-op)
- [x] CI build + all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)