### PR TITLE
security: upgrade DES to AES-256-CBC encryption

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Utils.cs
+++ b/src/WalkingTec.Mvvm.Core/Utils.cs
@@ -662,12 +662,13 @@ namespace WalkingTec.Mvvm.Core
         }
 
         #region 加解密
+
         /// <summary>
-        /// 通过密钥将内容加密
+        /// 使用 AES-256-CBC 加密字串。每次加密產生隨機 IV，並將 IV 前置於密文中。
         /// </summary>
-        /// <param name="stringToEncrypt">要加密的字符串</param>
-        /// <param name="encryptKey">加密密钥</param>
-        /// <returns></returns>
+        /// <param name="stringToEncrypt">要加密的字串</param>
+        /// <param name="encryptKey">加密金鑰（任意長度，內部以 SHA-256 衍生 32 位元組金鑰）</param>
+        /// <returns>Base64 編碼的 (IV + 密文)，或空字串（若輸入為空）</returns>
         public static string EncryptString(string stringToEncrypt, string encryptKey)
         {
             if (string.IsNullOrEmpty(stringToEncrypt))
@@ -675,68 +676,145 @@ namespace WalkingTec.Mvvm.Core
                 return "";
             }
 
-            string stringEncrypted = string.Empty;
-            byte[] bytIn = UTF8Encoding.UTF8.GetBytes(stringToEncrypt);
-            MemoryStream encryptStream = new System.IO.MemoryStream();
-            CryptoStream encStream = new CryptoStream(encryptStream, GenerateDESCryptoServiceProvider(encryptKey).CreateEncryptor(), CryptoStreamMode.Write);
+            using var aes = CreateAes(encryptKey);
+            aes.GenerateIV();
+            byte[] iv = aes.IV;
+            byte[] plainBytes = UTF8Encoding.UTF8.GetBytes(stringToEncrypt);
 
-            try
+            using var encryptStream = new MemoryStream();
+            using (var cryptoStream = new CryptoStream(encryptStream, aes.CreateEncryptor(), CryptoStreamMode.Write))
             {
-                encStream.Write(bytIn, 0, bytIn.Length);
-                encStream.FlushFinalBlock();
-                stringEncrypted = Convert.ToBase64String(encryptStream.ToArray(), 0, (int)encryptStream.Length);
-            }
-            catch
-            {
-                return "";
-            }
-            finally
-            {
-                encryptStream.Close();
-                encStream.Close();
+                cryptoStream.Write(plainBytes, 0, plainBytes.Length);
+                cryptoStream.FlushFinalBlock();
             }
 
-            return stringEncrypted;
+            byte[] cipherBytes = encryptStream.ToArray();
+            byte[] result = new byte[iv.Length + cipherBytes.Length];
+            Buffer.BlockCopy(iv, 0, result, 0, iv.Length);
+            Buffer.BlockCopy(cipherBytes, 0, result, iv.Length, cipherBytes.Length);
+
+            return Convert.ToBase64String(result);
         }
 
         /// <summary>
-        /// 通过密钥讲内容解密
+        /// 使用 AES-256-CBC 解密字串。若 AES 解密失敗，自動嘗試舊版 DES 解密（向後相容）。
         /// </summary>
-        /// <param name="stringToDecrypt">要解密的字符串</param>
-        /// <param name="encryptKey">密钥</param>
-        /// <returns></returns>
+        /// <param name="stringToDecrypt">要解密的字串（Base64 編碼）</param>
+        /// <param name="encryptKey">解密金鑰</param>
+        /// <returns>解密後的明文，或空字串（若輸入為空或解密失敗）</returns>
         public static string DecryptString(string stringToDecrypt, string encryptKey)
         {
-            if (String.IsNullOrEmpty(stringToDecrypt))
+            if (string.IsNullOrEmpty(stringToDecrypt))
             {
                 return "";
             }
 
-            string stringDecrypted = string.Empty;
-            byte[] bytIn = Convert.FromBase64String(stringToDecrypt.Replace(" ", "+"));
-            MemoryStream decryptStream = new MemoryStream();
-            CryptoStream encStream = new CryptoStream(decryptStream, GenerateDESCryptoServiceProvider(encryptKey).CreateDecryptor(), CryptoStreamMode.Write);
+            // Try AES-256-CBC first
+            try
+            {
+                byte[] fullCipher = Convert.FromBase64String(stringToDecrypt.Replace(" ", "+"));
+
+                // AES-256-CBC requires at least 16 bytes for IV + at least 16 bytes for one cipher block
+                if (fullCipher.Length < 32)
+                {
+#pragma warning disable CS0618
+                    return DecryptStringLegacy(stringToDecrypt, encryptKey);
+#pragma warning restore CS0618
+                }
+
+                byte[] iv = new byte[16];
+                byte[] cipherBytes = new byte[fullCipher.Length - 16];
+                Buffer.BlockCopy(fullCipher, 0, iv, 0, 16);
+                Buffer.BlockCopy(fullCipher, 16, cipherBytes, 0, cipherBytes.Length);
+
+                using var aes = CreateAes(encryptKey);
+                aes.IV = iv;
+
+                var decryptStream = new MemoryStream();
+                var cryptoStream = new CryptoStream(decryptStream, aes.CreateDecryptor(), CryptoStreamMode.Write);
+
+                try
+                {
+                    cryptoStream.Write(cipherBytes, 0, cipherBytes.Length);
+                    cryptoStream.FlushFinalBlock();
+                    return UTF8Encoding.UTF8.GetString(decryptStream.ToArray());
+                }
+                finally
+                {
+                    decryptStream.Dispose();
+                    try { cryptoStream.Dispose(); } catch { /* suppress dispose errors */ }
+                }
+            }
+            catch (CryptographicException)
+            {
+                // AES failed — fall back to legacy DES decryption for migration period
+#pragma warning disable CS0618
+                return DecryptStringLegacy(stringToDecrypt, encryptKey);
+#pragma warning restore CS0618
+            }
+        }
+
+        /// <summary>
+        /// 使用舊版 DES 解密字串。僅供向後相容遷移期間使用。
+        /// </summary>
+        /// <param name="stringToDecrypt">要解密的字串（Base64 編碼）</param>
+        /// <param name="encryptKey">解密金鑰</param>
+        /// <returns>解密後的明文，或空字串</returns>
+        [Obsolete("Legacy DES decryption retained for backward compatibility. Use EncryptString/DecryptString (AES-256) for new data.")]
+        public static string DecryptStringLegacy(string stringToDecrypt, string encryptKey)
+        {
+            if (string.IsNullOrEmpty(stringToDecrypt))
+            {
+                return "";
+            }
 
             try
             {
-                encStream.Write(bytIn, 0, bytIn.Length);
-                encStream.FlushFinalBlock();
-                stringDecrypted = Encoding.Default.GetString(decryptStream.ToArray());
+                byte[] bytIn = Convert.FromBase64String(stringToDecrypt.Replace(" ", "+"));
+
+                using var des = CreateLegacyDes(encryptKey);
+                var decryptStream = new MemoryStream();
+                var cryptoStream = new CryptoStream(decryptStream, des.CreateDecryptor(), CryptoStreamMode.Write);
+
+                try
+                {
+                    cryptoStream.Write(bytIn, 0, bytIn.Length);
+                    cryptoStream.FlushFinalBlock();
+                    return UTF8Encoding.UTF8.GetString(decryptStream.ToArray());
+                }
+                finally
+                {
+                    decryptStream.Dispose();
+                    try { cryptoStream.Dispose(); } catch { /* suppress dispose errors */ }
+                }
             }
-            catch
+            catch (CryptographicException)
             {
                 return "";
             }
-            finally
+            catch (FormatException)
             {
-                decryptStream.Close();
-                encStream.Close();
+                return "";
             }
-
-            return stringDecrypted;
         }
 
-        private static DES GenerateDESCryptoServiceProvider(string key)
+        /// <summary>
+        /// 建立 AES-256-CBC 加密器，使用 SHA-256 從使用者金鑰衍生 32 位元組金鑰。
+        /// </summary>
+        private static Aes CreateAes(string key)
+        {
+            var aes = Aes.Create();
+            aes.Mode = CipherMode.CBC;
+            aes.Padding = PaddingMode.PKCS7;
+            aes.KeySize = 256;
+            aes.Key = SHA256.HashData(UTF8Encoding.UTF8.GetBytes(key));
+            return aes;
+        }
+
+        /// <summary>
+        /// 建立舊版 DES 加密器（僅供向後相容解密使用）。
+        /// </summary>
+        private static DES CreateLegacyDes(string key)
         {
             var dCrypter = DES.Create();
 
@@ -744,7 +822,7 @@ namespace WalkingTec.Mvvm.Core
             if (dCrypter.LegalKeySizes.Length > 0)
             {
                 int moreSize = dCrypter.LegalKeySizes[0].MinSize;
-                while (key.Length > 8)
+                if (key.Length > 8)
                 {
                     key = key.Substring(0, 8);
                 }

--- a/test/WalkingTec.Mvvm.Core.Test/Utils/EncryptionTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Utils/EncryptionTests.cs
@@ -1,0 +1,175 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Core.Test.Utils
+{
+    [TestClass]
+    public class EncryptionTests
+    {
+        // ─── AES Round-Trip ──────────────────────────────────────────────────
+
+        [TestMethod]
+        public void EncryptString_DecryptString_RoundTrip_ReturnsOriginal()
+        {
+            var plaintext = "Hello, AES-256!";
+            var key = "my-secret-key";
+
+            var encrypted = WalkingTec.Mvvm.Core.Utils.EncryptString(plaintext, key);
+            var decrypted = WalkingTec.Mvvm.Core.Utils.DecryptString(encrypted, key);
+
+            decrypted.Should().Be(plaintext);
+        }
+
+        [TestMethod]
+        public void EncryptString_DecryptString_UnicodeRoundTrip()
+        {
+            var plaintext = "密碼テスト🔐Ñoño 中文測試";
+            var key = "unicode-key-密碼";
+
+            var encrypted = WalkingTec.Mvvm.Core.Utils.EncryptString(plaintext, key);
+            var decrypted = WalkingTec.Mvvm.Core.Utils.DecryptString(encrypted, key);
+
+            decrypted.Should().Be(plaintext);
+        }
+
+        // ─── Various Key Lengths ─────────────────────────────────────────────
+
+        [DataTestMethod]
+        [DataRow("a", "short key")]
+        [DataRow("Hello World 123", "this-is-a-longer-key-that-exceeds-32-characters-easily")]
+        [DataRow("test data", "k")]
+        public void EncryptString_DecryptString_VariousKeyLengths_RoundTrips(string plaintext, string key)
+        {
+            var encrypted = WalkingTec.Mvvm.Core.Utils.EncryptString(plaintext, key);
+            var decrypted = WalkingTec.Mvvm.Core.Utils.DecryptString(encrypted, key);
+
+            decrypted.Should().Be(plaintext);
+        }
+
+        // ─── Empty Input ─────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void EncryptString_EmptyInput_ReturnsEmpty()
+        {
+            WalkingTec.Mvvm.Core.Utils.EncryptString("", "key").Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void DecryptString_EmptyInput_ReturnsEmpty()
+        {
+            WalkingTec.Mvvm.Core.Utils.DecryptString("", "key").Should().BeEmpty();
+        }
+
+        // ─── Different Keys Produce Different Ciphertexts ────────────────────
+
+        [TestMethod]
+        public void EncryptString_DifferentKeys_ProduceDifferentCiphertexts()
+        {
+            var plaintext = "same plaintext";
+
+            var enc1 = WalkingTec.Mvvm.Core.Utils.EncryptString(plaintext, "key-one");
+            var enc2 = WalkingTec.Mvvm.Core.Utils.EncryptString(plaintext, "key-two");
+
+            enc1.Should().NotBe(enc2);
+        }
+
+        // ─── Random IV: Same Plaintext Encrypted Twice Differs ───────────────
+
+        [TestMethod]
+        public void EncryptString_SamePlaintextTwice_ProducesDifferentCiphertexts()
+        {
+            var plaintext = "deterministic?";
+            var key = "same-key";
+
+            var enc1 = WalkingTec.Mvvm.Core.Utils.EncryptString(plaintext, key);
+            var enc2 = WalkingTec.Mvvm.Core.Utils.EncryptString(plaintext, key);
+
+            enc1.Should().NotBe(enc2, "each encryption should use a random IV");
+
+            // But both should decrypt to the same plaintext
+            WalkingTec.Mvvm.Core.Utils.DecryptString(enc1, key).Should().Be(plaintext);
+            WalkingTec.Mvvm.Core.Utils.DecryptString(enc2, key).Should().Be(plaintext);
+        }
+
+        // ─── Wrong Key Fails ─────────────────────────────────────────────────
+
+        [TestMethod]
+        public void DecryptString_WrongKey_ReturnsEmptyOrGarbage()
+        {
+            var encrypted = WalkingTec.Mvvm.Core.Utils.EncryptString("secret", "correct-key");
+
+            // With wrong key, AES decrypt will fail (padding exception) and
+            // DES fallback will also fail, returning empty string
+            var result = WalkingTec.Mvvm.Core.Utils.DecryptString(encrypted, "wrong-key");
+            result.Should().NotBe("secret");
+        }
+
+        // ─── DES Backward Compatibility ──────────────────────────────────────
+
+        [TestMethod]
+        public void DecryptString_DESEncryptedData_FallsBackCorrectly()
+        {
+            // Encrypt using legacy DES via the private CreateLegacyDes helper
+            var plaintext = "legacy data";
+            var key = "testkey1";
+
+            string desEncrypted = EncryptWithLegacyDes(plaintext, key);
+
+            // DecryptString should fall back to DES and succeed
+            var decrypted = WalkingTec.Mvvm.Core.Utils.DecryptString(desEncrypted, key);
+            decrypted.Should().Be(plaintext);
+        }
+
+        [TestMethod]
+        public void DecryptStringLegacy_DirectCall_Works()
+        {
+#pragma warning disable CS0618 // Obsolete warning expected
+            var plaintext = "legacy test";
+            var key = "mykey123";
+
+            string desEncrypted = EncryptWithLegacyDes(plaintext, key);
+
+            var decrypted = WalkingTec.Mvvm.Core.Utils.DecryptStringLegacy(desEncrypted, key);
+            decrypted.Should().Be(plaintext);
+#pragma warning restore CS0618
+        }
+
+        [TestMethod]
+        public void DecryptStringLegacy_EmptyInput_ReturnsEmpty()
+        {
+#pragma warning disable CS0618
+            WalkingTec.Mvvm.Core.Utils.DecryptStringLegacy("", "key").Should().BeEmpty();
+#pragma warning restore CS0618
+        }
+
+        // ─── Helper: encrypt with legacy DES (mirrors old EncryptString) ─────
+
+        private static string EncryptWithLegacyDes(string plaintext, string key)
+        {
+            // Use reflection to call the private CreateLegacyDes method
+            var method = typeof(WalkingTec.Mvvm.Core.Utils).GetMethod(
+                "CreateLegacyDes",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            method.Should().NotBeNull("CreateLegacyDes should exist as a private static method");
+
+            using var des = (DES)method!.Invoke(null, new object[] { key })!;
+            byte[] plainBytes = Encoding.UTF8.GetBytes(plaintext);
+
+            using var ms = new MemoryStream();
+            using (var cs = new CryptoStream(ms, des.CreateEncryptor(), CryptoStreamMode.Write))
+            {
+                cs.Write(plainBytes, 0, plainBytes.Length);
+                cs.FlushFinalBlock();
+            }
+
+            return Convert.ToBase64String(ms.ToArray());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace legacy DES (56-bit) encryption in `Utils.cs` with AES-256-CBC
- SHA-256 key derivation for consistent 32-byte keys from any-length user input
- Random 16-byte IV prepended to ciphertext (same plaintext → different ciphertext each time)
- `DecryptString` auto-falls back to DES for backward compatibility during migration
- `DecryptStringLegacy` marked `[Obsolete]` for explicit legacy DES decryption
- Fixed `Encoding.Default` bug → `UTF8Encoding.UTF8` for cross-platform consistency
- Proper `using` patterns replacing manual `Close()` calls

Closes #148

## Test plan
- [x] 13 new MSTest tests covering:
  - AES round-trip (basic + Unicode)
  - Various key lengths (short, long, single-char)
  - Empty input handling
  - Different keys → different ciphertexts
  - Same plaintext twice → different ciphertexts (random IV)
  - DES→AES fallback compatibility
  - Legacy DES direct call

🤖 Generated with [Claude Code](https://claude.com/claude-code)