### PR TITLE
feat(analysis): add DateHierarchy enum and DateTime detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # wtm custom
+.worktrees/
 
 demo/WalkingTec.Mvvm.Demo/wwwroot/layuiadminsrc
 .Publish/

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldMeta.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldMeta.cs
@@ -29,5 +29,11 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
         /// <summary>欄位的 CLR 型別</summary>
         public Type ClrType { get; set; } = typeof(object);
+
+        /// <summary>是否為日期型別的維度欄位</summary>
+        public bool IsDate { get; set; }
+
+        /// <summary>日期維度的時間層級（僅 IsDate=true 時有意義）</summary>
+        public DateHierarchy Hierarchy { get; set; } = DateHierarchy.None;
     }
 }

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldScanner.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldScanner.cs
@@ -29,12 +29,18 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 var dim = prop.GetCustomAttribute<DimensionAttribute>();
                 if (dim != null)
                 {
+                    var clrType = prop.PropertyType;
+                    var underlying = Nullable.GetUnderlyingType(clrType) ?? clrType;
+                    var isDate = underlying == typeof(DateTime);
+
                     yield return new AnalysisFieldMeta
                     {
                         FieldName = prop.Name,
                         DisplayName = dim.DisplayName ?? prop.Name,
                         Kind = AnalysisFieldKind.Dimension,
-                        ClrType = prop.PropertyType
+                        ClrType = clrType,
+                        IsDate = isDate,
+                        Hierarchy = isDate ? dim.Hierarchy : DateHierarchy.None
                     };
                     continue;
                 }

--- a/src/WalkingTec.Mvvm.Core/Analysis/DateHierarchy.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/DateHierarchy.cs
@@ -1,0 +1,13 @@
+#nullable enable
+namespace WalkingTec.Mvvm.Core.Analysis
+{
+    /// <summary>日期維度的時間層級</summary>
+    public enum DateHierarchy
+    {
+        None = 0,
+        Year,
+        Quarter,
+        Month,
+        Day
+    }
+}

--- a/src/WalkingTec.Mvvm.Core/Analysis/DimensionAttribute.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/DimensionAttribute.cs
@@ -11,5 +11,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
     {
         /// <summary>前端顯示名稱（可為 null，預設使用屬性名）</summary>
         public string? DisplayName { get; set; }
+
+        /// <summary>日期維度的時間層級（僅對 DateTime/DateTime? 屬性有效）</summary>
+        public DateHierarchy Hierarchy { get; set; } = DateHierarchy.None;
     }
 }

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisFieldScannerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisFieldScannerTests.cs
@@ -75,5 +75,67 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.AreEqual(1, fields.Count);
             Assert.AreEqual("Category", fields[0].DisplayName);
         }
+
+        // --- DateHierarchy tests (#91, #92, #93) ---
+
+        private class DateModel
+        {
+            [Dimension(DisplayName = "訂單日期", Hierarchy = DateHierarchy.Month)]
+            public DateTime OrderDate { get; set; }
+
+            [Dimension(DisplayName = "取消日期")]
+            public DateTime? CancelDate { get; set; }
+
+            [Dimension(DisplayName = "地區")]
+            public string Region { get; set; } = string.Empty;
+
+            [Dimension(Hierarchy = DateHierarchy.Year)]
+            public DateTime CreatedAt { get; set; }
+        }
+
+        [TestMethod]
+        public void DateTime_property_sets_IsDate_true_and_Hierarchy()
+        {
+            var field = AnalysisFieldScanner.ScanModel(typeof(DateModel))
+                            .Single(f => f.FieldName == "OrderDate");
+            Assert.IsTrue(field.IsDate);
+            Assert.AreEqual(DateHierarchy.Month, field.Hierarchy);
+        }
+
+        [TestMethod]
+        public void Nullable_DateTime_property_sets_IsDate_true()
+        {
+            var field = AnalysisFieldScanner.ScanModel(typeof(DateModel))
+                            .Single(f => f.FieldName == "CancelDate");
+            Assert.IsTrue(field.IsDate);
+            Assert.AreEqual(DateHierarchy.None, field.Hierarchy);
+        }
+
+        [TestMethod]
+        public void String_dimension_sets_IsDate_false()
+        {
+            var field = AnalysisFieldScanner.ScanModel(typeof(DateModel))
+                            .Single(f => f.FieldName == "Region");
+            Assert.IsFalse(field.IsDate);
+            Assert.AreEqual(DateHierarchy.None, field.Hierarchy);
+        }
+
+        [TestMethod]
+        public void Non_date_dimension_has_Hierarchy_None()
+        {
+            var field = AnalysisFieldScanner.ScanModel(typeof(OrderModel))
+                            .Single(f => f.FieldName == "Region");
+            Assert.IsFalse(field.IsDate);
+            Assert.AreEqual(DateHierarchy.None, field.Hierarchy);
+        }
+
+        [TestMethod]
+        public void DateTime_with_Year_hierarchy()
+        {
+            var field = AnalysisFieldScanner.ScanModel(typeof(DateModel))
+                            .Single(f => f.FieldName == "CreatedAt");
+            Assert.IsTrue(field.IsDate);
+            Assert.AreEqual(DateHierarchy.Year, field.Hierarchy);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `DateHierarchy` enum (`None`, `Year`, `Quarter`, `Month`, `Day`)
- Extend `AnalysisFieldMeta` with `IsDate` and `Hierarchy` properties
- Update `DimensionAttribute` with `Hierarchy` property
- Enhance `AnalysisFieldScanner` to auto-detect `DateTime`/`DateTime?`

Closes #91, Closes #92, Closes #93

## Test plan
- [x] 5 new tests added
- [x] All 74 Analysis tests pass (69 existing + 5 new)
- [x] Build 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)