### PR TITLE
feat(dashboard): add table, progress, list, embed renderers

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_dashboard.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_dashboard.js
@@ -219,9 +219,131 @@
         chart.setOption(option);
     }
 
+    function renderTable(container, data, config) {
+        container.innerHTML = '';
+        if (!data || !data.columns || !data.rows) return;
+
+        var table = document.createElement('table');
+        table.className = 'wtm-widget-table';
+
+        // header row
+        var headerRow = document.createElement('tr');
+        for (var c = 0; c < data.columns.length; c++) {
+            var th = document.createElement('th');
+            th.textContent = data.columns[c];
+            headerRow.appendChild(th);
+        }
+        table.appendChild(headerRow);
+
+        // data rows
+        for (var i = 0; i < data.rows.length; i++) {
+            var tr = document.createElement('tr');
+            for (var j = 0; j < data.columns.length; j++) {
+                var td = document.createElement('td');
+                var val = data.rows[i][data.columns[j]];
+                td.textContent = val != null ? String(val) : '';
+                tr.appendChild(td);
+            }
+            table.appendChild(tr);
+        }
+
+        container.appendChild(table);
+    }
+
+    function renderProgress(container, data, config) {
+        container.innerHTML = '';
+        var value = (data && data.value != null) ? Number(data.value) : 0;
+        var pct = Math.max(0, Math.min(1, value));
+
+        if (config.title) {
+            var titleDiv = document.createElement('div');
+            titleDiv.className = 'wtm-progress-title';
+            titleDiv.textContent = config.title;
+            container.appendChild(titleDiv);
+        }
+
+        var track = document.createElement('div');
+        track.className = 'wtm-progress-track';
+
+        var bar = document.createElement('div');
+        bar.className = 'wtm-progress-bar';
+        bar.style.width = (pct * 100) + '%';
+        if (config.color) {
+            bar.style.backgroundColor = config.color;
+        }
+        track.appendChild(bar);
+        container.appendChild(track);
+
+        var label = document.createElement('div');
+        label.className = 'wtm-progress-label';
+        label.textContent = Math.round(pct * 100) + '%';
+        container.appendChild(label);
+    }
+
+    function renderList(container, data, config) {
+        container.innerHTML = '';
+
+        if (config.title) {
+            var titleDiv = document.createElement('div');
+            titleDiv.className = 'wtm-list-title';
+            titleDiv.textContent = config.title;
+            container.appendChild(titleDiv);
+        }
+
+        if (!data || !data.items) return;
+
+        var ul = document.createElement('ul');
+        ul.className = 'wtm-list';
+
+        for (var i = 0; i < data.items.length; i++) {
+            var item = data.items[i];
+            var li = document.createElement('li');
+            li.className = 'wtm-list-item';
+            // Security: all dynamic text via textContent only
+            var text = item.label || '';
+            if (item.description) {
+                text += ' \u2014 ' + item.description;
+            }
+            li.textContent = text;
+
+            if (item.url && config.clickAction === 'navigate') {
+                li.dataset = li.dataset || {};
+                li.dataset.href = item.url;
+            }
+            ul.appendChild(li);
+        }
+
+        container.appendChild(ul);
+    }
+
+    function renderEmbed(container, data, config) {
+        container.innerHTML = '';
+        var url = config.url || '';
+
+        // Security: block dangerous URL schemes
+        var lower = url.toLowerCase().replace(/\s/g, '');
+        if (lower.indexOf('javascript:') === 0 || lower.indexOf('data:') === 0 || lower.indexOf('vbscript:') === 0) {
+            container.textContent = 'Blocked: invalid URL scheme';
+            return;
+        }
+
+        var iframe = document.createElement('iframe');
+        iframe.className = 'wtm-embed-iframe';
+        iframe.src = url;
+        iframe.sandbox = 'allow-scripts'; // no allow-same-origin
+        iframe.style.width = '100%';
+        iframe.style.height = '100%';
+        iframe.style.border = 'none';
+        container.appendChild(iframe);
+    }
+
     var _renderers = {
         kpi: renderKpi,
-        chart: renderChart
+        chart: renderChart,
+        table: renderTable,
+        progress: renderProgress,
+        list: renderList,
+        embed: renderEmbed
     };
 
     var WidgetRendererFactory = {

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/widget-renderers.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/widget-renderers.test.js
@@ -108,12 +108,111 @@ describe('WtmDashboard.WidgetRendererFactory', () => {
             rows: [ { Region: 'North', Amount: 100 } ]
         };
         const config = { chartType: 'bar' };
-        
+
         wd.WidgetRendererFactory.getRenderer('chart')(container, data, config);
-        
+
         expect(mockEcharts.init).toHaveBeenCalledWith(container);
         expect(capturedOptions.length).toBe(1);
         expect(capturedOptions[0].xAxis.type).toBe('category');
         expect(capturedOptions[0].series[0].type).toBe('bar');
+    });
+
+    test('getRenderer returns function for table type', () => {
+        const { wd } = makeEnv();
+        expect(typeof wd.WidgetRendererFactory.getRenderer('table')).toBe('function');
+    });
+
+    test('renderTable creates table with headers and rows', () => {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        const data = {
+            columns: ['Name', 'Score'],
+            rows: [
+                { Name: 'Alice', Score: 95 },
+                { Name: 'Bob', Score: 88 }
+            ]
+        };
+        const config = {};
+
+        wd.WidgetRendererFactory.getRenderer('table')(container, data, config);
+
+        // Should create a table element
+        expect(mockDocument.createElement).toHaveBeenCalledWith('table');
+        expect(container.children.length).toBeGreaterThan(0);
+        const table = container.children[0];
+        expect(table.tag).toBe('table');
+        // thead row + 2 data rows
+        expect(table.children.length).toBe(3);
+        // header cells
+        const headerRow = table.children[0];
+        expect(headerRow.children.some(c => c.textContent === 'Name')).toBe(true);
+        expect(headerRow.children.some(c => c.textContent === 'Score')).toBe(true);
+    });
+
+    test('renderProgress creates bar with percentage', () => {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        const data = { value: 0.73 };
+        const config = { title: 'Completion', color: '#4caf50' };
+
+        wd.WidgetRendererFactory.getRenderer('progress')(container, data, config);
+
+        expect(container.children.length).toBeGreaterThan(0);
+        // Should have title and a progress bar container
+        expect(container.children.some(c => c.textContent === 'Completion')).toBe(true);
+        // The percentage label
+        expect(container.children.some(c => c.textContent === '73%')).toBe(true);
+    });
+
+    test('renderList creates list items with textContent only', () => {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        const data = {
+            items: [
+                { label: 'Task A', description: 'Do something' },
+                { label: 'Task B', description: 'Do another' }
+            ]
+        };
+        const config = { title: 'Recent Tasks' };
+
+        wd.WidgetRendererFactory.getRenderer('list')(container, data, config);
+
+        expect(container.children.length).toBeGreaterThan(0);
+        expect(container.children.some(c => c.textContent === 'Recent Tasks')).toBe(true);
+        // Should have a list container with items
+        const listContainer = container.children.find(c => c.tag === 'ul');
+        expect(listContainer).toBeDefined();
+        expect(listContainer.children.length).toBe(2);
+        expect(listContainer.children[0].textContent).toBe('Task A — Do something');
+    });
+
+    test('renderEmbed creates iframe with sandbox', () => {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        const data = {};
+        const config = { url: 'https://example.com/report' };
+
+        wd.WidgetRendererFactory.getRenderer('embed')(container, data, config);
+
+        expect(mockDocument.createElement).toHaveBeenCalledWith('iframe');
+        expect(container.children.length).toBe(1);
+        const iframe = container.children[0];
+        expect(iframe.tag).toBe('iframe');
+        expect(iframe.src).toBe('https://example.com/report');
+        expect(iframe.sandbox).toBe('allow-scripts');
+    });
+
+    test('renderEmbed rejects javascript: URLs', () => {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        const data = {};
+        const config = { url: 'javascript:alert(1)' };
+
+        wd.WidgetRendererFactory.getRenderer('embed')(container, data, config);
+
+        // Should not create an iframe, should show error
+        const hasIframe = container.children && container.children.some(c => c.tag === 'iframe');
+        expect(hasIframe).toBeFalsy();
+        expect(container.textContent).toMatch(/blocked|invalid/i);
     });
 });


### PR DESCRIPTION
## Summary
- Add 4 widget renderers to `framework_dashboard.js`: **table**, **progress**, **list**, **embed**
- Security hardening: all dynamic text via `textContent`, iframe `sandbox="allow-scripts"` (no `allow-same-origin`), `javascript:`/`data:`/`vbscript:` URL scheme blocking
- 6 new Jest tests covering DOM structure, percentage display, list rendering, iframe sandbox, and XSS prevention

## Test plan
- [x] All 14 widget-renderer tests pass (8 existing + 6 new)
- [x] All 23 dashboard tests pass
- [ ] CI green

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)