### PR TITLE
feat(analysis): add QueryHash cache layer with IAnalysisCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # wtm custom
+.worktrees/
 
 demo/WalkingTec.Mvvm.Demo/wwwroot/layuiadminsrc
 .Publish/

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -17,6 +17,21 @@ namespace WalkingTec.Mvvm.Core.Analysis
         // 防止全表載入造成記憶體耗盡（C-1）
         private const int MaxMaterializeRows = 50_000;
 
+        private readonly IAnalysisCache? _cache;
+
+        /// <summary>
+        /// 建立不帶快取的引擎（向後相容）。
+        /// </summary>
+        public AnalysisQueryEngine() : this(null) { }
+
+        /// <summary>
+        /// 建立帶快取的引擎。傳入 null 表示不使用快取。
+        /// </summary>
+        public AnalysisQueryEngine(IAnalysisCache? cache)
+        {
+            _cache = cache;
+        }
+
         /// <summary>
         /// 執行分析查詢，回傳聚合結果。
         /// </summary>
@@ -28,6 +43,13 @@ namespace WalkingTec.Mvvm.Core.Analysis
             var wl = whitelist.ToDictionary(f => f.FieldName);
             ValidateFields(req, wl);
 
+            // 先計算 hash，用於快取查詢（hash 僅由 request 決定，與資料無關）
+            var queryHash = ComputeHash(req);
+
+            // 快取命中時直接回傳
+            if (_cache != null && _cache.TryGet(queryHash, out var cached) && cached != null)
+                return cached;
+
             var filtered = ApplyFilters(baseQuery, req.Filters, wl);
             var rows = ExecuteGroupBy(filtered, req, wl);
             int totalCount = rows.Count;   // 截斷前的真實筆數（I-3）
@@ -38,14 +60,18 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 .Concat(req.Measures.Select(m => $"{m.Field}_{m.Func}"))
                 .ToList();
 
-            return new AnalysisQueryResponse
+            var response = new AnalysisQueryResponse
             {
                 Columns = columns,
                 Rows = rows,
                 TotalCount = totalCount,
                 Truncated = truncated,
-                QueryHash = ComputeHash(req)
+                QueryHash = queryHash
             };
+
+            _cache?.Set(queryHash, response);
+
+            return response;
         }
 
         /// <summary>

--- a/src/WalkingTec.Mvvm.Core/Analysis/IAnalysisCache.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/IAnalysisCache.cs
@@ -1,0 +1,16 @@
+#nullable enable
+using System;
+
+namespace WalkingTec.Mvvm.Core.Analysis
+{
+    /// <summary>
+    /// 分析查詢快取介面，用於快取 QueryHash 對應的查詢結果。
+    /// </summary>
+    public interface IAnalysisCache
+    {
+        bool TryGet(string queryHash, out AnalysisQueryResponse? cached);
+        void Set(string queryHash, AnalysisQueryResponse response, TimeSpan? ttl = null);
+        void Invalidate(string queryHash);
+        void InvalidateAll();
+    }
+}

--- a/src/WalkingTec.Mvvm.Core/Analysis/MemoryAnalysisCache.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/MemoryAnalysisCache.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using System;
+using System.Threading;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+
+namespace WalkingTec.Mvvm.Core.Analysis
+{
+    /// <summary>
+    /// 基於 IMemoryCache 的分析查詢快取實作。
+    /// 使用 CancellationTokenSource 實現 InvalidateAll（IMemoryCache 無 Clear 方法）。
+    /// </summary>
+    public class MemoryAnalysisCache : IAnalysisCache
+    {
+        private readonly IMemoryCache _cache;
+        private readonly TimeSpan _defaultTtl;
+        private CancellationTokenSource _cts;
+        private readonly object _lock = new();
+
+        public MemoryAnalysisCache(IMemoryCache cache, TimeSpan? defaultTtl = null)
+        {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _defaultTtl = defaultTtl ?? TimeSpan.FromMinutes(5);
+            _cts = new CancellationTokenSource();
+        }
+
+        public bool TryGet(string queryHash, out AnalysisQueryResponse? cached)
+        {
+            return _cache.TryGetValue(queryHash, out cached);
+        }
+
+        public void Set(string queryHash, AnalysisQueryResponse response, TimeSpan? ttl = null)
+        {
+            var options = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = ttl ?? _defaultTtl
+            };
+
+            lock (_lock)
+            {
+                options.AddExpirationToken(new CancellationChangeToken(_cts.Token));
+            }
+
+            _cache.Set(queryHash, response, options);
+        }
+
+        public void Invalidate(string queryHash)
+        {
+            _cache.Remove(queryHash);
+        }
+
+        public void InvalidateAll()
+        {
+            lock (_lock)
+            {
+                _cts.Cancel();
+                _cts.Dispose();
+                _cts = new CancellationTokenSource();
+            }
+        }
+    }
+}

--- a/src/WalkingTec.Mvvm.Core/Analysis/NullAnalysisCache.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/NullAnalysisCache.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+
+namespace WalkingTec.Mvvm.Core.Analysis
+{
+    /// <summary>
+    /// 不執行任何快取的空實作，用於停用快取時。
+    /// </summary>
+    public class NullAnalysisCache : IAnalysisCache
+    {
+        public bool TryGet(string queryHash, out AnalysisQueryResponse? cached)
+        {
+            cached = null;
+            return false;
+        }
+
+        public void Set(string queryHash, AnalysisQueryResponse response, TimeSpan? ttl = null) { }
+        public void Invalidate(string queryHash) { }
+        public void InvalidateAll() { }
+    }
+}

--- a/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
+++ b/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.22" />
     <PackageReference Include="NPOI" Version="2.7.6" />
     <PackageReference Include="Fare" Version="2.2.1" />

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -546,6 +546,8 @@ namespace WalkingTec.Mvvm.Mvc
             var analysisRegistry = new WalkingTec.Mvvm.Core.Analysis.AnalysisVmRegistry();
             analysisRegistry.Build(AppDomain.CurrentDomain.GetAssemblies());
             services.AddSingleton(analysisRegistry);
+            services.AddMemoryCache();
+            services.AddSingleton<WalkingTec.Mvvm.Core.Analysis.IAnalysisCache, WalkingTec.Mvvm.Core.Analysis.MemoryAnalysisCache>();
             var cs = conf.Connections.Where(x => x.Enabled).ToList();
             foreach (var item in cs)
             {

--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -21,9 +21,13 @@ namespace WalkingTec.Mvvm.Mvc
     public class _AnalysisController : BaseController
     {
         private readonly AnalysisVmRegistry _registry;
+        private readonly IAnalysisCache? _cache;
 
-        public _AnalysisController(AnalysisVmRegistry registry)
-            => _registry = registry;
+        public _AnalysisController(AnalysisVmRegistry registry, IAnalysisCache? cache = null)
+        {
+            _registry = registry;
+            _cache = cache;
+        }
 
         /// <summary>
         /// GET /_analysis/meta?listVmType=Foo.BarListVM
@@ -71,7 +75,7 @@ namespace WalkingTec.Mvvm.Mvc
 
             try
             {
-                var result = new AnalysisQueryEngine().ExecuteDynamic(baseQuery, req, fields);
+                var result = new AnalysisQueryEngine(_cache).ExecuteDynamic(baseQuery, req, fields);
                 return Ok(result);
             }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
@@ -99,7 +103,7 @@ namespace WalkingTec.Mvvm.Mvc
             if (baseQuery == null) return BadRequest("無法取得查詢來源。");
 
             AnalysisQueryResponse result;
-            try { result = new AnalysisQueryEngine().ExecuteDynamic(baseQuery, req, fields); }
+            try { result = new AnalysisQueryEngine(_cache).ExecuteDynamic(baseQuery, req, fields); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
 
             if (format.Equals("csv", StringComparison.OrdinalIgnoreCase))

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisCacheTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisCacheTests.cs
@@ -1,0 +1,207 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Core.Analysis;
+
+namespace WalkingTec.Mvvm.Core.Test.Analysis
+{
+    [TestClass]
+    public class AnalysisCacheTests
+    {
+        // ─── NullAnalysisCache ──────────────────────────────────────────────
+
+        [TestMethod]
+        public void NullCache_TryGet_always_returns_false()
+        {
+            var cache = new NullAnalysisCache();
+            var response = new AnalysisQueryResponse { QueryHash = "ABCD1234ABCD1234" };
+            cache.Set("ABCD1234ABCD1234", response);
+
+            var hit = cache.TryGet("ABCD1234ABCD1234", out var cached);
+
+            Assert.IsFalse(hit);
+            Assert.IsNull(cached);
+        }
+
+        // ─── MemoryAnalysisCache ────────────────────────────────────────────
+
+        [TestMethod]
+        public void MemoryCache_Set_then_TryGet_returns_cached_response()
+        {
+            var mc = new MemoryCache(new MemoryCacheOptions());
+            var cache = new MemoryAnalysisCache(mc);
+            var response = MakeResponse("HASH0001");
+
+            cache.Set("HASH0001", response);
+            var hit = cache.TryGet("HASH0001", out var cached);
+
+            Assert.IsTrue(hit);
+            Assert.IsNotNull(cached);
+            Assert.AreEqual("HASH0001", cached!.QueryHash);
+            Assert.AreEqual(response.TotalCount, cached.TotalCount);
+        }
+
+        [TestMethod]
+        public void MemoryCache_Invalidate_removes_specific_entry()
+        {
+            var mc = new MemoryCache(new MemoryCacheOptions());
+            var cache = new MemoryAnalysisCache(mc);
+            cache.Set("KEY_A", MakeResponse("KEY_A"));
+            cache.Set("KEY_B", MakeResponse("KEY_B"));
+
+            cache.Invalidate("KEY_A");
+
+            Assert.IsFalse(cache.TryGet("KEY_A", out _));
+            Assert.IsTrue(cache.TryGet("KEY_B", out _));
+        }
+
+        [TestMethod]
+        public void MemoryCache_InvalidateAll_clears_everything()
+        {
+            var mc = new MemoryCache(new MemoryCacheOptions());
+            var cache = new MemoryAnalysisCache(mc);
+            cache.Set("KEY_A", MakeResponse("KEY_A"));
+            cache.Set("KEY_B", MakeResponse("KEY_B"));
+
+            cache.InvalidateAll();
+
+            Assert.IsFalse(cache.TryGet("KEY_A", out _));
+            Assert.IsFalse(cache.TryGet("KEY_B", out _));
+        }
+
+        [TestMethod]
+        public void MemoryCache_expired_entry_is_not_returned()
+        {
+            var mc = new MemoryCache(new MemoryCacheOptions());
+            var cache = new MemoryAnalysisCache(mc);
+            cache.Set("SHORT", MakeResponse("SHORT"), ttl: TimeSpan.FromMilliseconds(1));
+
+            Thread.Sleep(50);
+
+            Assert.IsFalse(cache.TryGet("SHORT", out _));
+        }
+
+        // ─── Engine + Cache 整合 ────────────────────────────────────────────
+
+        private class SaleRecord : TopBasePoco
+        {
+            [Dimension(DisplayName = "地區")]
+            public string Region { get; set; } = string.Empty;
+
+            [Measure(AllowedFuncs = AggregateFunc.Sum | AggregateFunc.Count,
+                     DisplayName = "金額")]
+            public decimal Amount { get; set; }
+        }
+
+        private class SaleTestContext : DbContext
+        {
+            public SaleTestContext(DbContextOptions opts) : base(opts) { }
+            public DbSet<SaleRecord> SaleRecords { get; set; } = null!;
+        }
+
+        [TestMethod]
+        public void Engine_with_cache_returns_cached_on_second_call()
+        {
+            using var conn = new SqliteConnection("DataSource=:memory:");
+            conn.Open();
+            var opts = new DbContextOptionsBuilder<SaleTestContext>().UseSqlite(conn).Options;
+            using var ctx = new SaleTestContext(opts);
+            ctx.Database.EnsureCreated();
+            ctx.SaleRecords.Add(new SaleRecord
+            {
+                ID = Guid.NewGuid(), Region = "北", Amount = 100m
+            });
+            ctx.SaveChanges();
+
+            var whitelist = AnalysisFieldScanner.ScanModel(typeof(SaleRecord));
+            var mc = new MemoryCache(new MemoryCacheOptions());
+            var cache = new MemoryAnalysisCache(mc);
+            var engine = new AnalysisQueryEngine(cache);
+
+            var req = new AnalysisQueryRequest
+            {
+                Dimensions = new List<string> { "Region" },
+                Measures = new List<MeasureRequest>
+                {
+                    new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum }
+                },
+                Filters = new List<FilterCondition>()
+            };
+
+            var result1 = engine.Execute(ctx.SaleRecords.AsQueryable(), req, whitelist);
+            Assert.AreEqual(1, result1.Rows.Count);
+            Assert.AreEqual(100m, Convert.ToDecimal(result1.Rows[0]["Amount_Sum"]));
+
+            // 新增資料後，因快取命中，第二次查詢應回傳與第一次相同的結果
+            ctx.SaleRecords.Add(new SaleRecord
+            {
+                ID = Guid.NewGuid(), Region = "南", Amount = 200m
+            });
+            ctx.SaveChanges();
+
+            var result2 = engine.Execute(ctx.SaleRecords.AsQueryable(), req, whitelist);
+
+            // 快取命中：結果應與第一次一致（1 列，非 2 列）
+            Assert.AreEqual(1, result2.Rows.Count);
+            Assert.AreSame(result1, result2);
+        }
+
+        [TestMethod]
+        public void Engine_without_cache_works_as_before()
+        {
+            using var conn = new SqliteConnection("DataSource=:memory:");
+            conn.Open();
+            var opts = new DbContextOptionsBuilder<SaleTestContext>().UseSqlite(conn).Options;
+            using var ctx = new SaleTestContext(opts);
+            ctx.Database.EnsureCreated();
+            ctx.SaleRecords.Add(new SaleRecord
+            {
+                ID = Guid.NewGuid(), Region = "北", Amount = 100m
+            });
+            ctx.SaveChanges();
+
+            var whitelist = AnalysisFieldScanner.ScanModel(typeof(SaleRecord));
+            var engine = new AnalysisQueryEngine(); // 無快取
+
+            var req = new AnalysisQueryRequest
+            {
+                Dimensions = new List<string> { "Region" },
+                Measures = new List<MeasureRequest>
+                {
+                    new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum }
+                },
+                Filters = new List<FilterCondition>()
+            };
+
+            var result = engine.Execute(ctx.SaleRecords.AsQueryable(), req, whitelist);
+
+            Assert.AreEqual(1, result.Rows.Count);
+            Assert.AreEqual(100m, Convert.ToDecimal(result.Rows[0]["Amount_Sum"]));
+            Assert.AreEqual(16, result.QueryHash.Length);
+        }
+
+        // ─── Helpers ────────────────────────────────────────────────────────
+
+        private static AnalysisQueryResponse MakeResponse(string hash)
+        {
+            return new AnalysisQueryResponse
+            {
+                QueryHash = hash,
+                Columns = new List<string> { "Col1" },
+                Rows = new List<Dictionary<string, object?>>
+                {
+                    new Dictionary<string, object?> { ["Col1"] = "val" }
+                },
+                TotalCount = 1,
+                Truncated = false
+            };
+        }
+    }
+}

--- a/test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj
+++ b/test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.22" />
     <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Define `IAnalysisCache` interface (`TryGet`/`Set`/`Invalidate`/`InvalidateAll`)
- Implement `MemoryAnalysisCache` wrapping `IMemoryCache` (5-min default TTL, `CancellationTokenSource`-based `InvalidateAll`)
- Add `NullAnalysisCache` no-op implementation for disabled caching
- Integrate into `AnalysisQueryEngine` — hash computed before query for cache lookup, results stored after
- Wire DI: `FrameworkServiceExtension.AddWtmContext()` registers `AddMemoryCache()` + `IAnalysisCache`
- `_AnalysisController` accepts `IAnalysisCache?` via constructor injection

Closes #97

## Test plan
- [x] 7 new cache tests (NullCache, MemoryCache set/get/invalidate/expiry, Engine integration)
- [x] All 76 Analysis tests pass (69 existing + 7 new)
- [x] Build 0 errors
- [x] Backward compatible: parameterless `AnalysisQueryEngine()` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)