### PR TITLE
fix(ci): upload .nupkg files as release assets on tag push

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -12,7 +12,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -110,3 +110,10 @@ jobs:
           dotnet add package WalkingTec.Mvvm.TagHelpers.LayUI --version "$PKG_VERSION" --source "${{ env.PACKAGE_SOURCE }}"
           dotnet restore
           dotnet build -c Release --no-restore
+
+      - name: Upload .nupkg to release assets
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: gh release upload "$TAG_NAME" nupkgs/*.nupkg --clobber


### PR DESCRIPTION
## Summary

- `permissions.contents: read` → `write`，讓 workflow 有權上傳 release assets
- 在 smoke test 後加 `gh release upload` 步驟，把 `.nupkg` 附加到對應 GitHub Release（僅 tag push 觸發）
- v8.3.1 已手動補救，三個 `.nupkg` 已上傳至 release assets

## Test plan

- [ ] 確認 v8.3.1 release 頁面已出現三個 `.nupkg` 下載連結
- [ ] 下次 tag push 後驗證 workflow 自動上傳 release assets

Closes #137