### PR TITLE
test(admin,core): DataPrivilege API and BaseImportVM tests

### DIFF
--- a/test/WalkingTec.Mvvm.Admin.Test/DataPrivilegeApiTest.cs
+++ b/test/WalkingTec.Mvvm.Admin.Test/DataPrivilegeApiTest.cs
@@ -35,7 +35,6 @@ namespace WalkingTec.Mvvm.Admin.Test
         [TestMethod]
         public void GetTest()
         {
-            // Seed a DataPrivilege record and query it back
             using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
             {
                 context.Set<DataPrivilege>().Add(new DataPrivilege
@@ -54,9 +53,28 @@ namespace WalkingTec.Mvvm.Admin.Test
         }
 
         [TestMethod]
+        public void GetByGroupTest()
+        {
+            using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
+            {
+                context.Set<DataPrivilege>().Add(new DataPrivilege
+                {
+                    TableName = "GroupTable",
+                    GroupCode = "grp01",
+                    RelateId = "grel1"
+                });
+                context.SaveChanges();
+            }
+
+            var rv = _controller.Get("GroupTable", "grp01", DpTypeEnum.UserGroup);
+            Assert.IsNotNull(rv);
+            Assert.IsNotNull(rv.SelectedItemsID);
+            Assert.IsTrue(rv.SelectedItemsID.Contains("grel1"));
+        }
+
+        [TestMethod]
         public void CreateTest()
         {
-            // DataPrivilegeVM.Validate() checks that UserCode maps to a real FrameworkUser
             using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
             {
                 context.Set<FrameworkUser>().Add(new FrameworkUser
@@ -87,6 +105,157 @@ namespace WalkingTec.Mvvm.Admin.Test
                 Assert.AreEqual("TestTable", records[0].TableName);
                 Assert.AreEqual("dpuser", records[0].UserCode);
                 Assert.IsNull(records[0].RelateId, "IsAll=true stores a null RelateId row");
+            }
+        }
+
+        [TestMethod]
+        public void CreateWithSelectedItemsTest()
+        {
+            using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
+            {
+                context.Set<FrameworkUser>().Add(new FrameworkUser
+                {
+                    ITCode = "seluser",
+                    Name = "Selected Items User",
+                    Password = PasswordHashHelper.HashPassword("pass")
+                });
+                context.SaveChanges();
+            }
+
+            DataPrivilegeVM vm = _controller.Wtm.CreateVM<DataPrivilegeVM>();
+            vm.Entity = new DataPrivilege
+            {
+                TableName = "ItemTable",
+                UserCode = "seluser"
+            };
+            vm.DpType = DpTypeEnum.User;
+            vm.IsAll = false;
+            vm.SelectedItemsID = new List<string> { "item1", "item2", "item3" };
+
+            var rv = _controller.Add(vm).Result;
+            Assert.IsInstanceOfType(rv, typeof(OkObjectResult));
+
+            using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
+            {
+                var records = context.Set<DataPrivilege>()
+                    .Where(x => x.TableName == "ItemTable")
+                    .OrderBy(x => x.RelateId)
+                    .ToList();
+                Assert.AreEqual(3, records.Count);
+                Assert.AreEqual("item1", records[0].RelateId);
+                Assert.AreEqual("item2", records[1].RelateId);
+                Assert.AreEqual("item3", records[2].RelateId);
+            }
+        }
+
+        [TestMethod]
+        public void EditTest()
+        {
+            // Seed user and initial privilege (IsAll)
+            using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
+            {
+                context.Set<FrameworkUser>().Add(new FrameworkUser
+                {
+                    ITCode = "edituser",
+                    Name = "Edit User",
+                    Password = PasswordHashHelper.HashPassword("pass")
+                });
+                context.Set<DataPrivilege>().Add(new DataPrivilege
+                {
+                    TableName = "EditTable",
+                    UserCode = "edituser",
+                    RelateId = null // IsAll
+                });
+                context.SaveChanges();
+            }
+
+            // Edit: change from IsAll to specific items
+            DataPrivilegeVM vm = _controller.Wtm.CreateVM<DataPrivilegeVM>(
+                values: x => x.Entity.TableName == "EditTable"
+                          && x.Entity.UserCode == "edituser"
+                          && x.DpType == DpTypeEnum.User);
+            vm.IsAll = false;
+            vm.SelectedItemsID = new List<string> { "new1", "new2" };
+
+            var rv = _controller.Edit(vm).Result;
+            Assert.IsInstanceOfType(rv, typeof(OkObjectResult));
+
+            using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
+            {
+                var records = context.Set<DataPrivilege>()
+                    .Where(x => x.TableName == "EditTable" && x.UserCode == "edituser")
+                    .OrderBy(x => x.RelateId)
+                    .ToList();
+                Assert.AreEqual(2, records.Count);
+                Assert.AreEqual("new1", records[0].RelateId);
+                Assert.AreEqual("new2", records[1].RelateId);
+            }
+        }
+
+        [TestMethod]
+        public void DeleteTest()
+        {
+            // Seed privilege records
+            using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
+            {
+                context.Set<DataPrivilege>().Add(new DataPrivilege
+                {
+                    TableName = "DelTable",
+                    UserCode = "deluser",
+                    RelateId = "r1"
+                });
+                context.Set<DataPrivilege>().Add(new DataPrivilege
+                {
+                    TableName = "DelTable",
+                    UserCode = "deluser",
+                    RelateId = "r2"
+                });
+                context.SaveChanges();
+            }
+
+            var rv = _controller.Delete(new SimpleDpModel
+            {
+                ModelName = "DelTable",
+                Id = "deluser",
+                Type = DpTypeEnum.User
+            }).Result;
+            Assert.IsInstanceOfType(rv, typeof(OkObjectResult));
+
+            using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
+            {
+                var count = context.Set<DataPrivilege>()
+                    .Count(x => x.TableName == "DelTable" && x.UserCode == "deluser");
+                Assert.AreEqual(0, count, "All records for the user+table should be deleted");
+            }
+        }
+
+        [TestMethod]
+        public void DeleteByGroupTest()
+        {
+            using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
+            {
+                context.Set<DataPrivilege>().Add(new DataPrivilege
+                {
+                    TableName = "GrpDelTable",
+                    GroupCode = "grp01",
+                    RelateId = "g1"
+                });
+                context.SaveChanges();
+            }
+
+            var rv = _controller.Delete(new SimpleDpModel
+            {
+                ModelName = "GrpDelTable",
+                Id = "grp01",
+                Type = DpTypeEnum.UserGroup
+            }).Result;
+            Assert.IsInstanceOfType(rv, typeof(OkObjectResult));
+
+            using (var context = new Demo.DataContext(_seed, DBTypeEnum.Memory))
+            {
+                var count = context.Set<DataPrivilege>()
+                    .Count(x => x.TableName == "GrpDelTable" && x.GroupCode == "grp01");
+                Assert.AreEqual(0, count);
             }
         }
     }

--- a/test/WalkingTec.Mvvm.Core.Test/VM/BaseImportVMTest.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/VM/BaseImportVMTest.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Test.Mock;
+
+namespace WalkingTec.Mvvm.Core.Test.VM
+{
+    /// <summary>
+    /// Minimal entity for import tests — uses BasePoco (has audit fields).
+    /// </summary>
+    public class ImportTestItem : BasePoco
+    {
+        [StringLength(50)]
+        public string Name { get; set; } = "";
+
+        public int Value { get; set; }
+    }
+
+    /// <summary>
+    /// DataContext that registers ImportTestItem so EF Core can query/save it.
+    /// </summary>
+    internal class ImportTestDataContext : DataContext
+    {
+        public DbSet<ImportTestItem> ImportTestItems { get; set; } = null!;
+
+        public ImportTestDataContext(string cs, DBTypeEnum dbType) : base(cs, dbType) { }
+    }
+
+    /// <summary>
+    /// Minimal template VM — fields map 1:1 to ImportTestItem properties.
+    /// </summary>
+    public class ImportTestTemplateVM : BaseTemplateVM
+    {
+        public ExcelPropety Name_Excel = ExcelPropety.CreateProperty<ImportTestItem>(x => x.Name);
+        public ExcelPropety Value_Excel = ExcelPropety.CreateProperty<ImportTestItem>(x => x.Value);
+
+        protected override void InitVM() { }
+    }
+
+    /// <summary>
+    /// Test import VM that overrides SetEntityList() to bypass Excel parsing.
+    /// Test code pre-populates EntityList and sets isEntityListSet = true.
+    /// </summary>
+    public class TestImportVM : BaseImportVM<ImportTestTemplateVM, ImportTestItem>
+    {
+        private readonly List<ImportTestItem> _presetEntities;
+
+        public TestImportVM() { _presetEntities = new List<ImportTestItem>(); }
+
+        public TestImportVM(List<ImportTestItem> entities)
+        {
+            _presetEntities = entities;
+        }
+
+        public override void SetEntityList()
+        {
+            if (!isEntityListSet)
+            {
+                EntityList = _presetEntities;
+                isEntityListSet = true;
+            }
+        }
+    }
+
+    [TestClass]
+    public class BaseImportVMTest
+    {
+        private string _seed = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _seed = Guid.NewGuid().ToString();
+        }
+
+        private IDataContext CreateDb() => new ImportTestDataContext(_seed, DBTypeEnum.Memory);
+
+        [TestMethod]
+        public void BatchSaveData_ValidEntities_SavesToDB()
+        {
+            var entities = new List<ImportTestItem>
+            {
+                new ImportTestItem { Name = "Item1", Value = 10 },
+                new ImportTestItem { Name = "Item2", Value = 20 }
+            };
+
+            var vm = new TestImportVM(entities);
+            vm.Wtm = MockWtmContext.CreateWtmContext(CreateDb(), "importuser");
+
+            var result = vm.BatchSaveData();
+
+            Assert.IsTrue(result, "BatchSaveData should return true for valid entities");
+            Assert.AreEqual(0, vm.ErrorListVM.EntityList.Count, "No errors expected");
+
+            using (var context = CreateDb())
+            {
+                var saved = ((DbContext)context).Set<ImportTestItem>().OrderBy(x => x.Name).ToList();
+                Assert.AreEqual(2, saved.Count);
+                Assert.AreEqual("Item1", saved[0].Name);
+                Assert.AreEqual(10, saved[0].Value);
+                Assert.AreEqual("Item2", saved[1].Name);
+                Assert.AreEqual(20, saved[1].Value);
+                Assert.AreEqual("importuser", saved[0].CreateBy);
+                Assert.IsNotNull(saved[0].CreateTime);
+            }
+        }
+
+        [TestMethod]
+        public void BatchSaveData_EmptyList_ReturnsTrue()
+        {
+            var vm = new TestImportVM(new List<ImportTestItem>());
+            vm.Wtm = MockWtmContext.CreateWtmContext(CreateDb(), "importuser");
+
+            var result = vm.BatchSaveData();
+
+            Assert.IsTrue(result, "Empty entity list should not cause failure");
+
+            using (var context = CreateDb())
+            {
+                Assert.AreEqual(0, ((DbContext)context).Set<ImportTestItem>().Count());
+            }
+        }
+
+        [TestMethod]
+        public void BatchSaveData_SetsAuditFields()
+        {
+            var entities = new List<ImportTestItem>
+            {
+                new ImportTestItem { Name = "Audited", Value = 99 }
+            };
+
+            var vm = new TestImportVM(entities);
+            vm.Wtm = MockWtmContext.CreateWtmContext(CreateDb(), "audituser");
+
+            vm.BatchSaveData();
+
+            using (var context = CreateDb())
+            {
+                var item = ((DbContext)context).Set<ImportTestItem>().Single();
+                Assert.AreEqual("audituser", item.CreateBy);
+                Assert.IsNotNull(item.CreateTime);
+                Assert.IsTrue(DateTime.Now.Subtract(item.CreateTime!.Value).TotalSeconds < 10);
+            }
+        }
+
+        [TestMethod]
+        public void BatchSaveData_MultipleItems_AllPersisted()
+        {
+            var entities = new List<ImportTestItem>();
+            for (int i = 0; i < 5; i++)
+            {
+                entities.Add(new ImportTestItem { Name = $"Batch{i}", Value = i * 100 });
+            }
+
+            var vm = new TestImportVM(entities);
+            vm.Wtm = MockWtmContext.CreateWtmContext(CreateDb(), "batchuser");
+
+            var result = vm.BatchSaveData();
+
+            Assert.IsTrue(result);
+
+            using (var context = CreateDb())
+            {
+                Assert.AreEqual(5, ((DbContext)context).Set<ImportTestItem>().Count());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add 5 new DataPrivilege API tests: GetByGroup, CreateWithSelectedItems, Edit, Delete (user), Delete (group)
- Add 4 BaseImportVM.BatchSaveData tests using a custom `TestImportVM` that bypasses Excel parsing via `SetEntityList()` override
- Total: 9 new tests (8 DataPrivilege + 4 BaseImportVM = 12, minus 3 existing = 9 net new)

Closes #132

## Test plan
- [x] All 8 DataPrivilege API tests pass locally
- [x] All 4 BaseImportVM tests pass locally
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)