### PR TITLE
feat(codegen): Code Generator Analysis Mode integration

### DIFF
--- a/docs/analysis-mode.md
+++ b/docs/analysis-mode.md
@@ -619,3 +619,26 @@ ListVM 的 FullName 沒有在 `AnalysisVmRegistry` 中登記。確認：
 **Q：`FilterOperator.In` 支援嗎？**
 
 `In` 運算子已從 `FilterOperator` enum 移除（8.1.17）。若需多值過濾，目前可用多個 `Eq` + `Contains` 條件組合替代；Phase 2 評估重新加入完整的 `In` 支援。
+
+---
+
+## Code Generator 整合
+
+WTM Code Generator 支援自動產生 Analysis Mode 所需的 attribute。
+
+### 使用方式
+
+1. 在 Code Generator 頁面勾選 **Enable Analysis**
+2. 表格會顯示 **IsDimension** 和 **IsMeasure** 兩欄
+3. 系統根據屬性型別自動推薦（string/enum→Dimension、數值→Measure、DateTime→Dimension）
+4. 開發者可覆寫預設值
+5. 點擊生成後，`[EnableAnalysis]` 自動加到 ListVM，`[Dimension]`/`[Measure]` 自動插入 Model 檔案
+
+### 智慧預設規則
+
+| 屬性型別 | 預設 |
+|----------|------|
+| `string`, `enum` | Dimension |
+| `decimal`, `int`, `double`, `float`, `long`, `short` | Measure |
+| `DateTime` | Dimension (Hierarchy = DateHierarchy.Month) |
+| 其他 | 無 |

--- a/src/WalkingTec.Mvvm.Mvc/CodeGenListVM.cs
+++ b/src/WalkingTec.Mvvm.Mvc/CodeGenListVM.cs
@@ -263,6 +263,12 @@ namespace WalkingTec.Mvvm.Mvc
         [Display(Name = "Codegen.IsBatchField")]
         public bool IsBatchField { get; set; }
 
+        [Display(Name = "Codegen.IsDimensionField")]
+        public bool IsDimensionField { get; set; }
+
+        [Display(Name = "Codegen.IsMeasureField")]
+        public bool IsMeasureField { get; set; }
+
         public int Index { get; set; }
 
         [Display(Name = "Codegen.LinkedType")]

--- a/src/WalkingTec.Mvvm.Mvc/CodeGenListVM.cs
+++ b/src/WalkingTec.Mvvm.Mvc/CodeGenListVM.cs
@@ -30,7 +30,9 @@ namespace WalkingTec.Mvvm.Mvc
                 this.MakeGridHeader(x=>x.IsListField,150).SetFormat((entity,val)=>{return getCheckBox($"FieldInfos[{entity.Index}].IsListField",entity.IsListField); }),
                 this.MakeGridHeader(x=>x.IsFormField,150).SetFormat((entity,val)=>{return getCheckBox($"FieldInfos[{entity.Index}].IsFormField",entity.IsFormField); }),
                 this.MakeGridHeader(x=>x.IsImportField,150).SetFormat((entity,val)=>{return getCheckBox($"FieldInfos[{entity.Index}].IsImportField",entity.IsImportField); }),
-                this.MakeGridHeader(x=>x.IsBatchField,150).SetFormat((entity,val)=>{return getCheckBox($"FieldInfos[{entity.Index}].IsBatchField",entity.IsBatchField); })
+                this.MakeGridHeader(x=>x.IsBatchField,150).SetFormat((entity,val)=>{return getCheckBox($"FieldInfos[{entity.Index}].IsBatchField",entity.IsBatchField); }),
+                this.MakeGridHeader(x=>x.IsDimensionField,150).SetFormat((entity,val)=>{return getCheckBox($"FieldInfos[{entity.Index}].IsDimensionField",entity.IsDimensionField); }),
+                this.MakeGridHeader(x=>x.IsMeasureField,150).SetFormat((entity,val)=>{return getCheckBox($"FieldInfos[{entity.Index}].IsMeasureField",entity.IsMeasureField); })
           };
         }
 
@@ -137,6 +139,21 @@ namespace WalkingTec.Mvvm.Mvc
                     if (checktype.IsPrimitive || checktype == typeof(string) || checktype == typeof(DateTime) || checktype.IsEnum() || checktype == typeof(decimal))
                     {
                         show = true;
+
+                        // Analysis Mode smart defaults
+                        if (checktype == typeof(string) || checktype.IsEnum())
+                        {
+                            view.IsDimensionField = true;
+                        }
+                        else if (checktype == typeof(decimal) || checktype == typeof(int) || checktype == typeof(double)
+                            || checktype == typeof(float) || checktype == typeof(long) || checktype == typeof(short))
+                        {
+                            view.IsMeasureField = true;
+                        }
+                        else if (checktype == typeof(DateTime))
+                        {
+                            view.IsDimensionField = true;
+                        }
                     }
                     if (typeof(TopBasePoco).IsAssignableFrom(checktype)){
                         var fk = DC.GetFKName2(modeltype, pro.Name);

--- a/src/WalkingTec.Mvvm.Mvc/CodeGenVM.cs
+++ b/src/WalkingTec.Mvvm.Mvc/CodeGenVM.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Extensions;
 
@@ -389,6 +390,143 @@ namespace WalkingTec.Mvvm.Mvc
             FieldList = new CodeGenListVM();
             FieldList.CopyContext(this);
         }
+        /// <summary>
+        /// 在 Model source file 中自動插入 [Dimension] / [Measure] attribute
+        /// </summary>
+        public string InjectAnalysisAttributes()
+        {
+            if (!EnableAnalysis) return "";
+
+            var analysisFields = FieldInfos?.Where(x => x.IsDimensionField || x.IsMeasureField).ToList();
+            if (analysisFields == null || analysisFields.Count == 0) return "";
+
+            // Find Model source file
+            string modelName = SelectedModel?.Split(',').FirstOrDefault()?.Split('.').LastOrDefault() ?? "";
+            if (string.IsNullOrEmpty(modelName)) return "Error: Cannot resolve model name.";
+
+            string modelFileName = modelName + ".cs";
+            string modelFilePath = FindModelFile(MainDir, modelFileName);
+            if (modelFilePath == null)
+            {
+                return $"Warning: Cannot find {modelFileName}. Please manually add [Dimension]/[Measure] attributes.";
+            }
+
+            string content = File.ReadAllText(modelFilePath, Encoding.UTF8);
+            string originalContent = content;
+            bool modified = false;
+
+            // Add using if missing
+            if (!content.Contains("using WalkingTec.Mvvm.Core.Analysis;"))
+            {
+                var lastUsingMatch = Regex.Match(
+                    content,
+                    @"^using [^;]+;\s*$",
+                    RegexOptions.Multiline | RegexOptions.RightToLeft);
+                if (lastUsingMatch.Success)
+                {
+                    int insertPos = lastUsingMatch.Index + lastUsingMatch.Length;
+                    content = content.Insert(insertPos, "\nusing WalkingTec.Mvvm.Core.Analysis;");
+                    modified = true;
+                }
+            }
+
+            // Try to resolve model type for DateTime detection
+            Type modelType = Type.GetType(SelectedModel);
+
+            foreach (var field in analysisFields)
+            {
+                string attrName = field.IsDimensionField ? "Dimension" : "Measure";
+
+                // Skip if attribute already exists on this property
+                var alreadyHasAttr = Regex.IsMatch(
+                    content,
+                    @"\[" + attrName + @"[\](]" + @".*\n\s*public\s+\S+\??\s+" + Regex.Escape(field.FieldName) + @"\s",
+                    RegexOptions.Multiline);
+                if (alreadyHasAttr) continue;
+
+                // Build attribute string
+                string attrStr;
+                if (field.IsDimensionField)
+                {
+                    bool isDateTime = false;
+                    if (modelType != null)
+                    {
+                        var propType = modelType.GetSingleProperty(field.FieldName)?.PropertyType;
+                        if (propType != null)
+                        {
+                            var underlying = Nullable.GetUnderlyingType(propType) ?? propType;
+                            isDateTime = underlying == typeof(DateTime);
+                        }
+                    }
+                    else
+                    {
+                        // Fallback: check source text for DateTime type
+                        isDateTime = Regex.IsMatch(
+                            content,
+                            @"public\s+DateTime\??\s+" + Regex.Escape(field.FieldName) + @"\s");
+                    }
+
+                    attrStr = isDateTime
+                        ? "[Dimension(Hierarchy = DateHierarchy.Month)]"
+                        : "[Dimension]";
+                }
+                else
+                {
+                    attrStr = "[Measure]";
+                }
+
+                // Find property declaration and insert attribute before it
+                var propPattern = @"(\n)((\s*)\[[\s\S]*?)?((\s*)(public\s+\S+\??\s+" + Regex.Escape(field.FieldName) + @"\s*\{))";
+                var propMatch = Regex.Match(content, propPattern);
+                if (propMatch.Success)
+                {
+                    string indent = propMatch.Groups[5].Value;
+                    if (string.IsNullOrEmpty(indent)) indent = propMatch.Groups[3].Value;
+                    if (string.IsNullOrEmpty(indent)) indent = "        ";
+                    string insertion = indent + attrStr + "\n";
+                    int insertPos = propMatch.Groups[4].Index;
+                    content = content.Insert(insertPos, insertion);
+                    modified = true;
+                }
+            }
+
+            if (modified && content != originalContent)
+            {
+                File.WriteAllText(modelFilePath, content, Encoding.UTF8);
+                return $"Analysis attributes injected into {modelFilePath}";
+            }
+
+            return "";
+        }
+
+        /// <summary>
+        /// Search for a model .cs file starting from startDir and going up
+        /// </summary>
+        public string FindModelFile(string startDir, string fileName)
+        {
+            var dir = new DirectoryInfo(startDir);
+            int levels = 0;
+            while (dir != null && levels < 5)
+            {
+                try
+                {
+                    var files = dir.GetFiles(fileName, SearchOption.AllDirectories);
+                    var match = files.FirstOrDefault(f =>
+                        !f.FullName.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}") &&
+                        !f.FullName.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"));
+                    if (match != null) return match.FullName;
+                }
+                catch
+                {
+                    // Permission or access errors, try parent
+                }
+
+                dir = dir.Parent;
+                levels++;
+            }
+            return null;
+        }
+
         public void DoGen()
         {
             File.WriteAllText($"{ControllerDir}{Path.DirectorySeparatorChar}{ModelName}{(IsApi == true ? "Api" : "")}Controller.cs", GenerateController(), Encoding.UTF8);
@@ -558,6 +696,12 @@ namespace WalkingTec.Mvvm.Mvc
                 {
                     File.WriteAllText($"{TestDir}{Path.DirectorySeparatorChar}{ModelName}ApiTest.cs", test, Encoding.UTF8);
                 }
+            }
+
+            // Inject Analysis Mode attributes into Model source file
+            if (EnableAnalysis)
+            {
+                InjectAnalysisAttributes();
             }
         }
 

--- a/src/WalkingTec.Mvvm.Mvc/CodeGenVM.cs
+++ b/src/WalkingTec.Mvvm.Mvc/CodeGenVM.cs
@@ -37,6 +37,9 @@ namespace WalkingTec.Mvvm.Mvc
         [Display(Name = "Codegen.GenApi")]
         public bool IsApi { get; set; }
 
+        [Display(Name = "Codegen.EnableAnalysis")]
+        public bool EnableAnalysis { get; set; }
+
         [Display(Name = "Codegen.AuthMode")]
         public ApiAuthMode AuthMode { get; set; }
 
@@ -3129,6 +3132,8 @@ namespace WalkingTec.Mvvm.Mvc
 
         public bool IsImportField { get; set; }
         public bool IsBatchField { get; set; }
+        public bool IsDimensionField { get; set; }
+        public bool IsMeasureField { get; set; }
 
         public FieldInfoType InfoType
         {

--- a/src/WalkingTec.Mvvm.Mvc/CodeGenVM.cs
+++ b/src/WalkingTec.Mvvm.Mvc/CodeGenVM.cs
@@ -869,6 +869,16 @@ namespace WalkingTec.Mvvm.Mvc
                     }
                 }
                 rv = rv.Replace("$headers$", headerstring).Replace("$where$", wherestring).Replace("$select$", selectstring).Replace("$subpros$", subprostring).Replace("$format$", formatstring).Replace("$actions$", actionstring);
+                if (EnableAnalysis)
+                {
+                    rv = rv.Replace("$analysisusing$", "\nusing WalkingTec.Mvvm.Core.Analysis;\n");
+                    rv = rv.Replace("$analysisattr$", "[EnableAnalysis]\n    ");
+                }
+                else
+                {
+                    rv = rv.Replace("$analysisusing$", "");
+                    rv = rv.Replace("$analysisattr$", "");
+                }
                 rv = GetRelatedNamespace(pros, rv);
             }
             if (name == "CrudVM")

--- a/src/WalkingTec.Mvvm.Mvc/GeneratorFiles/ListVM.txt
+++ b/src/WalkingTec.Mvvm.Mvc/GeneratorFiles/ListVM.txt
@@ -7,11 +7,11 @@ using WalkingTec.Mvvm.Core.Extensions;
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
 using $modelnamespace$;
-$othernamespace$
+$othernamespace$$analysisusing$
 
 namespace $vmnamespace$
 {
-    public partial class $classname$ListVM : BasePagedListVM<$classname$_View, $classname$Searcher>
+    $analysisattr$public partial class $classname$ListVM : BasePagedListVM<$classname$_View, $classname$Searcher>
     {$actions$
 
         protected override IEnumerable<IGridColumn<$classname$_View>> InitGridHeader()

--- a/test/WalkingTec.Mvvm.Core.Test/CodeGen/CodeGenAnalysisTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/CodeGen/CodeGenAnalysisTests.cs
@@ -1,0 +1,234 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Mvc;
+
+namespace WalkingTec.Mvvm.Core.Test.CodeGen
+{
+    [TestClass]
+    public class CodeGenAnalysisTests
+    {
+        private string _tempDir;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "wtm_codegen_test_" + Guid.NewGuid().ToString("N")[..8]);
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, true);
+        }
+
+        [TestMethod]
+        public void InjectAnalysisAttributes_Adds_Dimension_And_Measure()
+        {
+            // Arrange
+            var modelContent = @"using System;
+namespace TestApp.Models
+{
+    public class Student : BasePoco
+    {
+        public string Name { get; set; }
+        public decimal Score { get; set; }
+    }
+}";
+            var modelPath = Path.Combine(_tempDir, "Student.cs");
+            File.WriteAllText(modelPath, modelContent);
+
+            var vm = CreateCodeGenVM("Student", _tempDir, new List<FieldInfo>
+            {
+                new FieldInfo { FieldName = "Name", IsDimensionField = true },
+                new FieldInfo { FieldName = "Score", IsMeasureField = true }
+            });
+
+            // Act
+            var result = vm.InjectAnalysisAttributes();
+
+            // Assert
+            var content = File.ReadAllText(modelPath);
+            Assert.IsTrue(content.Contains("[Dimension]"), "Should contain [Dimension]");
+            Assert.IsTrue(content.Contains("[Measure]"), "Should contain [Measure]");
+            Assert.IsTrue(content.Contains("using WalkingTec.Mvvm.Core.Analysis;"), "Should contain analysis using");
+            Assert.IsTrue(result.Contains("injected"), "Should report success");
+        }
+
+        [TestMethod]
+        public void InjectAnalysisAttributes_Idempotent_No_Duplicate()
+        {
+            // Arrange
+            var modelContent = @"using System;
+using WalkingTec.Mvvm.Core.Analysis;
+namespace TestApp.Models
+{
+    public class Student : BasePoco
+    {
+        [Dimension]
+        public string Name { get; set; }
+    }
+}";
+            var modelPath = Path.Combine(_tempDir, "Student.cs");
+            File.WriteAllText(modelPath, modelContent);
+
+            var vm = CreateCodeGenVM("Student", _tempDir, new List<FieldInfo>
+            {
+                new FieldInfo { FieldName = "Name", IsDimensionField = true }
+            });
+
+            // Act
+            vm.InjectAnalysisAttributes();
+
+            // Assert
+            var result = File.ReadAllText(modelPath);
+            var count = result.Split("[Dimension]").Length - 1;
+            Assert.AreEqual(1, count, "Should not duplicate [Dimension]");
+        }
+
+        [TestMethod]
+        public void InjectAnalysisAttributes_EnableAnalysis_False_Does_Nothing()
+        {
+            var vm = new CodeGenVM { EnableAnalysis = false };
+            var result = vm.InjectAnalysisAttributes();
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void InjectAnalysisAttributes_Missing_File_Returns_Warning()
+        {
+            var vm = CreateCodeGenVM("NonExistent", _tempDir, new List<FieldInfo>
+            {
+                new FieldInfo { FieldName = "Name", IsDimensionField = true }
+            });
+
+            var result = vm.InjectAnalysisAttributes();
+            Assert.IsTrue(result.Contains("Warning") || result.Contains("Cannot find"),
+                $"Should return warning, got: {result}");
+        }
+
+        [TestMethod]
+        public void InjectAnalysisAttributes_Adds_Using_Statement()
+        {
+            // Arrange — file without the analysis using
+            var modelContent = @"using System;
+using WalkingTec.Mvvm.Core;
+namespace TestApp.Models
+{
+    public class Order : BasePoco
+    {
+        public string Region { get; set; }
+    }
+}";
+            var modelPath = Path.Combine(_tempDir, "Order.cs");
+            File.WriteAllText(modelPath, modelContent);
+
+            var vm = CreateCodeGenVM("Order", _tempDir, new List<FieldInfo>
+            {
+                new FieldInfo { FieldName = "Region", IsDimensionField = true }
+            });
+
+            // Act
+            vm.InjectAnalysisAttributes();
+
+            // Assert
+            var content = File.ReadAllText(modelPath);
+            Assert.IsTrue(content.Contains("using WalkingTec.Mvvm.Core.Analysis;"),
+                "Should add analysis using statement");
+        }
+
+        [TestMethod]
+        public void InjectAnalysisAttributes_DateTime_Gets_Hierarchy()
+        {
+            // Arrange — Type.GetType will return null for test types,
+            // so fallback to source text detection
+            var modelContent = @"using System;
+namespace TestApp.Models
+{
+    public class Order : BasePoco
+    {
+        public DateTime OrderDate { get; set; }
+    }
+}";
+            var modelPath = Path.Combine(_tempDir, "Order.cs");
+            File.WriteAllText(modelPath, modelContent);
+
+            var vm = CreateCodeGenVM("Order", _tempDir, new List<FieldInfo>
+            {
+                new FieldInfo { FieldName = "OrderDate", IsDimensionField = true }
+            });
+
+            // Act
+            vm.InjectAnalysisAttributes();
+
+            // Assert
+            var content = File.ReadAllText(modelPath);
+            Assert.IsTrue(content.Contains("[Dimension(Hierarchy = DateHierarchy.Month)]"),
+                "DateTime dimension should have Hierarchy = DateHierarchy.Month");
+        }
+
+        [TestMethod]
+        public void InjectAnalysisAttributes_No_Fields_Returns_Empty()
+        {
+            var vm = CreateCodeGenVM("Student", _tempDir, new List<FieldInfo>());
+            var result = vm.InjectAnalysisAttributes();
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void FindModelFile_Finds_File_In_Directory()
+        {
+            // Arrange
+            var modelPath = Path.Combine(_tempDir, "MyModel.cs");
+            File.WriteAllText(modelPath, "public class MyModel {}");
+
+            var vm = new CodeGenVM();
+
+            // Act
+            var result = vm.FindModelFile(_tempDir, "MyModel.cs");
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.EndsWith("MyModel.cs"));
+        }
+
+        [TestMethod]
+        public void FindModelFile_Excludes_Bin_Obj()
+        {
+            // Arrange — file only in bin directory
+            var binDir = Path.Combine(_tempDir, "bin", "Debug");
+            Directory.CreateDirectory(binDir);
+            File.WriteAllText(Path.Combine(binDir, "MyModel.cs"), "// in bin");
+
+            var vm = new CodeGenVM();
+
+            // Act
+            var result = vm.FindModelFile(_tempDir, "MyModel.cs");
+
+            // Assert
+            Assert.IsNull(result, "Should not find file in bin directory");
+        }
+
+        [TestMethod]
+        public void FindModelFile_Returns_Null_For_Missing()
+        {
+            var vm = new CodeGenVM();
+            var result = vm.FindModelFile(_tempDir, "DoesNotExist.cs");
+            Assert.IsNull(result);
+        }
+
+        private CodeGenVM CreateCodeGenVM(string modelName, string mainDir, List<FieldInfo> fields)
+        {
+            return new CodeGenVM
+            {
+                EnableAnalysis = true,
+                FieldInfos = fields,
+                _mainDir = mainDir,
+                SelectedModel = $"TestApp.Models.{modelName}, TestAssembly"
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Code Generator UI 新增 `EnableAnalysis` checkbox + `IsDimension`/`IsMeasure` 欄位選擇
- 智慧預設：string/enum → Dimension、數值 → Measure、DateTime → Dimension(Month)
- ListVM 模板自動加入 `[EnableAnalysis]` attribute + using
- 生成後自動在 Model .cs 檔案插入 `[Dimension]`/`[Measure]` attribute（正則 + 幂等保護）
- `FindModelFile` 從 MainDir 往上搜尋 Model source file
- 10 個新 MSTest 測試

Closes #156, Closes #157, Closes #158, Closes #159

## Test plan
- [x] 10 tests: attribute injection, idempotency, missing file, DateTime hierarchy, FindModelFile
- [x] All 435 existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)