### PR TITLE
feat(analysis): add chart drill-down interaction

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -36,6 +36,26 @@
     }
 
     /**
+     * 建構 drill-down 用的 filter 條件（純函式）
+     * @param {string} dimField - 維度欄位名
+     * @param {*} value - 點擊的維度值
+     * @returns {{ field: string, operator: string, value: * }}
+     */
+    function buildDrillFilter(dimField, value) {
+        return { field: dimField, operator: 'Eq', value: value };
+    }
+
+    /**
+     * 日期階層自動降級（純函式）
+     * @param {string} current - 'Year'|'Quarter'|'Month'|'Day'
+     * @returns {string|null} 下一層，Day 時回傳 null
+     */
+    function nextHierarchy(current) {
+        var map = { Year: 'Quarter', Quarter: 'Month', Month: 'Day' };
+        return map[current] || null;
+    }
+
+    /**
      * 格式化日期整數 key 為人類可讀字串
      * @param {number|string} key - 日期整數 key（如 2026, 20263, 202603, 20260309）
      * @returns {string} 格式化後的字串
@@ -67,7 +87,7 @@
         if (!panel) return;
 
         if (!_state[gridId]) {
-            _state[gridId] = { visible: false, listVmType: listVmType, fields: null };
+            _state[gridId] = { visible: false, listVmType: listVmType, fields: null, drillStack: [] };
         }
 
         var st = _state[gridId];
@@ -170,6 +190,12 @@
             chartToggleRow.appendChild(btn);
         });
         body.appendChild(chartToggleRow);
+
+        var drillBar = document.createElement('div');
+        drillBar.id = 'analysis-drill-bar-' + gridId;
+        drillBar.style.marginTop = '6px';
+        drillBar.style.display = 'none';
+        body.appendChild(drillBar);
 
         var resultDiv = document.createElement('div');
         resultDiv.id = 'analysis-result-' + gridId;
@@ -362,10 +388,18 @@
             renderTable(gridId, result, resultDiv, dateDimSet);
             renderChart(gridId, result, { dimensions: dims, measures: msrs }, dimFields, resultDiv);
 
-            // Store for chart type toggle
+            // Store for chart type toggle + drill
             st.lastResult = result;
-            st.lastReq = { dimensions: dims, measures: msrs };
+            st.lastReq = {
+                dimensions: dims, measures: msrs,
+                dimensionHierarchies: Object.keys(sel.dimensionHierarchies).length > 0
+                    ? sel.dimensionHierarchies : undefined
+            };
             st.lastDimFields = dimFields;
+            // Reset drill state on fresh query
+            st.drillStack = [];
+            st.drillFilters = [];
+            updateDrillBar(gridId);
             var toggleRow = document.getElementById('analysis-chart-toggle-' + gridId);
             if (toggleRow) toggleRow.style.display = 'block';
         })
@@ -455,6 +489,188 @@
             yAxis: { type: 'value' },
             series: series
         });
+
+        // drill-down click handler
+        chart.on('click', function (params) {
+            if (!firstDim) return;
+            var rawRow = result.rows[params.dataIndex];
+            if (!rawRow) return;
+            var rawValue = rawRow[firstDim];
+            drillDown(gridId, firstDim, rawValue, firstDimIsDate);
+        });
+    }
+
+    /**
+     * 更新 drill 路徑列（顯示麵包屑 + 返回/重置按鈕）
+     */
+    function updateDrillBar(gridId) {
+        var drillBar = document.getElementById('analysis-drill-bar-' + gridId);
+        if (!drillBar) return;
+
+        var st = _state[gridId];
+        if (!st || st.drillStack.length === 0) {
+            drillBar.style.display = 'none';
+            clearChildren(drillBar);
+            return;
+        }
+
+        drillBar.style.display = 'block';
+        clearChildren(drillBar);
+
+        var pathSpan = document.createElement('span');
+        pathSpan.textContent = '全部';
+        st.drillStack.forEach(function (frame) {
+            pathSpan.textContent += ' > ' + String(frame.label);
+        });
+        drillBar.appendChild(pathSpan);
+
+        var backBtn = document.createElement('button');
+        backBtn.type = 'button';
+        backBtn.className = 'layui-btn layui-btn-xs layui-btn-primary';
+        backBtn.style.marginLeft = '8px';
+        backBtn.textContent = '返回上層';
+        backBtn.addEventListener('click', function () { drillBack(gridId); });
+        drillBar.appendChild(backBtn);
+
+        var resetBtn = document.createElement('button');
+        resetBtn.type = 'button';
+        resetBtn.className = 'layui-btn layui-btn-xs layui-btn-danger';
+        resetBtn.style.marginLeft = '4px';
+        resetBtn.textContent = '重置';
+        resetBtn.addEventListener('click', function () { drillReset(gridId); });
+        drillBar.appendChild(resetBtn);
+    }
+
+    /**
+     * 執行 drill-down：push 當前狀態到 stack，加 filter，重新查詢
+     */
+    function drillDown(gridId, dimField, value, isDate) {
+        var st = _state[gridId];
+        if (!st || !st.lastReq) return;
+
+        // push current state
+        var currentFilters = (st.drillFilters || []).slice();
+        var currentHierarchies = {};
+        if (st.lastReq.dimensionHierarchies) {
+            Object.keys(st.lastReq.dimensionHierarchies).forEach(function (k) {
+                currentHierarchies[k] = st.lastReq.dimensionHierarchies[k];
+            });
+        }
+        var label = isDate ? formatDateKey(value) : String(value);
+        st.drillStack.push({
+            filters: currentFilters,
+            dimensionHierarchies: currentHierarchies,
+            label: label
+        });
+
+        // add new filter
+        var newFilters = currentFilters.concat([buildDrillFilter(dimField, value)]);
+        st.drillFilters = newFilters;
+
+        // auto-downgrade date hierarchy
+        var newHierarchies = {};
+        Object.keys(currentHierarchies).forEach(function (k) {
+            newHierarchies[k] = currentHierarchies[k];
+        });
+        if (isDate && newHierarchies[dimField]) {
+            var next = nextHierarchy(newHierarchies[dimField]);
+            if (next) {
+                newHierarchies[dimField] = next;
+            }
+        }
+
+        updateDrillBar(gridId);
+        drillQuery(gridId, newFilters, newHierarchies);
+    }
+
+    /**
+     * 返回上一層 drill
+     */
+    function drillBack(gridId) {
+        var st = _state[gridId];
+        if (!st || st.drillStack.length === 0) return;
+
+        var frame = st.drillStack.pop();
+        st.drillFilters = frame.filters;
+
+        updateDrillBar(gridId);
+        drillQuery(gridId, frame.filters, frame.dimensionHierarchies);
+    }
+
+    /**
+     * 重置 drill 回到最頂層
+     */
+    function drillReset(gridId) {
+        var st = _state[gridId];
+        if (!st) return;
+
+        st.drillStack = [];
+        st.drillFilters = [];
+
+        updateDrillBar(gridId);
+        // re-query with no drill filters and original hierarchies from collectSelection
+        drillQuery(gridId, [], st.lastReq.dimensionHierarchies || {});
+    }
+
+    /**
+     * drill 專用查詢（帶自訂 filters 和 hierarchies）
+     */
+    function drillQuery(gridId, filters, hierarchies) {
+        var st = _state[gridId];
+        if (!st) return;
+
+        var req = {
+            listVmType: st.listVmType,
+            dimensions: st.lastReq.dimensions,
+            measures: st.lastReq.measures,
+            filters: filters,
+            dimensionHierarchies: Object.keys(hierarchies).length > 0 ? hierarchies : undefined
+        };
+
+        var resultDiv = document.getElementById('analysis-result-' + gridId);
+        if (resultDiv) resultDiv.textContent = '查詢中...';
+
+        fetch('/_analysis/query', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(req)
+        })
+        .then(function (res) {
+            if (!res.ok) return res.text().then(function (t) { throw new Error(t); });
+            return res.json();
+        })
+        .then(function (result) {
+            if (!resultDiv) return;
+            clearChildren(resultDiv);
+
+            if (result.truncated) {
+                var warn = document.createElement('div');
+                warn.className = 'layui-alert layui-alert-warm';
+                warn.textContent = '結果已截斷，僅顯示前 10,000 列。';
+                resultDiv.appendChild(warn);
+            }
+
+            var dimFields = (st.fields || []).filter(function (f) {
+                return f.kind === 'Dimension' && st.lastReq.dimensions.indexOf(f.fieldName) >= 0;
+            });
+            var dateDimSet = {};
+            dimFields.forEach(function (f) { if (f.isDate) dateDimSet[f.fieldName] = true; });
+
+            // Update lastReq with current drill state
+            st.lastReq = {
+                dimensions: st.lastReq.dimensions,
+                measures: st.lastReq.measures,
+                dimensionHierarchies: hierarchies
+            };
+            st.lastResult = result;
+            st.lastDimFields = dimFields;
+
+            renderTable(gridId, result, resultDiv, dateDimSet);
+            renderChart(gridId, result, st.lastReq, dimFields, resultDiv);
+        })
+        .catch(function (err) {
+            if (resultDiv) resultDiv.textContent = '查詢失敗：' + err.message;
+        });
     }
 
     /**
@@ -524,7 +740,13 @@
         collectSelection: collectSelection,
         parseFuncs: parseFuncs,
         renderChart: renderChart,
-        formatDateKey: formatDateKey
+        formatDateKey: formatDateKey,
+        buildDrillFilter: buildDrillFilter,
+        nextHierarchy: nextHierarchy,
+        drillDown: drillDown,
+        drillBack: drillBack,
+        drillReset: drillReset,
+        _getState: function (gridId) { return _state[gridId]; }
     };
 
 }(typeof window !== 'undefined' ? window : global));

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -586,6 +586,7 @@ describe('renderChart — forceChartType parameter', () => {
             echarts: {
                 init: jest.fn(() => ({
                     setOption: jest.fn((opt) => { capturedOptions.push(opt); }),
+                    on: jest.fn(),
                     dispose: jest.fn(),
                 })),
             },
@@ -1170,7 +1171,7 @@ describe('[cov] waReq.renderChart — all branches', () => {
 
     test('renderChart with echarts → calls init and setOption', () => {
         const setOption = jest.fn();
-        global.echarts = { init: jest.fn(function() { return { setOption, dispose: jest.fn() }; }) };
+        global.echarts = { init: jest.fn(function() { return { setOption, on: jest.fn(), dispose: jest.fn() }; }) };
         waReq.renderChart('scovR2', sampleResult, sampleReq, sampleDimFields, makeContainer(), 'bar');
         expect(global.echarts.init).toHaveBeenCalled();
         expect(setOption).toHaveBeenCalled();
@@ -1178,21 +1179,21 @@ describe('[cov] waReq.renderChart — all branches', () => {
 
     test('forceChartType=line → series[0].type=line', () => {
         const opts = [];
-        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), dispose: jest.fn() }; }) };
+        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), on: jest.fn(), dispose: jest.fn() }; }) };
         waReq.renderChart('scovR3', sampleResult, sampleReq, sampleDimFields, makeContainer(), 'line');
         expect(opts[0].series[0].type).toBe('line');
     });
 
     test('forceChartType=bar-stacked → stack=total', () => {
         const opts = [];
-        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), dispose: jest.fn() }; }) };
+        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), on: jest.fn(), dispose: jest.fn() }; }) };
         waReq.renderChart('scovR4', sampleResult, sampleReq, sampleDimFields, makeContainer(), 'bar-stacked');
         expect(opts[0].series[0].stack).toBe('total');
     });
 
     test('date dim (no force) → detectChartType → line', () => {
         const opts = [];
-        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), dispose: jest.fn() }; }) };
+        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), on: jest.fn(), dispose: jest.fn() }; }) };
         const dateDim = [{ fieldName: 'Date', isDate: true }];
         const dateReq = { dimensions: ['Date'], measures: [{ field: 'Amount', func: 'Sum' }] };
         waReq.renderChart('scovR5', sampleResult, dateReq, dateDim, makeContainer());
@@ -1201,7 +1202,7 @@ describe('[cov] waReq.renderChart — all branches', () => {
 
     test('2 dims (no force) → detectChartType → bar-stacked', () => {
         const opts = [];
-        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), dispose: jest.fn() }; }) };
+        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), on: jest.fn(), dispose: jest.fn() }; }) };
         const twoDimReq = { dimensions: ['R', 'C'], measures: [{ field: 'A', func: 'Sum' }] };
         const twoDimFields = [{ fieldName: 'R', isDate: false }, { fieldName: 'C', isDate: false }];
         waReq.renderChart('scovR6', { columns: ['R', 'C', 'A_Sum'], rows: [{ R: 'N', C: 'X', A_Sum: 10 }] }, twoDimReq, twoDimFields, makeContainer());
@@ -1210,7 +1211,7 @@ describe('[cov] waReq.renderChart — all branches', () => {
 
     test('no dims (card) → type=bar, no stack', () => {
         const opts = [];
-        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), dispose: jest.fn() }; }) };
+        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), on: jest.fn(), dispose: jest.fn() }; }) };
         const noDimReq = { dimensions: [], measures: [{ field: 'Amount', func: 'Sum' }] };
         waReq.renderChart('scovR7', { columns: ['Amount_Sum'], rows: [{ Amount_Sum: 42 }] }, noDimReq, [], makeContainer());
         expect(opts[0].series[0].type).toBe('bar');
@@ -1219,7 +1220,7 @@ describe('[cov] waReq.renderChart — all branches', () => {
 
     test('dim not in dimFields → isDate defaults false → bar type', () => {
         const opts = [];
-        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), dispose: jest.fn() }; }) };
+        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), on: jest.fn(), dispose: jest.fn() }; }) };
         const unknownReq = { dimensions: ['Unknown'], measures: [{ field: 'A', func: 'Sum' }] };
         waReq.renderChart('scovR8', { columns: ['Unknown', 'A_Sum'], rows: [{ Unknown: 'X', A_Sum: 1 }] }, unknownReq, [], makeContainer());
         expect(opts[0].series[0].type).toBe('bar');
@@ -1329,7 +1330,7 @@ describe('[cov] query with real meta — dimFields filter + chart toggle click',
         const setOptionCalls = [];
         global.echarts = {
             init: jest.fn(function() {
-                return { setOption: jest.fn(function(o) { setOptionCalls.push(o); }), dispose: jest.fn() };
+                return { setOption: jest.fn(function(o) { setOptionCalls.push(o); }), on: jest.fn(), dispose: jest.fn() };
             })
         };
         global.fetch = jest.fn()
@@ -1352,11 +1353,14 @@ describe('[cov] query with real meta — dimFields filter + chart toggle click',
         const msrCb = { dataset: { kind: 'Measure', fieldName: 'Amt', gridId, defaultFunc: 'Sum' }, nextElementSibling: null };
         const toggleRow = document.createElement('div');
         toggleRow.id = 'analysis-chart-toggle-' + gridId;
+        const drillBarToggle = document.createElement('div');
+        drillBarToggle.id = 'analysis-drill-bar-' + gridId;
         spySetup(
             function(id) {
                 if (id === 'analysis-panel-' + gridId) return panel;
                 if (id === 'analysis-result-' + gridId) return resultDiv;
                 if (id === 'analysis-chart-toggle-' + gridId) return toggleRow;
+                if (id === 'analysis-drill-bar-' + gridId) return drillBarToggle;
                 return null;
             },
             function() { return [dimCb, msrCb]; }
@@ -1522,5 +1526,238 @@ describe('collectSelection with dimensionHierarchies', () => {
         var result = wa.collectSelection('g2');
         expect(result.dims).toEqual(['Region']);
         expect(result.dimensionHierarchies).toEqual({});
+    });
+});
+
+// ─── buildDrillFilter ─────────────────────────────────────────────────────────
+describe('wtmAnalysis.buildDrillFilter', () => {
+    test('建構 Eq filter 物件', () => {
+        expect(wa.buildDrillFilter('Region', '華東')).toEqual({
+            field: 'Region', operator: 'Eq', value: '華東'
+        });
+    });
+
+    test('數值型 value 保持原型別', () => {
+        expect(wa.buildDrillFilter('Year', 2026)).toEqual({
+            field: 'Year', operator: 'Eq', value: 2026
+        });
+    });
+});
+
+// ─── nextHierarchy ────────────────────────────────────────────────────────────
+describe('wtmAnalysis.nextHierarchy', () => {
+    test('Year → Quarter', () => {
+        expect(wa.nextHierarchy('Year')).toBe('Quarter');
+    });
+
+    test('Quarter → Month', () => {
+        expect(wa.nextHierarchy('Quarter')).toBe('Month');
+    });
+
+    test('Month → Day', () => {
+        expect(wa.nextHierarchy('Month')).toBe('Day');
+    });
+
+    test('Day → null（已到最細層）', () => {
+        expect(wa.nextHierarchy('Day')).toBeNull();
+    });
+
+    test('未知值 → null', () => {
+        expect(wa.nextHierarchy('Unknown')).toBeNull();
+    });
+});
+
+// ─── drill-down 互動 ─────────────────────────────────────────────────────────
+describe('drill-down integration', () => {
+    function makeDrillEnv() {
+        const chartOnHandlers = {};
+        const { wa, mockDocument, mockFetch, domNodes } = makeEnv({
+            echarts: {
+                init: jest.fn(() => ({
+                    setOption: jest.fn(),
+                    on: jest.fn((event, handler) => { chartOnHandlers[event] = handler; }),
+                    dispose: jest.fn(),
+                })),
+            },
+        });
+        return { wa, mockDocument, mockFetch, domNodes, chartOnHandlers };
+    }
+
+    // Helper: create a mock node that supports clearChildren (firstChild-based loop)
+    function mockNode(id, extraProps) {
+        const node = {
+            id: id,
+            style: { display: 'none' },
+            _children: [],
+            get firstChild() { return this._children.length > 0 ? this._children[0] : null; },
+            appendChild: jest.fn(function(c) { this._children.push(c); return c; }),
+            removeChild: jest.fn(function(c) {
+                var idx = this._children.indexOf(c);
+                if (idx >= 0) this._children.splice(idx, 1);
+            }),
+            textContent: '',
+            ...(extraProps || {}),
+        };
+        return node;
+    }
+
+    // Helper: setup a full drill test env with panel, resultDiv, drillBar, and state initialized
+    function setupDrillState(suffix, env) {
+        const { wa, mockDocument, mockFetch } = env;
+        const panel = mockNode('analysis-panel-' + suffix);
+        const resultDiv = mockNode('analysis-result-' + suffix);
+        const drillBar = mockNode('analysis-drill-bar-' + suffix);
+
+        mockDocument.getElementById.mockImplementation((id) => {
+            if (id === 'analysis-panel-' + suffix) return panel;
+            if (id === 'analysis-result-' + suffix) return resultDiv;
+            if (id === 'analysis-drill-bar-' + suffix) return drillBar;
+            return null;
+        });
+
+        mockFetch.mockResolvedValue({ ok: false, text: jest.fn().mockResolvedValue('err') });
+        wa.toggle(suffix, 'TestVm');
+
+        // Manually set lastReq so drillDown/drillBack/drillReset work
+        var st = wa._getState(suffix);
+        st.lastReq = {
+            dimensions: ['Region'],
+            measures: [{ field: 'Amount', func: 'Sum' }],
+            dimensionHierarchies: undefined,
+        };
+        st.lastDimFields = [{ fieldName: 'Region', isDate: false }];
+        st.drillFilters = [];
+
+        return { panel, resultDiv, drillBar, st };
+    }
+
+    test('drillDown pushes to drillStack and calls fetch', () => {
+        const env = makeDrillEnv();
+        const { drillBar } = setupDrillState('dd1', env);
+
+        env.mockFetch.mockClear();
+        env.wa.drillDown('dd1', 'Region', '華東', false);
+
+        expect(env.mockFetch).toHaveBeenCalledWith(
+            '/_analysis/query',
+            expect.objectContaining({ method: 'POST' })
+        );
+        // drillBar should be visible after drill-down
+        expect(drillBar.style.display).toBe('block');
+    });
+
+    test('drillBack pops stack and re-queries', () => {
+        const env = makeDrillEnv();
+        setupDrillState('dd2', env);
+
+        env.wa.drillDown('dd2', 'Region', '華東', false);
+        env.mockFetch.mockClear();
+
+        env.wa.drillBack('dd2');
+        expect(env.mockFetch).toHaveBeenCalledWith(
+            '/_analysis/query',
+            expect.objectContaining({ method: 'POST' })
+        );
+    });
+
+    test('drillReset clears stack and re-queries', () => {
+        const env = makeDrillEnv();
+        const { drillBar } = setupDrillState('dd3', env);
+
+        env.wa.drillDown('dd3', 'Region', '華東', false);
+        env.wa.drillDown('dd3', 'Region', '上海', false);
+        env.mockFetch.mockClear();
+
+        env.wa.drillReset('dd3');
+        expect(drillBar.style.display).toBe('none');
+        expect(env.mockFetch).toHaveBeenCalled();
+    });
+
+    test('日期 drill-down 自動降階 hierarchy', () => {
+        const env = makeDrillEnv();
+        setupDrillState('dd4', env);
+
+        // Override with date dimension + hierarchy
+        var st = env.wa._getState('dd4');
+        st.lastReq.dimensions = ['OrderDate'];
+        st.lastReq.dimensionHierarchies = { OrderDate: 'Year' };
+        st.lastDimFields = [{ fieldName: 'OrderDate', isDate: true }];
+
+        env.mockFetch.mockClear();
+        env.wa.drillDown('dd4', 'OrderDate', 2026, true);
+
+        const lastCall = env.mockFetch.mock.calls[0];
+        const body = JSON.parse(lastCall[1].body);
+        expect(body.filters).toEqual([
+            { field: 'OrderDate', operator: 'Eq', value: 2026 }
+        ]);
+        // Hierarchy should have been downgraded from Year to Quarter
+        expect(body.dimensionHierarchies).toEqual({ OrderDate: 'Quarter' });
+    });
+
+    test('ECharts click handler triggers drillDown', () => {
+        const env = makeDrillEnv();
+        const { resultDiv } = setupDrillState('dd5', env);
+
+        const result = {
+            columns: ['Region', 'Amount_Sum'],
+            rows: [
+                { Region: '華東', Amount_Sum: 100 },
+                { Region: '華南', Amount_Sum: 200 },
+            ],
+        };
+        const dimFields = [{ fieldName: 'Region', isDate: false }];
+        const req = { dimensions: ['Region'], measures: [{ field: 'Amount', func: 'Sum' }] };
+
+        env.wa.renderChart('dd5', result, req, dimFields, resultDiv);
+
+        expect(env.chartOnHandlers['click']).toBeDefined();
+
+        env.mockFetch.mockClear();
+        env.chartOnHandlers['click']({ dataIndex: 0, name: '華東' });
+
+        expect(env.mockFetch).toHaveBeenCalledWith(
+            '/_analysis/query',
+            expect.objectContaining({ method: 'POST' })
+        );
+    });
+
+    test('drill path 顯示麵包屑', () => {
+        const env = makeDrillEnv();
+        const { drillBar } = setupDrillState('dd6', env);
+
+        env.wa.drillDown('dd6', 'Region', '華東', false);
+
+        expect(drillBar.style.display).toBe('block');
+        // Should have path span + back button + reset button
+        expect(drillBar._children.length).toBe(3);
+        expect(drillBar._children[0].textContent).toBe('全部 > 華東');
+    });
+
+    test('drillBack 後堆疊為空則隱藏 drillBar', () => {
+        const env = makeDrillEnv();
+        const { drillBar } = setupDrillState('dd7', env);
+
+        env.wa.drillDown('dd7', 'Region', '華東', false);
+        expect(drillBar.style.display).toBe('block');
+
+        env.wa.drillBack('dd7');
+        expect(drillBar.style.display).toBe('none');
+    });
+
+    test('多層 drill-down 麵包屑疊加', () => {
+        const env = makeDrillEnv();
+        const { drillBar } = setupDrillState('dd8', env);
+
+        env.wa.drillDown('dd8', 'Region', '華東', false);
+        env.wa.drillDown('dd8', 'Region', '上海', false);
+
+        expect(drillBar._children[0].textContent).toBe('全部 > 華東 > 上海');
+    });
+
+    test('drillDown 無 lastReq 時 silent return', () => {
+        const env = makeDrillEnv();
+        // Don't call setupDrillState — no state at all
+        expect(() => env.wa.drillDown('nonexistent', 'X', 'Y', false)).not.toThrow();
     });
 });


### PR DESCRIPTION
## Summary
- 點擊圖表柱體/節點自動加 filter 條件並重新查詢（drill-down 一層）
- Drill 歷史堆疊（`drillStack`）支援「返回上層」和「重置」
- 日期維度自動降階（Year → Quarter → Month → Day）
- 麵包屑 UI 顯示當前 drill 路徑

Closes #104

## Changes
- `framework_analysis.js`: +230 行 — `buildDrillFilter`、`nextHierarchy` 純函式，`drillDown`/`drillBack`/`drillReset` 流程，ECharts click handler，drill bar UI
- `framework_analysis.test.js`: +253 行 — 10 個新 Jest 測試（純函式、stack push/pop、reset、日期降階、ECharts click、麵包屑、silent return）

## Test plan
- [x] Jest 148 tests all pass
- [x] .NET build 0 errors
- [x] .NET 413 tests all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)