### PR TITLE
fix(deps): upgrade System.Text.Json and ImageSharp to fix High vulnerabilities

### DIFF
--- a/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
+++ b/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Quartz" Version="3.16.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.22" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
+++ b/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
@@ -82,7 +82,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DUWENINK.Captcha" Version="0.7.0" />
+    <PackageReference Include="DUWENINK.Captcha" Version="0.8.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.22" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />


### PR DESCRIPTION
## Summary

- Add direct `System.Text.Json 8.0.6` to Core (overrides transitive 8.0.0) — fixes 2× High CVEs
- Upgrade `DUWENINK.Captcha` 0.7.0 → 0.8.0 (last .NET 8 compatible version)
- Pin `SixLabors.ImageSharp 3.1.12` + `ImageSharp.Drawing 2.1.7` in Mvc — fixes 6 CVEs

`dotnet list package --vulnerable --include-transitive` reports zero vulnerabilities after this change.

Closes #82

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `dotnet test -c Release` — 227 passed
- [x] `dotnet list package --vulnerable` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)