### PR TITLE
feat(analysis): add date hierarchy UI to frontend analysis mode

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -35,6 +35,20 @@
         return errors;
     }
 
+    /**
+     * 格式化日期整數 key 為人類可讀字串
+     * @param {number|string} key - 日期整數 key（如 2026, 20263, 202603, 20260309）
+     * @returns {string} 格式化後的字串
+     */
+    function formatDateKey(key) {
+        var s = String(key);
+        if (s.length === 4) return s;                                         // Year: 2026
+        if (s.length === 5) return s.substring(0, 4) + ' Q' + s.substring(4); // Quarter: 2026 Q3
+        if (s.length === 6) return s.substring(0, 4) + '-' + s.substring(4);  // Month: 2026-03
+        if (s.length === 8) return s.substring(0, 4) + '-' + s.substring(4, 6) + '-' + s.substring(6); // Day: 2026-03-09
+        return s; // fallback
+    }
+
     /** 清空 DOM 節點的所有子節點 */
     function clearChildren(el) {
         while (el.firstChild) {
@@ -205,6 +219,26 @@
             cb.dataset.kind = kind;
             cb.dataset.fieldName = f.fieldName;
             cb.dataset.displayName = f.displayName;
+            if (kind === 'Dimension' && f.isDate) {
+                cb.dataset.isDate = 'true';
+                var hierarchySelect = document.createElement('select');
+                hierarchySelect.className = 'analysis-hierarchy-select';
+                hierarchySelect.dataset.field = f.fieldName;
+                hierarchySelect.style.marginLeft = '4px';
+                [
+                    { value: 'Year', text: '年' },
+                    { value: 'Quarter', text: '季' },
+                    { value: 'Month', text: '月' },
+                    { value: 'Day', text: '日' }
+                ].forEach(function (h) {
+                    var opt = document.createElement('option');
+                    opt.value = h.value;
+                    opt.textContent = h.text;
+                    if (h.value === 'Month') opt.selected = true;
+                    hierarchySelect.appendChild(opt);
+                });
+                wrapper.appendChild(hierarchySelect);
+            }
             if (kind === 'Measure') {
                 var funcs = parseFuncs(f.allowedFuncs || 0);
                 if (funcs.length === 1) {
@@ -241,8 +275,9 @@
     function collectSelection(gridId) {
         var dims = [];
         var msrs = [];
+        var dimensionHierarchies = {};
         var panel = document.getElementById('analysis-panel-' + gridId);
-        
+
         var hasQsa = panel && typeof panel.querySelectorAll === 'function';
         var root = hasQsa ? panel : document;
         var selector = hasQsa ? '.analysis-field-cb:checked' : '.analysis-field-cb[data-grid-id="' + gridId + '"]:checked';
@@ -251,6 +286,14 @@
             .forEach(function (cb) {
                 if (cb.dataset.kind === 'Dimension') {
                     dims.push(cb.dataset.fieldName);
+                    if (cb.dataset.isDate === 'true') {
+                        var hSel = cb.parentNode && cb.parentNode.querySelector
+                            ? cb.parentNode.querySelector('.analysis-hierarchy-select')
+                            : null;
+                        if (hSel) {
+                            dimensionHierarchies[cb.dataset.fieldName] = hSel.value;
+                        }
+                    }
                 } else {
                     var sel = cb.nextElementSibling;
                     var func = (sel && sel.tagName === 'SELECT')
@@ -259,7 +302,7 @@
                     msrs.push({ field: cb.dataset.fieldName, func: func });
                 }
             });
-        return { dims: dims, msrs: msrs };
+        return { dims: dims, msrs: msrs, dimensionHierarchies: dimensionHierarchies };
     }
 
     /**
@@ -283,7 +326,9 @@
             listVmType: st.listVmType,
             dimensions: dims,
             measures: msrs,
-            filters: []
+            filters: [],
+            dimensionHierarchies: Object.keys(sel.dimensionHierarchies).length > 0
+                ? sel.dimensionHierarchies : undefined
         };
 
         var resultDiv = document.getElementById('analysis-result-' + gridId);
@@ -309,11 +354,12 @@
                 resultDiv.appendChild(warn);
             }
 
-            renderTable(gridId, result, resultDiv);
-
             var dimFields = (st.fields || []).filter(function (f) {
                 return f.kind === 'Dimension' && dims.indexOf(f.fieldName) >= 0;
             });
+            var dateDimSet = {};
+            dimFields.forEach(function (f) { if (f.isDate) dateDimSet[f.fieldName] = true; });
+            renderTable(gridId, result, resultDiv, dateDimSet);
             renderChart(gridId, result, { dimensions: dims, measures: msrs }, dimFields, resultDiv);
 
             // Store for chart type toggle
@@ -331,7 +377,8 @@
     /**
      * 渲染聚合結果表格（所有值用 textContent 設值，XSS 安全）
      */
-    function renderTable(gridId, result, container) {
+    function renderTable(gridId, result, container, dateDims) {
+        dateDims = dateDims || {};
         var table = document.createElement('table');
         table.className = 'layui-table';
         table.style.marginTop = '10px';
@@ -352,7 +399,11 @@
             result.columns.forEach(function (col) {
                 var td = document.createElement('td');
                 var val = row[col];
-                td.textContent = (val !== null && val !== undefined) ? String(val) : '';
+                if (val !== null && val !== undefined) {
+                    td.textContent = dateDims[col] ? formatDateKey(val) : String(val);
+                } else {
+                    td.textContent = '';
+                }
                 tr.appendChild(td);
             });
             tbody.appendChild(tr);
@@ -382,7 +433,11 @@
         var chartType = forceChartType || detectChartType(dimMeta, req.measures);
         var chart = window.echarts.init(chartDiv);
         var firstDim = req.dimensions[0];
-        var categories = result.rows.map(function (r) { return String(r[firstDim] || ''); });
+        var firstDimIsDate = dimMeta.length > 0 && dimMeta[0].isDate;
+        var categories = result.rows.map(function (r) {
+            var v = r[firstDim];
+            return firstDimIsDate ? formatDateKey(v) : String(v || '');
+        });
         var series = req.measures.map(function (m) {
             var key = m.field + '_' + m.func;
             return {
@@ -425,6 +480,8 @@
             }
         }
 
+        var exportHierarchies = Object.keys(sel.dimensionHierarchies).length > 0
+            ? sel.dimensionHierarchies : undefined;
         return fetch('/_analysis/export?format=' + encodeURIComponent(format), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -432,7 +489,8 @@
                 listVmType: st.listVmType,
                 dimensions: dims,
                 measures: msrs,
-                filters: []
+                filters: [],
+                dimensionHierarchies: exportHierarchies
             })
         })
         .then(function (res) {
@@ -465,7 +523,8 @@
         validateSelection: validateSelection,
         collectSelection: collectSelection,
         parseFuncs: parseFuncs,
-        renderChart: renderChart
+        renderChart: renderChart,
+        formatDateKey: formatDateKey
     };
 
 }(typeof window !== 'undefined' ? window : global));

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -1380,3 +1380,147 @@ describe('[cov] query with real meta — dimFields filter + chart toggle click',
         expect(global.echarts.init.mock.calls.length).toBe(2);
     });
 });
+
+// ─── formatDateKey ──────────────────────────────────────────────────────────
+describe('wtmAnalysis.formatDateKey', () => {
+    test('4 位 → Year 格式', () => {
+        expect(wa.formatDateKey(2026)).toBe('2026');
+        expect(wa.formatDateKey('2026')).toBe('2026');
+    });
+
+    test('5 位 → Quarter 格式', () => {
+        expect(wa.formatDateKey(20261)).toBe('2026 Q1');
+        expect(wa.formatDateKey(20263)).toBe('2026 Q3');
+    });
+
+    test('6 位 → Month 格式', () => {
+        expect(wa.formatDateKey(202603)).toBe('2026-03');
+        expect(wa.formatDateKey(202612)).toBe('2026-12');
+    });
+
+    test('8 位 → Day 格式', () => {
+        expect(wa.formatDateKey(20260309)).toBe('2026-03-09');
+        expect(wa.formatDateKey(20261231)).toBe('2026-12-31');
+    });
+
+    test('其他長度 → 原樣回傳', () => {
+        expect(wa.formatDateKey(12)).toBe('12');
+        expect(wa.formatDateKey(1234567)).toBe('1234567');
+    });
+});
+
+// ─── Date hierarchy dropdown ────────────────────────────────────────────────
+describe('Date hierarchy dropdown', () => {
+    test('isDate 維度欄位旁渲染 hierarchy 下拉（createElement 追蹤）', async () => {
+        const { wa, makePanel, mockFetch, mockDocument } = makeEnv();
+        const panel = makePanel('analysis-panel-dateDim1');
+
+        // 追蹤所有 createElement 產生的元素
+        var createdElements = [];
+        var origCreate = mockDocument.createElement;
+        mockDocument.createElement = jest.fn(function (tag) {
+            var el = origCreate(tag);
+            createdElements.push(el);
+            return el;
+        });
+
+        mockFetch.mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue([
+                { fieldName: 'OrderDate', displayName: '訂單日期', kind: 'Dimension', isDate: true, allowedFuncs: [] },
+                { fieldName: 'Region', displayName: '地區', kind: 'Dimension', isDate: false, allowedFuncs: [] },
+                { fieldName: 'Amount', displayName: '金額', kind: 'Measure', allowedFuncs: ['Sum'] },
+            ])
+        });
+
+        wa.toggle('dateDim1', 'TestVm');
+        await new Promise(r => setTimeout(r, 40));
+
+        // 從 createElement 紀錄中找 hierarchy select
+        var selects = createdElements.filter(function (el) {
+            return el.className === 'analysis-hierarchy-select';
+        });
+
+        // 只有 OrderDate 是 isDate，所以只有 1 個 hierarchy select
+        expect(selects.length).toBe(1);
+        expect(selects[0].dataset.field).toBe('OrderDate');
+        // 應有 4 個 option（Year, Quarter, Month, Day）
+        expect(selects[0].children.length).toBe(4);
+    });
+
+    test('isDate checkbox 有 data-is-date 屬性', async () => {
+        const { wa, makePanel, mockFetch, mockDocument } = makeEnv();
+        const panel = makePanel('analysis-panel-dateDim2');
+
+        var createdElements = [];
+        var origCreate = mockDocument.createElement;
+        mockDocument.createElement = jest.fn(function (tag) {
+            var el = origCreate(tag);
+            createdElements.push(el);
+            return el;
+        });
+
+        mockFetch.mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue([
+                { fieldName: 'OrderDate', displayName: '訂單日期', kind: 'Dimension', isDate: true, allowedFuncs: [] },
+            ])
+        });
+
+        wa.toggle('dateDim2', 'TestVm');
+        await new Promise(r => setTimeout(r, 40));
+
+        var checkboxes = createdElements.filter(function (el) {
+            return el.className === 'analysis-field-cb' && el.dataset.fieldName === 'OrderDate';
+        });
+        expect(checkboxes.length).toBe(1);
+        expect(checkboxes[0].dataset.isDate).toBe('true');
+    });
+});
+
+// ─── collectSelection with hierarchy ────────────────────────────────────────
+describe('collectSelection with dimensionHierarchies', () => {
+    test('日期維度的 hierarchy 被收集到 dimensionHierarchies', () => {
+        const { wa, mockDocument } = makeEnv();
+
+        // 模擬 panel
+        const panel = {
+            querySelectorAll: jest.fn(function () {
+                return [dimCb];
+            })
+        };
+        mockDocument.getElementById.mockReturnValue(panel);
+
+        // 模擬 date dimension checkbox
+        var hierarchySelect = { value: 'Quarter', className: 'analysis-hierarchy-select' };
+        var dimCb = {
+            dataset: { kind: 'Dimension', fieldName: 'OrderDate', isDate: 'true', gridId: 'g1' },
+            parentNode: {
+                querySelector: jest.fn(function (sel) {
+                    if (sel === '.analysis-hierarchy-select') return hierarchySelect;
+                    return null;
+                })
+            }
+        };
+        panel.querySelectorAll = jest.fn(function () { return [dimCb]; });
+
+        var result = wa.collectSelection('g1');
+        expect(result.dims).toEqual(['OrderDate']);
+        expect(result.dimensionHierarchies).toEqual({ OrderDate: 'Quarter' });
+    });
+
+    test('非日期維度不加入 dimensionHierarchies', () => {
+        const { wa, mockDocument } = makeEnv();
+
+        var dimCb = {
+            dataset: { kind: 'Dimension', fieldName: 'Region', gridId: 'g2' },
+            parentNode: { querySelector: jest.fn(function () { return null; }) }
+        };
+        const panel = { querySelectorAll: jest.fn(function () { return [dimCb]; }) };
+        mockDocument.getElementById.mockReturnValue(panel);
+
+        var result = wa.collectSelection('g2');
+        expect(result.dims).toEqual(['Region']);
+        expect(result.dimensionHierarchies).toEqual({});
+    });
+});


### PR DESCRIPTION
## Summary
- Date dimension fields now show a hierarchy dropdown (Year/Quarter/Month/Day) in the analysis panel
- `formatDateKey` pure function formats integer date keys for human-readable display
- Query and export requests include `dimensionHierarchies` parameter for date dimensions
- Table and chart rendering automatically format date keys

Closes #99

## Test plan
- [x] 132 Jest tests pass (9 new: formatDateKey, hierarchy dropdown, collectSelection with hierarchy)
- [x] .NET build passes (0 errors)
- [x] formatDateKey: Year(4-digit), Quarter(5-digit), Month(6-digit), Day(8-digit)
- [x] Hierarchy dropdown renders only for `isDate` dimension fields
- [x] collectSelection collects hierarchy values into `dimensionHierarchies`
- [x] Non-date dimensions don't appear in `dimensionHierarchies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)