### PR TITLE
feat(dashboard): add AnalysisWidgetDataSource bridge

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Dashboard/AnalysisWidgetDataSource.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/AnalysisWidgetDataSource.cs
@@ -1,0 +1,163 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using WalkingTec.Mvvm.Core.Analysis;
+
+namespace WalkingTec.Mvvm.Core.Dashboard;
+
+/// <summary>
+/// Bridges Analysis Mode to the Dashboard widget data pipeline.
+/// Translates widget source config (listVmType, dimensions, measures, filters)
+/// into AnalysisQueryEngine calls and maps the result to WidgetDataResult.
+/// </summary>
+public class AnalysisWidgetDataSource : IWidgetDataSource
+{
+    private readonly AnalysisVmRegistry _registry;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly AnalysisQueryEngine _engine;
+
+    public string Name => "analysis";
+    public WidgetDataSourceKind Kind => WidgetDataSourceKind.Analysis;
+
+    public AnalysisWidgetDataSource(
+        AnalysisVmRegistry registry,
+        IServiceProvider serviceProvider,
+        AnalysisQueryEngine engine)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+    }
+
+    public Task<WidgetDataResult> GetDataAsync(WidgetDataRequest request, CancellationToken ct = default)
+    {
+        if (!request.Parameters.TryGetValue("listVmType", out var listVmType) || string.IsNullOrWhiteSpace(listVmType))
+            throw new InvalidOperationException("Widget data request missing required parameter 'listVmType'.");
+
+        // 1. Resolve VM type from whitelist
+        var vmType = _registry.Resolve(listVmType);
+
+        // 2. Create VM instance and bind WTMContext via scoped service
+        using var scope = _serviceProvider.CreateScope();
+        var wtm = scope.ServiceProvider.GetService<WTMContext>();
+
+        BaseVM vm;
+        try
+        {
+            vm = (Activator.CreateInstance(vmType) as BaseVM)!;
+        }
+        catch (MissingMethodException)
+        {
+            throw new InvalidOperationException(
+                $"VM type '{vmType.FullName}' must have a public parameterless constructor.");
+        }
+
+        if (vm is null)
+            throw new InvalidOperationException(
+                $"VM type '{vmType.FullName}' must inherit from BaseVM.");
+
+        if (wtm != null) vm.Wtm = wtm;
+
+        // 3. Get base query via reflection
+        var baseQuery = InvokeGetSearchQuery(vm, vmType)
+            ?? throw new InvalidOperationException(
+                $"VM type '{vmType.FullName}' GetSearchQuery() returned null.");
+
+        // 4. Get analysis field whitelist
+        var fields = InvokeGetAnalysisFields(vm, vmType);
+
+        // 5. Build AnalysisQueryRequest from widget parameters
+        var analysisReq = BuildAnalysisRequest(request.Parameters);
+
+        // 6. Execute via engine (handles TargetInvocationException unwrapping internally)
+        var response = _engine.ExecuteDynamic(baseQuery, analysisReq, fields);
+
+        // 7. Map to WidgetDataResult
+        var result = new WidgetDataResult
+        {
+            Columns = response.Columns,
+            Rows = response.Rows,
+            Metadata = new Dictionary<string, object?>
+            {
+                ["totalCount"] = response.TotalCount,
+                ["truncated"] = response.Truncated
+            }
+        };
+
+        return Task.FromResult(result);
+    }
+
+    private static AnalysisQueryRequest BuildAnalysisRequest(Dictionary<string, string> parameters)
+    {
+        var req = new AnalysisQueryRequest();
+
+        if (parameters.TryGetValue("listVmType", out var lvt))
+            req.ListVmType = lvt;
+
+        if (parameters.TryGetValue("dimensions", out var dims) && !string.IsNullOrWhiteSpace(dims))
+            req.Dimensions = JsonSerializer.Deserialize<List<string>>(dims) ?? new List<string>();
+
+        if (parameters.TryGetValue("measures", out var measures) && !string.IsNullOrWhiteSpace(measures))
+            req.Measures = JsonSerializer.Deserialize<List<MeasureRequest>>(measures) ?? new List<MeasureRequest>();
+
+        if (parameters.TryGetValue("filters", out var filters) && !string.IsNullOrWhiteSpace(filters))
+            req.Filters = JsonSerializer.Deserialize<List<FilterCondition>>(filters) ?? new List<FilterCondition>();
+
+        return req;
+    }
+
+    private static IQueryable InvokeGetSearchQuery(BaseVM vm, Type vmType)
+    {
+        var method = vmType.GetMethod(
+            "GetSearchQuery",
+            BindingFlags.Instance | BindingFlags.Public,
+            null,
+            Type.EmptyTypes,
+            null);
+        if (method == null)
+            throw new InvalidOperationException(
+                $"VM type '{vmType.FullName}' does not have a GetSearchQuery() method.");
+        try
+        {
+            var result = method.Invoke(vm, null);
+            if (result is IQueryable q) return q;
+            throw new InvalidOperationException(
+                $"VM type '{vmType.FullName}' GetSearchQuery() did not return IQueryable.");
+        }
+        catch (TargetInvocationException ex)
+        {
+            throw ex.InnerException ?? ex;
+        }
+    }
+
+    private static IEnumerable<AnalysisFieldMeta> InvokeGetAnalysisFields(BaseVM vm, Type vmType)
+    {
+        var method = vmType.GetMethod(
+            "GetAnalysisFields",
+            BindingFlags.Instance | BindingFlags.Public,
+            null,
+            Type.EmptyTypes,
+            null);
+        if (method == null)
+            throw new InvalidOperationException(
+                $"VM type '{vmType.FullName}' does not have a GetAnalysisFields() method.");
+        try
+        {
+            var result = method.Invoke(vm, null) as IEnumerable<AnalysisFieldMeta>;
+            if (result is null)
+                throw new InvalidOperationException(
+                    $"VM type '{vmType.FullName}' GetAnalysisFields() returned null.");
+            return result;
+        }
+        catch (TargetInvocationException ex)
+        {
+            throw ex.InnerException ?? ex;
+        }
+    }
+}

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/AnalysisWidgetDataSourceTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/AnalysisWidgetDataSourceTests.cs
@@ -1,0 +1,138 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Core.Analysis;
+using WalkingTec.Mvvm.Core.Dashboard;
+using WalkingTec.Mvvm.Test.Mock;
+
+namespace WalkingTec.Mvvm.Core.Test.Dashboard
+{
+    [TestClass]
+    public class AnalysisWidgetDataSourceTests
+    {
+        // ─── Test Model ──────────────────────────────────────────────────────
+
+        private class DashSaleRecord : TopBasePoco
+        {
+            [Dimension(DisplayName = "Region")] public string Region { get; set; } = "";
+            [Measure(AllowedFuncs = AggregateFunc.Sum | AggregateFunc.Count, DisplayName = "Amount")]
+            public decimal Amount { get; set; }
+        }
+
+        private static IList<DashSaleRecord> _testData = new List<DashSaleRecord>();
+
+        [EnableAnalysis]
+        private class DashSaleRecordListVM : BasePagedListVM<DashSaleRecord, BaseSearcher>
+        {
+            public override IOrderedQueryable<DashSaleRecord> GetSearchQuery()
+                => _testData.AsQueryable().OrderByDescending(x => x.ID);
+        }
+
+        // ─── Infrastructure ──────────────────────────────────────────────────
+
+        private AnalysisVmRegistry _registry = null!;
+        private AnalysisQueryEngine _engine = null!;
+        private IServiceProvider _serviceProvider = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _testData = new List<DashSaleRecord>
+            {
+                new() { ID = Guid.NewGuid(), Region = "North", Amount = 100m },
+                new() { ID = Guid.NewGuid(), Region = "North", Amount = 200m },
+                new() { ID = Guid.NewGuid(), Region = "South", Amount = 150m },
+            };
+
+            _registry = new AnalysisVmRegistry();
+            _registry.Build(new[] { typeof(AnalysisWidgetDataSourceTests).Assembly });
+
+            _engine = new AnalysisQueryEngine();
+
+            var services = new ServiceCollection();
+            _serviceProvider = services.BuildServiceProvider();
+        }
+
+        private AnalysisWidgetDataSource CreateSource()
+            => new(_registry, _serviceProvider, _engine);
+
+        // ─── Tests ───────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task GetDataAsync_returns_columns_and_rows()
+        {
+            var source = CreateSource();
+            var request = new WidgetDataRequest
+            {
+                Parameters = new Dictionary<string, string>
+                {
+                    ["listVmType"] = typeof(DashSaleRecordListVM).FullName!,
+                    ["dimensions"] = JsonSerializer.Serialize(new[] { "Region" }),
+                    ["measures"] = JsonSerializer.Serialize(new[]
+                    {
+                        new { Field = "Amount", Func = AggregateFunc.Sum }
+                    })
+                }
+            };
+
+            var result = await source.GetDataAsync(request);
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.Columns);
+            Assert.IsNotNull(result.Rows);
+            Assert.AreEqual(2, result.Columns.Count); // Region, Amount_Sum
+            Assert.IsTrue(result.Columns.Contains("Region"));
+            Assert.IsTrue(result.Columns.Contains("Amount_Sum"));
+            Assert.AreEqual(2, result.Rows.Count); // North, South
+
+            var northRow = result.Rows.First(r => r["Region"]?.ToString() == "North");
+            Assert.AreEqual(300m, Convert.ToDecimal(northRow["Amount_Sum"]));
+
+            var southRow = result.Rows.First(r => r["Region"]?.ToString() == "South");
+            Assert.AreEqual(150m, Convert.ToDecimal(southRow["Amount_Sum"]));
+        }
+
+        [TestMethod]
+        public async Task GetDataAsync_throws_for_unregistered_listvm()
+        {
+            var source = CreateSource();
+            var request = new WidgetDataRequest
+            {
+                Parameters = new Dictionary<string, string>
+                {
+                    ["listVmType"] = "Some.Nonexistent.ListVM"
+                }
+            };
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => source.GetDataAsync(request));
+        }
+
+        [TestMethod]
+        public async Task GetDataAsync_throws_when_listVmType_missing()
+        {
+            var source = CreateSource();
+            var request = new WidgetDataRequest
+            {
+                Parameters = new Dictionary<string, string>()
+            };
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => source.GetDataAsync(request));
+        }
+
+        [TestMethod]
+        public void Properties_return_expected_values()
+        {
+            var source = CreateSource();
+            Assert.AreEqual("analysis", source.Name);
+            Assert.AreEqual(WidgetDataSourceKind.Analysis, source.Kind);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AnalysisWidgetDataSource` implementing `IWidgetDataSource` to bridge Analysis Mode with the Dashboard widget pipeline
- Translates widget source config (`listVmType`, dimensions, measures, filters as JSON) into `AnalysisQueryEngine.ExecuteDynamic` calls via reflection
- Reuses the full Analysis Mode pipeline: whitelist validation, expression tree filters, group-by strategies, `TargetInvocationException` unwrapping
- 4 MSTest: happy path (columns + rows + aggregation), unregistered VM, missing parameter, property assertions

## Test plan
- [x] All 4 `AnalysisWidgetDataSourceTests` pass
- [x] Build succeeds (no new errors)
- [ ] CI green

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)