### PR TITLE
feat(analysis): add DimensionHierarchies to query API DTO

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryRequest.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryRequest.cs
@@ -22,6 +22,9 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
         /// <summary>額外過濾條件（白名單驗證後進 Expression Tree）。</summary>
         public List<FilterCondition> Filters { get; set; } = new List<FilterCondition>();
+
+        /// <summary>維度對應的日期階層（僅日期維度需要，key=fieldName, value=hierarchy）</summary>
+        public Dictionary<string, DateHierarchy>? DimensionHierarchies { get; set; }
     }
 
     /// <summary>

--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -56,7 +56,9 @@ namespace WalkingTec.Mvvm.Mvc
                 Kind = f.Kind.ToString(),
                 AllowedFuncs = f.Kind == AnalysisFieldKind.Measure
                     ? GetAllowedFuncNames(f.AllowedFuncs)
-                    : Array.Empty<string>()
+                    : Array.Empty<string>(),
+                f.IsDate,
+                Hierarchy = f.Hierarchy.ToString()
             }));
         }
 
@@ -82,6 +84,9 @@ namespace WalkingTec.Mvvm.Mvc
             }
             var baseQuery = InvokeGetSearchQuery(vm, vmType);
             if (baseQuery == null) return BadRequest("無法取得查詢來源。");
+
+            var hierarchyError = ValidateDimensionHierarchies(req.DimensionHierarchies, fields);
+            if (hierarchyError != null) return BadRequest(hierarchyError);
 
             try
             {
@@ -115,6 +120,9 @@ namespace WalkingTec.Mvvm.Mvc
             }
             var baseQuery = InvokeGetSearchQuery(vm, vmType);
             if (baseQuery == null) return BadRequest("無法取得查詢來源。");
+
+            var hierarchyError = ValidateDimensionHierarchies(req.DimensionHierarchies, fields);
+            if (hierarchyError != null) return BadRequest(hierarchyError);
 
             AnalysisQueryResponse result;
             try { result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecuteDynamic(baseQuery, req, fields); }
@@ -233,6 +241,27 @@ namespace WalkingTec.Mvvm.Mvc
             {
                 throw ex.InnerException ?? ex;
             }
+        }
+
+        /// <summary>
+        /// 驗證 DimensionHierarchies 中的每個 key 都對應到 IsDate=true 的維度欄位。
+        /// 回傳 null 表示通過；否則回傳錯誤訊息字串。
+        /// </summary>
+        private static string? ValidateDimensionHierarchies(
+            Dictionary<string, DateHierarchy>? hierarchies,
+            IEnumerable<AnalysisFieldMeta> fields)
+        {
+            if (hierarchies == null || hierarchies.Count == 0) return null;
+
+            var fieldMap = fields.ToDictionary(f => f.FieldName, StringComparer.Ordinal);
+            foreach (var kvp in hierarchies)
+            {
+                if (!fieldMap.TryGetValue(kvp.Key, out var meta))
+                    return $"Field '{kvp.Key}' is not a valid analysis field.";
+                if (!meta.IsDate)
+                    return $"Field '{kvp.Key}' is not a date dimension.";
+            }
+            return null;
         }
 
         private static string[] GetAllowedFuncNames(AggregateFunc funcs)

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -49,6 +49,29 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 => _testData.AsQueryable().OrderByDescending(x => x.ID);
         }
 
+        // ─── 含日期維度的測試模型 ────────────────────────────────────────────────
+
+        private class OrderRecord : TopBasePoco
+        {
+            [Dimension(DisplayName = "訂單日期", Hierarchy = DateHierarchy.Month)]
+            public DateTime OrderDate { get; set; }
+
+            [Dimension(DisplayName = "地區")]
+            public string Region { get; set; }
+
+            [Measure(AllowedFuncs = AggregateFunc.Sum, DisplayName = "金額")]
+            public decimal Amount { get; set; }
+        }
+
+        private static IList<OrderRecord> _orderData = new List<OrderRecord>();
+
+        [EnableAnalysis]
+        private class OrderRecordListVM : BasePagedListVM<OrderRecord, BaseSearcher>
+        {
+            public override IOrderedQueryable<OrderRecord> GetSearchQuery()
+                => _orderData.AsQueryable().OrderByDescending(x => x.ID);
+        }
+
         // ─── 基礎設施 ──────────────────────────────────────────────────────────
 
         private AnalysisVmRegistry _registry;
@@ -57,6 +80,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         public void Setup()
         {
             _testData = new List<SaleRecord>();
+            _orderData = new List<OrderRecord>();
             _registry = new AnalysisVmRegistry();
             // 掃描本測試 assembly，會找到 SaleRecordListVM（帶 [EnableAnalysis]）
             _registry.Build(new[] { typeof(AnalysisControllerTests).Assembly });
@@ -352,6 +376,90 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
 
             Assert.IsFalse(csv.Contains(",+SUM"), "CSV 不應含未逸脫的 +SUM formula");
             Assert.IsTrue(csv.Contains("\t+SUM"), "危險值應以 tab 前置");
+        }
+
+        // ─── DimensionHierarchies 驗證 ─────────────────────────────────────────
+
+        [TestMethod]
+        public void Query_with_valid_DimensionHierarchies_on_date_field_returns_200()
+        {
+            _orderData = new List<OrderRecord>
+            {
+                new OrderRecord { ID = Guid.NewGuid(), OrderDate = new DateTime(2026, 1, 15), Region = "華東", Amount = 100m }
+            };
+
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(OrderRecordListVM).FullName,
+                Dimensions = new List<string> { "OrderDate" },
+                Measures = new List<MeasureRequest> { new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum } },
+                DimensionHierarchies = new Dictionary<string, DateHierarchy>
+                {
+                    ["OrderDate"] = DateHierarchy.Month
+                }
+            };
+
+            var result = CreateController().Query(req) as OkObjectResult;
+            Assert.IsNotNull(result, "帶有效 DimensionHierarchies 的查詢應回傳 200");
+        }
+
+        [TestMethod]
+        public void Query_with_DimensionHierarchies_on_non_date_field_returns_400()
+        {
+            _orderData = new List<OrderRecord>
+            {
+                new OrderRecord { ID = Guid.NewGuid(), OrderDate = new DateTime(2026, 1, 15), Region = "華東", Amount = 100m }
+            };
+
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(OrderRecordListVM).FullName,
+                Dimensions = new List<string> { "Region" },
+                Measures = new List<MeasureRequest> { new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum } },
+                DimensionHierarchies = new Dictionary<string, DateHierarchy>
+                {
+                    ["Region"] = DateHierarchy.Month
+                }
+            };
+
+            var result = CreateController().Query(req) as BadRequestObjectResult;
+            Assert.IsNotNull(result, "非日期欄位設定 DimensionHierarchies 應回傳 400");
+            Assert.IsTrue(result.Value.ToString().Contains("not a date dimension"),
+                "錯誤訊息應包含 'not a date dimension'");
+        }
+
+        [TestMethod]
+        public void Query_without_DimensionHierarchies_works_as_before()
+        {
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華東", Category = "A", Amount = 100m }
+            };
+
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+            // DimensionHierarchies is null by default — backward compat
+            Assert.IsNull(req.DimensionHierarchies);
+
+            var result = CreateController().Query(req) as OkObjectResult;
+            Assert.IsNotNull(result, "不帶 DimensionHierarchies 的查詢應向下相容回傳 200");
+        }
+
+        [TestMethod]
+        public void GetMeta_returns_IsDate_and_Hierarchy_for_date_fields()
+        {
+            var controller = CreateController();
+            var result = controller.GetMeta(typeof(OrderRecordListVM).FullName) as OkObjectResult;
+            Assert.IsNotNull(result);
+
+            var json = System.Text.Json.JsonSerializer.Serialize(result.Value);
+            // OrderDate 應有 IsDate=true 和 Hierarchy=Month
+            Assert.IsTrue(json.Contains("\"IsDate\":true"), "日期欄位應有 IsDate=true");
+            Assert.IsTrue(json.Contains("\"Hierarchy\":\"Month\""), "日期欄位應有 Hierarchy=Month");
+
+            // Region 應有 IsDate=false
+            Assert.IsTrue(json.Contains("\"IsDate\":false"), "非日期欄位應有 IsDate=false");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add nullable `DimensionHierarchies` dictionary to `AnalysisQueryRequest` DTO for frontend date drill-down per dimension
- Validate in `Query` and `Export` endpoints: non-date fields in `DimensionHierarchies` return 400
- Serialize `IsDate` and `Hierarchy` in meta endpoint response
- Add 4 new tests: valid hierarchy, non-date field rejection, backward compat, meta response fields

Closes #100

## Test plan
- [x] `dotnet build WalkingTec.Mvvm.sln -c Release` — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~Analysis"` — 115 tests pass
- [ ] Verify backward compat: old clients without `DimensionHierarchies` work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)