### PR TITLE
refactor(cache): Warmup 改用 IHostApplicationLifetime (Closes #143)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Cache/LookupCacheWarmupService.cs
+++ b/src/WalkingTec.Mvvm.Core/Cache/LookupCacheWarmupService.cs
@@ -25,22 +25,38 @@ namespace WalkingTec.Mvvm.Core.Cache
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly ILookupCacheService _cacheService;
+        private readonly IHostApplicationLifetime _lifetime;
         private readonly ILogger<LookupCacheWarmupService> _logger;
 
         public LookupCacheWarmupService(
             IServiceProvider serviceProvider,
             ILookupCacheService cacheService,
+            IHostApplicationLifetime lifetime,
             ILogger<LookupCacheWarmupService> logger)
         {
             _serviceProvider = serviceProvider;
             _cacheService = cacheService;
+            _lifetime = lifetime;
             _logger = logger;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            // 讓主應用完成 startup 後再預熱
-            await Task.Delay(TimeSpan.FromSeconds(3), stoppingToken).ConfigureAwait(false);
+            // 等待應用完全啟動後才開始預熱，取代硬編碼的 3 秒延遲
+            var tcs = new TaskCompletionSource();
+            using var reg = _lifetime.ApplicationStarted.Register(() => tcs.TrySetResult());
+
+            // 如果應用已停止或 stoppingToken 被取消，提前退出
+            using var stopReg = stoppingToken.Register(() => tcs.TrySetCanceled());
+
+            try
+            {
+                await tcs.Task.ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                return;
+            }
 
             var types = _cacheService.GetWarmupTypes();
             if (types.Count == 0) return;


### PR DESCRIPTION
## Summary

- Replace hardcoded `Task.Delay(3s)` with `IHostApplicationLifetime.ApplicationStarted` event
- Warmup now starts reliably after app is fully initialized, not after arbitrary delay
- Clean cancellation handling via `stoppingToken` registration

Closes #143

## Test plan
- [x] All 446 tests pass
- [x] No new tests needed (warmup timing is integration-level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)