### PR TITLE
feat(etl): PR1 — Models + Pipeline core + MSSQL Loader + 25 tests

### DIFF
--- a/WalkingTec.Mvvm.sln
+++ b/WalkingTec.Mvvm.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -60,6 +60,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WalkingTec.Mvvm.Vue3Demo", "demo\WalkingTec.Mvvm.Vue3Demo\WalkingTec.Mvvm.Vue3Demo.csproj", "{411690A4-0021-4509-BF24-900437B5DC6E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WalkingTec.Mvvm.Mvc.Tests", "src\WalkingTec.Mvvm.Mvc.Tests\WalkingTec.Mvvm.Mvc.Tests.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WalkingTec.Mvvm.Etl", "src\WalkingTec.Mvvm.Etl\WalkingTec.Mvvm.Etl.csproj", "{BA66447E-9130-423D-9A5B-67F4394D27D5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WalkingTec.Mvvm.Etl.Test", "test\WalkingTec.Mvvm.Etl.Test\WalkingTec.Mvvm.Etl.Test.csproj", "{62BB44F3-A478-42BF-B972-E6AD0347466B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -139,6 +143,14 @@ Global
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA66447E-9130-423D-9A5B-67F4394D27D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA66447E-9130-423D-9A5B-67F4394D27D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA66447E-9130-423D-9A5B-67F4394D27D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA66447E-9130-423D-9A5B-67F4394D27D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62BB44F3-A478-42BF-B972-E6AD0347466B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62BB44F3-A478-42BF-B972-E6AD0347466B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62BB44F3-A478-42BF-B972-E6AD0347466B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62BB44F3-A478-42BF-B972-E6AD0347466B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -163,6 +175,8 @@ Global
 		{D4104589-85BE-446A-A123-1E0FD1538A7B} = {840C6DED-B5D5-4763-A6A7-6F615B72EC10}
 		{411690A4-0021-4509-BF24-900437B5DC6E} = {DE184A47-CF5F-41C0-AB7D-CAD0AF2DAE75}
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890} = {46CFCDC6-4358-48EB-A901-5618B6530CEE}
+		{BA66447E-9130-423D-9A5B-67F4394D27D5} = {46CFCDC6-4358-48EB-A901-5618B6530CEE}
+		{62BB44F3-A478-42BF-B972-E6AD0347466B} = {55D5759D-10E9-4FC8-B2EC-A824CF6D74A1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8D25EAAD-E43A-466A-95DA-ECE1F3C462DC}

--- a/src/WalkingTec.Mvvm.Etl/Models/EtlEnums.cs
+++ b/src/WalkingTec.Mvvm.Etl/Models/EtlEnums.cs
@@ -1,0 +1,49 @@
+#nullable enable
+
+namespace WalkingTec.Mvvm.Etl.Models;
+
+/// <summary>
+/// ETL Job 狀態
+/// </summary>
+public enum EtlJobStatus
+{
+    Enabled,
+    Disabled,
+    Running,
+    Paused,
+    Failed
+}
+
+/// <summary>
+/// ETL 執行觸發方式
+/// </summary>
+public enum EtlRunTrigger
+{
+    Scheduled,
+    Manual,
+    Retry
+}
+
+/// <summary>
+/// ETL 執行結果
+/// </summary>
+public enum EtlRunResult
+{
+    Success,
+    Failed,
+    Aborted,
+    Skipped
+}
+
+/// <summary>
+/// Watermark 模式
+/// </summary>
+public enum EtlWatermarkType
+{
+    /// <summary>每次全量載入，無 watermark</summary>
+    FullLoad,
+    /// <summary>用時間欄位做增量（如 UpdatedAt）</summary>
+    Timestamp,
+    /// <summary>用自增 ID 做增量（如 auto-increment PK）</summary>
+    Identity
+}

--- a/src/WalkingTec.Mvvm.Etl/Models/EtlJobDefinition.cs
+++ b/src/WalkingTec.Mvvm.Etl/Models/EtlJobDefinition.cs
@@ -1,0 +1,83 @@
+#nullable enable
+using System;
+using System.ComponentModel.DataAnnotations;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Etl.Models;
+
+/// <summary>
+/// ETL Job 定義 — 描述一個定時資料導入任務的配置
+/// </summary>
+public class EtlJobDefinition : BasePoco
+{
+    [Display(Name = "Job 名稱")]
+    [Required]
+    [StringLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Display(Name = "描述")]
+    [StringLength(500)]
+    public string? Description { get; set; }
+
+    /// <summary>Cron 表達式（Quartz 格式，如 "0 0 2 * * ?"）</summary>
+    [Display(Name = "排程 (Cron)")]
+    [Required]
+    [StringLength(100)]
+    public string CronExpression { get; set; } = string.Empty;
+
+    /// <summary>Job 實作類別的完整型別名</summary>
+    [Required]
+    [StringLength(500)]
+    public string JobClassName { get; set; } = string.Empty;
+
+    [Display(Name = "狀態")]
+    public EtlJobStatus Status { get; set; } = EtlJobStatus.Disabled;
+
+    /// <summary>引用 Configs.Connections 的 Key（appsettings.json 中定義）</summary>
+    [Display(Name = "來源連線 Key")]
+    [Required]
+    [StringLength(100)]
+    public string SourceCsKey { get; set; } = string.Empty;
+
+    /// <summary>來源資料庫類型</summary>
+    [Display(Name = "來源 DB 類型")]
+    public DBTypeEnum SourceDbType { get; set; }
+
+    // ─── Watermark 設定 ───
+
+    [Display(Name = "Watermark 模式")]
+    public EtlWatermarkType WatermarkType { get; set; } = EtlWatermarkType.FullLoad;
+
+    /// <summary>Watermark 欄位名（如 "UpdatedAt" 或 "OrderId"）</summary>
+    [StringLength(100)]
+    public string? WatermarkColumn { get; set; }
+
+    /// <summary>上次成功完成後的 watermark 值（JSON 序列化）</summary>
+    public string? LastWatermarkValue { get; set; }
+
+    /// <summary>首次執行的起始值（null = 全量首跑）</summary>
+    public string? InitialWatermarkValue { get; set; }
+
+    /// <summary>Watermark 時區（IANA 格式，如 "Asia/Taipei"），存儲統一用 UTC</summary>
+    [StringLength(50)]
+    public string WatermarkTimeZone { get; set; } = "UTC";
+
+    // ─── 執行控制 ───
+
+    /// <summary>跳過接下來 N 次排程觸發</summary>
+    public int SkipCount { get; set; }
+
+    /// <summary>失敗後最大重試次數</summary>
+    public int RetryCount { get; set; } = 3;
+
+    /// <summary>單次執行超時（分鐘）</summary>
+    public int TimeoutMinutes { get; set; } = 60;
+
+    // ─── 執行狀態（唯讀顯示） ───
+
+    public DateTime? LastRunAt { get; set; }
+    public DateTime? NextFireAt { get; set; }
+
+    [StringLength(2000)]
+    public string? LastError { get; set; }
+}

--- a/src/WalkingTec.Mvvm.Etl/Models/EtlProgress.cs
+++ b/src/WalkingTec.Mvvm.Etl/Models/EtlProgress.cs
@@ -1,0 +1,19 @@
+#nullable enable
+using System;
+
+namespace WalkingTec.Mvvm.Etl.Models;
+
+/// <summary>
+/// ETL 執行進度（用於即時監控）
+/// </summary>
+public record EtlProgress
+{
+    public Guid JobId { get; init; }
+    public string JobName { get; init; } = string.Empty;
+    public int ProcessedRows { get; init; }
+    public int? TotalRows { get; init; }
+    /// <summary>Extracting / Loading / Merging / Done</summary>
+    public string Phase { get; init; } = "Idle";
+    public double? RowsPerSecond { get; init; }
+    public DateTime StartedAt { get; init; }
+}

--- a/src/WalkingTec.Mvvm.Etl/Models/EtlRunLog.cs
+++ b/src/WalkingTec.Mvvm.Etl/Models/EtlRunLog.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System;
+using System.ComponentModel.DataAnnotations;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Etl.Models;
+
+/// <summary>
+/// ETL 執行記錄 — 每次 Job 執行產生一筆
+/// </summary>
+public class EtlRunLog : BasePoco
+{
+    [Required]
+    public Guid JobId { get; set; }
+
+    /// <summary>關聯的 Job 定義</summary>
+    public EtlJobDefinition? Job { get; set; }
+
+    public EtlRunTrigger Trigger { get; set; }
+    public EtlRunResult Result { get; set; }
+
+    public int ExtractedRows { get; set; }
+    public int LoadedRows { get; set; }
+    public int ErrorRows { get; set; }
+    public long ElapsedMs { get; set; }
+
+    [StringLength(4000)]
+    public string? ErrorMessage { get; set; }
+
+    public DateTime StartedAt { get; set; }
+    public DateTime? FinishedAt { get; set; }
+
+    /// <summary>執行時的 watermark 起始值快照（供重跑用）</summary>
+    public string? WatermarkSnapshot { get; set; }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlExecutionResult.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlExecutionResult.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// ETL Pipeline 執行結果
+/// </summary>
+public class EtlExecutionResult
+{
+    public bool Success { get; init; }
+    public bool Aborted { get; init; }
+    public int ExtractedRows { get; init; }
+    public int LoadedRows { get; init; }
+    public int ErrorRows { get; init; }
+    public long ElapsedMs { get; init; }
+    public string? ErrorMessage { get; init; }
+    public string? NewWatermarkValue { get; init; }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineConfig.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineConfig.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System;
+using System.Data;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// ETL Pipeline 執行配置
+/// </summary>
+public record EtlPipelineConfig
+{
+    public Guid JobId { get; init; }
+    public string JobName { get; init; } = string.Empty;
+    public string SourceConnectionString { get; init; } = string.Empty;
+    public string TargetConnectionString { get; init; } = string.Empty;
+    public string QueryTemplate { get; init; } = string.Empty;
+    public string TargetTableName { get; init; } = string.Empty;
+    public string MergeKeyColumn { get; init; } = string.Empty;
+    public int BatchSize { get; init; } = 50_000;
+    public StagingTableSpec StagingTable { get; init; } = null!;
+
+    /// <summary>可選的轉換函式（null = 零轉換直搬）</summary>
+    public Func<DataTable, DataTable>? TransformFunc { get; init; }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
@@ -1,0 +1,171 @@
+#nullable enable
+using System;
+using System.Data;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// ETL Pipeline 執行引擎
+///
+/// 流程：
+/// 1. EnsureStagingTable
+/// 2. TruncateStaging
+/// 3. foreach batch in Extract:
+///    a. CancellationToken check
+///    b. Transform（如果有 mapper）
+///    c. BulkLoad to staging
+///    d. 更新進度
+/// 4. Merge staging → target
+/// 5. 成功 → commit watermark；失敗 → discard watermark
+/// </summary>
+public class EtlPipelineExecutor
+{
+    private readonly IEtlSource _source;
+    private readonly IBulkLoader _loader;
+    private readonly IProgress<EtlProgress>? _progress;
+
+    public EtlPipelineExecutor(IEtlSource source, IBulkLoader loader, IProgress<EtlProgress>? progress = null)
+    {
+        _source = source;
+        _loader = loader;
+        _progress = progress;
+    }
+
+    /// <summary>
+    /// 執行完整 ETL Pipeline
+    /// </summary>
+    public async Task<EtlExecutionResult> ExecuteAsync(
+        EtlPipelineConfig config,
+        WatermarkStrategy watermark,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        int totalExtracted = 0;
+        int totalLoaded = 0;
+
+        try
+        {
+            // 1. 確認 staging table
+            await _loader.EnsureStagingTableAsync(
+                config.TargetConnectionString, config.StagingTable.TableName,
+                config.StagingTable, cancellationToken);
+
+            // 2. 清空 staging
+            await _loader.TruncateStagingAsync(
+                config.TargetConnectionString, config.StagingTable.TableName,
+                cancellationToken);
+
+            // 3. Extract + Load to staging
+            var wmParam = watermark.GetParameterValue();
+
+            await foreach (var batch in _source.ExtractBatchesAsync(
+                config.SourceConnectionString, config.QueryTemplate, wmParam,
+                config.BatchSize, cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Transform hook
+                var transformed = config.TransformFunc != null
+                    ? config.TransformFunc(batch)
+                    : batch;
+
+                int batchRows = transformed.Rows.Count;
+                totalExtracted += batchRows;
+
+                await _loader.BulkLoadAsync(
+                    config.TargetConnectionString, config.StagingTable.TableName,
+                    transformed, cancellationToken);
+
+                totalLoaded += batchRows;
+
+                // 更新 watermark 暫存
+                if (watermark.Type != EtlWatermarkType.FullLoad && !string.IsNullOrEmpty(watermark.Column))
+                {
+                    var maxVal = GetMaxValue(batch, watermark.Column);
+                    if (maxVal != null) watermark.UpdateFromBatchMax(maxVal);
+                }
+
+                // 回報進度
+                ReportProgress(config, totalLoaded, sw);
+            }
+
+            // 4. Merge staging → target
+            ReportProgress(config, totalLoaded, sw, "Merging");
+
+            await _loader.MergeAsync(
+                config.TargetConnectionString, config.StagingTable.TableName,
+                config.TargetTableName, config.MergeKeyColumn,
+                cancellationToken);
+
+            // 5. 成功 → commit watermark
+            var newWatermark = watermark.CommitPendingValue();
+
+            sw.Stop();
+            return new EtlExecutionResult
+            {
+                Success = true,
+                ExtractedRows = totalExtracted,
+                LoadedRows = totalLoaded,
+                ElapsedMs = sw.ElapsedMilliseconds,
+                NewWatermarkValue = newWatermark
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            watermark.DiscardPendingValue();
+            sw.Stop();
+            return new EtlExecutionResult
+            {
+                Success = false,
+                Aborted = true,
+                ExtractedRows = totalExtracted,
+                LoadedRows = totalLoaded,
+                ElapsedMs = sw.ElapsedMilliseconds,
+                ErrorMessage = "Job was aborted"
+            };
+        }
+        catch (Exception ex)
+        {
+            watermark.DiscardPendingValue();
+            sw.Stop();
+            return new EtlExecutionResult
+            {
+                Success = false,
+                ExtractedRows = totalExtracted,
+                LoadedRows = totalLoaded,
+                ElapsedMs = sw.ElapsedMilliseconds,
+                ErrorMessage = ex.ToString()
+            };
+        }
+    }
+
+    private void ReportProgress(EtlPipelineConfig config, int totalLoaded, Stopwatch sw, string phase = "Loading")
+    {
+        _progress?.Report(new EtlProgress
+        {
+            JobId = config.JobId,
+            JobName = config.JobName,
+            ProcessedRows = totalLoaded,
+            TotalRows = null,
+            Phase = phase,
+            RowsPerSecond = totalLoaded / Math.Max(sw.Elapsed.TotalSeconds, 0.001),
+            StartedAt = DateTime.UtcNow - sw.Elapsed
+        });
+    }
+
+    private static object? GetMaxValue(DataTable batch, string columnName)
+    {
+        if (!batch.Columns.Contains(columnName) || batch.Rows.Count == 0)
+            return null;
+
+        return batch.AsEnumerable()
+            .Select(r => r[columnName])
+            .Where(v => v != null && v != DBNull.Value)
+            .Max();
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/IBulkLoader.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/IBulkLoader.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// ETL Load 介面 — 批量寫入目標 DB
+/// </summary>
+public interface IBulkLoader
+{
+    /// <summary>
+    /// 將一批資料 BulkCopy 到 staging table
+    /// </summary>
+    Task BulkLoadAsync(
+        string connectionString,
+        string stagingTableName,
+        DataTable batch,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 執行 MERGE INTO 從 staging table 合併到目標 table
+    /// </summary>
+    Task MergeAsync(
+        string connectionString,
+        string stagingTableName,
+        string targetTableName,
+        string mergeKeyColumn,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 清空 staging table（TRUNCATE）
+    /// </summary>
+    Task TruncateStagingAsync(
+        string connectionString,
+        string stagingTableName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 確認 staging table 存在，不存在則自動建立
+    /// </summary>
+    Task EnsureStagingTableAsync(
+        string connectionString,
+        string stagingTableName,
+        StagingTableSpec spec,
+        CancellationToken cancellationToken = default);
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/IEtlSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/IEtlSource.cs
@@ -1,0 +1,29 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// ETL Extract 介面 — 從來源 DB 串流讀取資料
+/// </summary>
+public interface IEtlSource : IDisposable
+{
+    /// <summary>
+    /// 以 DbDataReader 方式串流讀取資料，分批 yield return DataTable
+    /// </summary>
+    /// <param name="connectionString">來源 DB 連線字串</param>
+    /// <param name="queryTemplate">SQL 查詢模板，包含 @watermark 參數佔位</param>
+    /// <param name="watermarkValue">watermark 參數值（null = 不帶 watermark 條件）</param>
+    /// <param name="batchSize">每批筆數</param>
+    /// <param name="cancellationToken">取消 token</param>
+    /// <returns>每個 DataTable 是一個 batch</returns>
+    IAsyncEnumerable<DataTable> ExtractBatchesAsync(
+        string connectionString,
+        string queryTemplate,
+        object? watermarkValue,
+        int batchSize,
+        CancellationToken cancellationToken = default);
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/Loaders/MssqlBulkLoader.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/Loaders/MssqlBulkLoader.cs
@@ -1,0 +1,131 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline.Loaders;
+
+/// <summary>
+/// MSSQL 批量載入器 — SqlBulkCopy + MERGE INTO
+/// </summary>
+public class MssqlBulkLoader : IBulkLoader
+{
+    public async Task BulkLoadAsync(
+        string connectionString, string stagingTableName,
+        DataTable batch, CancellationToken cancellationToken = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        using var bulkCopy = new SqlBulkCopy(conn)
+        {
+            DestinationTableName = stagingTableName,
+            BatchSize = batch.Rows.Count,
+            BulkCopyTimeout = 0
+        };
+
+        foreach (DataColumn col in batch.Columns)
+        {
+            bulkCopy.ColumnMappings.Add(col.ColumnName, col.ColumnName);
+        }
+
+        await bulkCopy.WriteToServerAsync(batch, cancellationToken);
+    }
+
+    public async Task MergeAsync(
+        string connectionString, string stagingTableName,
+        string targetTableName, string mergeKeyColumn,
+        CancellationToken cancellationToken = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        var columns = await GetColumnsAsync(conn, stagingTableName, cancellationToken);
+        var updateCols = columns.Where(c => c != mergeKeyColumn).ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"MERGE [{targetTableName}] AS target");
+        sb.AppendLine($"USING [{stagingTableName}] AS source");
+        sb.AppendLine($"ON target.[{mergeKeyColumn}] = source.[{mergeKeyColumn}]");
+
+        if (updateCols.Count > 0)
+        {
+            sb.AppendLine("WHEN MATCHED THEN UPDATE SET");
+            sb.AppendLine(string.Join(",\n",
+                updateCols.Select(c => $"  target.[{c}] = source.[{c}]")));
+        }
+
+        sb.AppendLine("WHEN NOT MATCHED THEN INSERT (");
+        sb.AppendLine(string.Join(", ", columns.Select(c => $"[{c}]")));
+        sb.AppendLine(") VALUES (");
+        sb.AppendLine(string.Join(", ", columns.Select(c => $"source.[{c}]")));
+        sb.AppendLine(");");
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sb.ToString();
+        cmd.CommandTimeout = 0;
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task TruncateStagingAsync(
+        string connectionString, string stagingTableName,
+        CancellationToken cancellationToken = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"TRUNCATE TABLE [{stagingTableName}]";
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task EnsureStagingTableAsync(
+        string connectionString, string stagingTableName,
+        StagingTableSpec spec, CancellationToken cancellationToken = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var checkCmd = conn.CreateCommand();
+        checkCmd.CommandText = @"
+            SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_NAME = @tableName";
+        checkCmd.Parameters.AddWithValue("@tableName", stagingTableName);
+        var exists = (int)(await checkCmd.ExecuteScalarAsync(cancellationToken))! > 0;
+
+        if (!exists)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"CREATE TABLE [{stagingTableName}] (");
+            sb.AppendLine(string.Join(",\n",
+                spec.Columns.Select(c => $"  [{c.Name}] {c.SqlType}")));
+            sb.AppendLine(")");
+
+            await using var createCmd = conn.CreateCommand();
+            createCmd.CommandText = sb.ToString();
+            await createCmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+    }
+
+    private static async Task<List<string>> GetColumnsAsync(
+        SqlConnection conn, string tableName, CancellationToken ct)
+    {
+        var columns = new List<string>();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_NAME = @tableName
+            ORDER BY ORDINAL_POSITION";
+        cmd.Parameters.AddWithValue("@tableName", tableName);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            columns.Add(reader.GetString(0));
+        }
+        return columns;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/Sources/MssqlSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/Sources/MssqlSource.cs
@@ -1,0 +1,70 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.Data.SqlClient;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline.Sources;
+
+/// <summary>
+/// MSSQL 資料來源 — 使用 DbDataReader 串流讀取，分批 yield DataTable
+/// </summary>
+public class MssqlSource : IEtlSource
+{
+    private SqlConnection? _connection;
+
+    public async IAsyncEnumerable<DataTable> ExtractBatchesAsync(
+        string connectionString,
+        string queryTemplate,
+        object? watermarkValue,
+        int batchSize,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        _connection = new SqlConnection(connectionString);
+        await _connection.OpenAsync(cancellationToken);
+
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = queryTemplate;
+        cmd.CommandTimeout = 0; // Pipeline 層的 CancellationToken 控制超時
+
+        if (watermarkValue != null)
+        {
+            cmd.Parameters.AddWithValue("@watermark", watermarkValue);
+        }
+
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
+
+        while (true)
+        {
+            var batch = new DataTable();
+            for (int i = 0; i < reader.FieldCount; i++)
+            {
+                batch.Columns.Add(reader.GetName(i), reader.GetFieldType(i) ?? typeof(object));
+            }
+
+            int count = 0;
+            while (count < batchSize && await reader.ReadAsync(cancellationToken))
+            {
+                var row = batch.NewRow();
+                for (int i = 0; i < reader.FieldCount; i++)
+                {
+                    row[i] = reader.IsDBNull(i) ? DBNull.Value : reader.GetValue(i);
+                }
+                batch.Rows.Add(row);
+                count++;
+            }
+
+            if (count == 0) break;
+            yield return batch;
+            if (count < batchSize) break; // 最後一批
+        }
+    }
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
+        _connection = null;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/StagingTableSpec.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/StagingTableSpec.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// Staging table 結構定義
+/// </summary>
+public class StagingTableSpec
+{
+    public string TableName { get; }
+    public IReadOnlyList<StagingColumn> Columns { get; }
+
+    public StagingTableSpec(string tableName, params StagingColumn[] columns)
+    {
+        TableName = tableName;
+        Columns = columns;
+    }
+}
+
+/// <summary>
+/// Staging table 欄位定義（名稱 + 原生 SQL 類型）
+/// </summary>
+public record StagingColumn(string Name, string SqlType);

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/WatermarkStrategy.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/WatermarkStrategy.cs
@@ -1,0 +1,114 @@
+#nullable enable
+using System;
+using System.Text.Json;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// Watermark 計算邏輯
+///
+/// 規則：
+/// 1. FullLoad → WHERE 1=1（每次全量）
+/// 2. Timestamp/Identity → WHERE {Column} > @watermark
+/// 3. 首次執行：InitialWatermarkValue 有值用它，null 則全量
+/// 4. Watermark 只在整個 Job 成功後更新
+/// 5. 時區：存儲 UTC，查詢時轉回來源時區
+/// </summary>
+public class WatermarkStrategy
+{
+    public EtlWatermarkType Type { get; }
+    public string? Column { get; }
+    public string? CurrentValue { get; private set; }
+    public string TimeZone { get; }
+
+    private string? _pendingValue;
+
+    public WatermarkStrategy(EtlWatermarkType type, string? column, string? currentValue, string timeZone = "UTC")
+    {
+        Type = type;
+        Column = column;
+        CurrentValue = currentValue;
+        TimeZone = timeZone;
+    }
+
+    /// <summary>
+    /// 產生 WHERE 子句（不含 WHERE 關鍵字）
+    /// </summary>
+    public string BuildWhereClause()
+    {
+        if (Type == EtlWatermarkType.FullLoad)
+            return "1=1";
+
+        if (string.IsNullOrEmpty(CurrentValue))
+            return "1=1"; // 首次全量
+
+        return $"{Column} > @watermark";
+    }
+
+    /// <summary>
+    /// 取得 @watermark 參數值（已轉換時區）
+    /// </summary>
+    public object? GetParameterValue()
+    {
+        if (Type == EtlWatermarkType.FullLoad || string.IsNullOrEmpty(CurrentValue))
+            return null;
+
+        if (Type == EtlWatermarkType.Timestamp)
+        {
+            var utcValue = JsonSerializer.Deserialize<DateTime>(CurrentValue);
+            if (TimeZone != "UTC")
+            {
+                var tz = TimeZoneInfo.FindSystemTimeZoneById(TimeZone);
+                return TimeZoneInfo.ConvertTimeFromUtc(utcValue, tz);
+            }
+            return utcValue;
+        }
+
+        // Identity — 直接回傳數值
+        return JsonSerializer.Deserialize<long>(CurrentValue);
+    }
+
+    /// <summary>
+    /// 從一批資料中提取最大 watermark 值（暫存，不立即寫回 DB）
+    /// </summary>
+    public void UpdateFromBatchMax(object maxValue)
+    {
+        if (Type == EtlWatermarkType.FullLoad) return;
+
+        if (Type == EtlWatermarkType.Timestamp && maxValue is DateTime dt)
+        {
+            if (TimeZone != "UTC")
+            {
+                var tz = TimeZoneInfo.FindSystemTimeZoneById(TimeZone);
+                dt = TimeZoneInfo.ConvertTimeToUtc(dt, tz);
+            }
+            _pendingValue = JsonSerializer.Serialize(dt);
+        }
+        else if (Type == EtlWatermarkType.Identity && maxValue is long id)
+        {
+            _pendingValue = JsonSerializer.Serialize(id);
+        }
+    }
+
+    /// <summary>
+    /// Job 成功後，確認更新 watermark（回傳新值寫回 DB）
+    /// </summary>
+    public string? CommitPendingValue()
+    {
+        if (_pendingValue != null)
+        {
+            CurrentValue = _pendingValue;
+            _pendingValue = null;
+        }
+        return CurrentValue;
+    }
+
+    /// <summary>
+    /// Job 失敗時，丟棄暫存值（watermark 不更新）
+    /// </summary>
+    public void DiscardPendingValue()
+    {
+        _pendingValue = null;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Testing/MockBulkLoader.cs
+++ b/src/WalkingTec.Mvvm.Etl/Testing/MockBulkLoader.cs
@@ -1,0 +1,64 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Testing;
+
+/// <summary>
+/// 測試用 BulkLoader — 收集資料到 List，不做真正 BulkCopy。
+/// 隨框架發布，供使用者測試自己的 ETL Job。
+/// </summary>
+public class MockBulkLoader : IBulkLoader
+{
+    public List<DataTable> LoadedBatches { get; } = new();
+    public int BatchCount => LoadedBatches.Count;
+    public int TotalRows => LoadedBatches.Sum(b => b.Rows.Count);
+    public bool MergeCalled { get; private set; }
+    public bool TruncateCalled { get; private set; }
+    public bool EnsureStagingCalled { get; private set; }
+
+    /// <summary>設定此值讓指定 batch 拋出異常（從 1 開始計數）</summary>
+    public int? FailOnBatch { get; set; }
+
+    /// <summary>每次 BulkLoad 完成後觸發</summary>
+    public event EventHandler? OnBatchLoaded;
+
+    public Task BulkLoadAsync(string connectionString, string stagingTableName,
+        DataTable batch, CancellationToken cancellationToken = default)
+    {
+        LoadedBatches.Add(batch.Copy());
+
+        if (FailOnBatch.HasValue && LoadedBatches.Count == FailOnBatch.Value)
+            throw new InvalidOperationException($"MockBulkLoader: simulated failure on batch {FailOnBatch.Value}");
+
+        OnBatchLoaded?.Invoke(this, EventArgs.Empty);
+        return Task.CompletedTask;
+    }
+
+    public Task MergeAsync(string connectionString, string stagingTableName,
+        string targetTableName, string mergeKeyColumn,
+        CancellationToken cancellationToken = default)
+    {
+        MergeCalled = true;
+        return Task.CompletedTask;
+    }
+
+    public Task TruncateStagingAsync(string connectionString, string stagingTableName,
+        CancellationToken cancellationToken = default)
+    {
+        TruncateCalled = true;
+        return Task.CompletedTask;
+    }
+
+    public Task EnsureStagingTableAsync(string connectionString, string stagingTableName,
+        StagingTableSpec spec, CancellationToken cancellationToken = default)
+    {
+        EnsureStagingCalled = true;
+        return Task.CompletedTask;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Testing/MockEtlSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Testing/MockEtlSource.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Testing;
+
+/// <summary>
+/// 測試用 EtlSource — 回傳 in-memory DataTable，不連真實 DB。
+/// 隨框架發布，供使用者測試自己的 ETL Job。
+/// </summary>
+public class MockEtlSource : IEtlSource
+{
+    private DataTable _data = new();
+
+    /// <summary>設定測試資料</summary>
+    public void SetData(DataTable data) => _data = data;
+
+    public async IAsyncEnumerable<DataTable> ExtractBatchesAsync(
+        string connectionString, string queryTemplate, object? watermarkValue,
+        int batchSize, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        int offset = 0;
+        while (offset < _data.Rows.Count)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var batch = _data.Clone(); // schema only
+            int end = Math.Min(offset + batchSize, _data.Rows.Count);
+            for (int i = offset; i < end; i++)
+            {
+                batch.ImportRow(_data.Rows[i]);
+            }
+            offset = end;
+            yield return batch;
+            await Task.CompletedTask;
+        }
+    }
+
+    public void Dispose() { }
+}

--- a/src/WalkingTec.Mvvm.Etl/WalkingTec.Mvvm.Etl.csproj
+++ b/src/WalkingTec.Mvvm.Etl/WalkingTec.Mvvm.Etl.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>WalkingTec.Mvvm.Etl</AssemblyName>
+    <Title>$(AssemblyName)</Title>
+    <Description>WTM ETL Module - Batch data import pipeline</Description>
+    <IsPackable>true</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Project="..\..\common.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\WalkingTec.Mvvm.Core\WalkingTec.Mvvm.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/CancellationTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/CancellationTests.cs
@@ -1,0 +1,77 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Testing;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+[TestClass]
+public class CancellationTests
+{
+    private MockEtlSource _source = null!;
+    private MockBulkLoader _loader = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _source = new MockEtlSource();
+        _loader = new MockBulkLoader();
+    }
+
+    [TestMethod]
+    public async Task Cancellation_stops_after_current_batch()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(200_000));
+        var cts = new CancellationTokenSource();
+        _loader.OnBatchLoaded += (_, _) => cts.Cancel(); // 第一批後取消
+
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark, cts.Token);
+
+        _loader.TotalRows.Should().Be(50_000); // 只完成一批
+    }
+
+    [TestMethod]
+    public async Task Cancelled_result_is_aborted()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(200_000));
+        var cts = new CancellationTokenSource();
+        _loader.OnBatchLoaded += (_, _) => cts.Cancel();
+
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark, cts.Token);
+
+        result.Success.Should().BeFalse();
+        result.Aborted.Should().BeTrue();
+        result.ErrorMessage.Should().Contain("aborted");
+    }
+
+    [TestMethod]
+    public async Task Cancelled_discards_watermark()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(200_000));
+        var cts = new CancellationTokenSource();
+        _loader.OnBatchLoaded += (_, _) => cts.Cancel();
+
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(
+            EtlWatermarkType.Timestamp, "UpdatedAt", "\"2026-01-01T00:00:00\"");
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark, cts.Token);
+
+        // watermark 不應更新
+        watermark.CurrentValue.Should().Be("\"2026-01-01T00:00:00\"");
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EtlPipelineTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EtlPipelineTests.cs
@@ -1,0 +1,150 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Testing;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+[TestClass]
+public class EtlPipelineTests
+{
+    private MockEtlSource _source = null!;
+    private MockBulkLoader _loader = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _source = new MockEtlSource();
+        _loader = new MockBulkLoader();
+    }
+
+    [TestMethod]
+    public async Task Execute_splits_data_into_correct_batches()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(120_000));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue();
+        _loader.BatchCount.Should().Be(3); // 50K + 50K + 20K
+        _loader.TotalRows.Should().Be(120_000);
+    }
+
+    [TestMethod]
+    public async Task Execute_calls_merge_after_all_batches()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100));
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        _loader.MergeCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Execute_calls_truncate_before_loading()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100));
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        _loader.TruncateCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Execute_calls_ensure_staging()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100));
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        _loader.EnsureStagingCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Execute_reports_progress_per_batch()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(120_000));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+
+        var progressReports = new List<EtlProgress>();
+        var progress = new SynchronousProgress<EtlProgress>(p => progressReports.Add(p));
+        var executor = new EtlPipelineExecutor(_source, _loader, progress);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        // 3 Loading reports + 1 Merging report = at least 4
+        progressReports.Count.Should().BeGreaterThanOrEqualTo(4);
+    }
+
+    [TestMethod]
+    public async Task Execute_returns_correct_row_counts()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(5_000));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 2_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.ExtractedRows.Should().Be(5_000);
+        result.LoadedRows.Should().Be(5_000);
+        result.ElapsedMs.Should().BeGreaterOrEqualTo(0);
+    }
+
+    [TestMethod]
+    public async Task Execute_with_transform_applies_function()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100));
+        bool transformCalled = false;
+        var config = TestHelpers.CreateTestConfig() with
+        {
+            TransformFunc = dt =>
+            {
+                transformCalled = true;
+                return dt; // pass-through
+            }
+        };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        transformCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Execute_empty_source_returns_success_zero_rows()
+    {
+        _source.SetData(new DataTable());
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue();
+        result.ExtractedRows.Should().Be(0);
+        result.LoadedRows.Should().Be(0);
+        _loader.MergeCalled.Should().BeTrue();
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/FailureTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/FailureTests.cs
@@ -1,0 +1,73 @@
+#nullable enable
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Testing;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+[TestClass]
+public class FailureTests
+{
+    private MockEtlSource _source = null!;
+    private MockBulkLoader _loader = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _source = new MockEtlSource();
+        _loader = new MockBulkLoader();
+    }
+
+    [TestMethod]
+    public async Task Failure_on_batch_returns_error_result()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100_000));
+        _loader.FailOnBatch = 2;
+
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeFalse();
+        result.Aborted.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task Failure_discards_watermark()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100_000));
+        _loader.FailOnBatch = 2;
+
+        var original = JsonSerializer.Serialize(new System.DateTime(2026, 3, 10, 0, 0, 0));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(
+            EtlWatermarkType.Timestamp, "UpdatedAt", original);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        watermark.CurrentValue.Should().Be(original);
+    }
+
+    [TestMethod]
+    public async Task Failure_includes_error_message()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100_000));
+        _loader.FailOnBatch = 1;
+
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("simulated failure");
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/TestHelpers.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/TestHelpers.cs
@@ -1,0 +1,66 @@
+#nullable enable
+using System;
+using System.Data;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+/// <summary>
+/// 測試用輔助方法
+/// </summary>
+public static class TestHelpers
+{
+    /// <summary>
+    /// 產生含 OrderNo (string), Amount (decimal), UpdatedAt (DateTime) 的測試資料
+    /// </summary>
+    public static DataTable GenerateOrderData(int rowCount, DateTime? baseDate = null)
+    {
+        var dt = new DataTable();
+        dt.Columns.Add("OrderNo", typeof(string));
+        dt.Columns.Add("Amount", typeof(decimal));
+        dt.Columns.Add("UpdatedAt", typeof(DateTime));
+
+        var start = baseDate ?? new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        for (int i = 0; i < rowCount; i++)
+        {
+            var row = dt.NewRow();
+            row["OrderNo"] = $"ORD-{i:D8}";
+            row["Amount"] = 100m + (i % 1000);
+            row["UpdatedAt"] = start.AddSeconds(i);
+            dt.Rows.Add(row);
+        }
+
+        return dt;
+    }
+
+    public static StagingTableSpec CreateTestStagingSpec() => new(
+        "stg_orders",
+        new StagingColumn("OrderNo", "NVARCHAR(50)"),
+        new StagingColumn("Amount", "DECIMAL(18,2)"),
+        new StagingColumn("UpdatedAt", "DATETIME2")
+    );
+
+    public static EtlPipelineConfig CreateTestConfig(Guid? jobId = null) => new()
+    {
+        JobId = jobId ?? Guid.NewGuid(),
+        JobName = "TestJob",
+        SourceConnectionString = "Source=test",
+        TargetConnectionString = "Target=test",
+        QueryTemplate = "SELECT * FROM Orders WHERE @watermark_clause",
+        TargetTableName = "SyncedOrders",
+        MergeKeyColumn = "OrderNo",
+        BatchSize = 50_000,
+        StagingTable = CreateTestStagingSpec()
+    };
+}
+
+/// <summary>
+/// 同步版 IProgress — 避免 Progress&lt;T&gt; 的 SynchronizationContext 非同步回調問題
+/// </summary>
+public class SynchronousProgress<T> : IProgress<T>
+{
+    private readonly Action<T> _handler;
+    public SynchronousProgress(Action<T> handler) => _handler = handler;
+    public void Report(T value) => _handler(value);
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/WatermarkTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/WatermarkTests.cs
@@ -1,0 +1,119 @@
+#nullable enable
+using System;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+[TestClass]
+public class WatermarkTests
+{
+    [TestMethod]
+    public void FullLoad_always_returns_1_equals_1()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        wm.BuildWhereClause().Should().Be("1=1");
+    }
+
+    [TestMethod]
+    public void Timestamp_with_null_value_returns_full_load()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", null);
+        wm.BuildWhereClause().Should().Be("1=1");
+    }
+
+    [TestMethod]
+    public void Timestamp_with_value_returns_column_gt_watermark()
+    {
+        var value = JsonSerializer.Serialize(new DateTime(2026, 3, 10, 2, 0, 0));
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", value);
+        wm.BuildWhereClause().Should().Be("UpdatedAt > @watermark");
+    }
+
+    [TestMethod]
+    public void Identity_with_value_returns_column_gt_watermark()
+    {
+        var value = JsonSerializer.Serialize(185600L);
+        var wm = new WatermarkStrategy(EtlWatermarkType.Identity, "OrderId", value);
+        wm.BuildWhereClause().Should().Be("OrderId > @watermark");
+    }
+
+    [TestMethod]
+    public void FullLoad_get_parameter_returns_null()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        wm.GetParameterValue().Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Timestamp_get_parameter_returns_datetime()
+    {
+        var dt = new DateTime(2026, 3, 10, 2, 0, 0, DateTimeKind.Utc);
+        var value = JsonSerializer.Serialize(dt);
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", value);
+
+        var param = wm.GetParameterValue();
+        param.Should().BeOfType<DateTime>();
+    }
+
+    [TestMethod]
+    public void Identity_get_parameter_returns_long()
+    {
+        var value = JsonSerializer.Serialize(185600L);
+        var wm = new WatermarkStrategy(EtlWatermarkType.Identity, "OrderId", value);
+
+        var param = wm.GetParameterValue();
+        param.Should().BeOfType<long>();
+        ((long)param!).Should().Be(185600L);
+    }
+
+    [TestMethod]
+    public void CommitPendingValue_updates_current()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", null);
+        var dt = new DateTime(2026, 3, 11, 2, 0, 0, DateTimeKind.Utc);
+        wm.UpdateFromBatchMax(dt);
+
+        var committed = wm.CommitPendingValue();
+
+        committed.Should().NotBeNullOrEmpty();
+        wm.CurrentValue.Should().Be(committed);
+    }
+
+    [TestMethod]
+    public void DiscardPendingValue_keeps_current()
+    {
+        var original = JsonSerializer.Serialize(new DateTime(2026, 3, 10, 0, 0, 0));
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", original);
+        wm.UpdateFromBatchMax(new DateTime(2026, 3, 11, 0, 0, 0, DateTimeKind.Utc));
+
+        wm.DiscardPendingValue();
+
+        wm.CurrentValue.Should().Be(original);
+    }
+
+    [TestMethod]
+    public void Timezone_conversion_taipei_to_utc()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", null, "Asia/Taipei");
+
+        // Taipei 10:00 = UTC 02:00
+        var taipeiTime = new DateTime(2026, 3, 11, 10, 0, 0);
+        wm.UpdateFromBatchMax(taipeiTime);
+        var committed = wm.CommitPendingValue();
+
+        var storedUtc = JsonSerializer.Deserialize<DateTime>(committed!);
+        storedUtc.Hour.Should().Be(2);
+    }
+
+    [TestMethod]
+    public void FullLoad_ignores_update_from_batch()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        wm.UpdateFromBatchMax(new DateTime(2026, 3, 11, 0, 0, 0));
+        wm.CommitPendingValue().Should().BeNull();
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/WalkingTec.Mvvm.Etl.Test.csproj
+++ b/test/WalkingTec.Mvvm.Etl.Test/WalkingTec.Mvvm.Etl.Test.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WalkingTec.Mvvm.Etl\WalkingTec.Mvvm.Etl.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

- New project `WalkingTec.Mvvm.Etl` — ETL batch data import module
- **Models**: `EtlJobDefinition`, `EtlRunLog`, `EtlProgress`, enums (`EtlJobStatus`, `EtlRunTrigger`, `EtlRunResult`, `EtlWatermarkType`)
- **Pipeline abstractions**: `IEtlSource`, `IBulkLoader`, `StagingTableSpec`, `EtlPipelineConfig`, `EtlPipelineExecutor`
- **WatermarkStrategy**: 3 modes (FullLoad/Timestamp/Identity) + timezone conversion (Asia/Taipei → UTC)
- **MSSQL implementations**: `MssqlSource` (DbDataReader streaming), `MssqlBulkLoader` (SqlBulkCopy + MERGE INTO)
- **Testing tools** (shipped in `src/`): `MockBulkLoader`, `MockEtlSource` — for consumer unit testing
- **25 MSTest tests**: pipeline batching, progress reporting, cancellation/abort, watermark lifecycle, failure handling

## Key design decisions

- Models inherit `BasePoco` (Guid ID), use existing `DBTypeEnum`
- Pipeline uses `IEtlSource`/`IBulkLoader` interfaces — fully mockable for unit tests
- Watermark only commits on success; discards on failure (idempotent re-run)
- `EtlPipelineConfig` is a `record` for `with` expression support in tests

Closes #165

## Test plan

- [x] `dotnet build WalkingTec.Mvvm.sln -c Release` — 0 errors
- [x] `dotnet test test/WalkingTec.Mvvm.Etl.Test/ -c Release` — 25/25 passed
- [x] All new files `#nullable enable`
- [x] SQL uses parameterized queries (`@watermark`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)