### PR TITLE
feat(dashboard): add DashboardEditor UI + widget CSS

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_dashboard.css
+++ b/src/WalkingTec.Mvvm.Mvc/framework_dashboard.css
@@ -1,0 +1,258 @@
+/* WTM Dashboard Module Styles */
+
+/* --- Container --- */
+.wtm-dashboard {
+    position: relative;
+    padding: 12px;
+}
+
+/* --- Toolbar --- */
+.wtm-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    margin-bottom: 12px;
+    background: #f8f9fa;
+    border-radius: 4px;
+    border: 1px solid #e6e6e6;
+}
+
+.wtm-toolbar .wtm-toolbar-title {
+    font-size: 16px;
+    font-weight: 600;
+    margin-right: auto;
+}
+
+/* --- Widget Card --- */
+.wtm-widget {
+    background: #fff;
+    border-radius: 4px;
+    border: 1px solid #e6e6e6;
+    overflow: hidden;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.wtm-widget-header {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+    border-bottom: 1px solid #f0f0f0;
+    font-size: 14px;
+    font-weight: 600;
+    color: #333;
+}
+
+.wtm-widget-header .wtm-widget-actions {
+    margin-left: auto;
+    display: none;
+}
+
+.wtm-dashboard.edit-mode .wtm-widget-header .wtm-widget-actions {
+    display: flex;
+    gap: 4px;
+}
+
+.wtm-widget-body {
+    flex: 1;
+    padding: 12px;
+    overflow: auto;
+}
+
+/* --- KPI Widget --- */
+.wtm-kpi-title {
+    font-size: 13px;
+    color: #666;
+    margin-bottom: 4px;
+}
+
+.wtm-kpi-value {
+    font-size: 28px;
+    font-weight: 700;
+    color: #1a1a1a;
+    line-height: 1.2;
+}
+
+.wtm-kpi-trend {
+    font-size: 13px;
+    margin-top: 4px;
+}
+
+.wtm-kpi-trend.up {
+    color: #52c41a;
+}
+
+.wtm-kpi-trend.down {
+    color: #f5222d;
+}
+
+/* --- Table Widget --- */
+.wtm-widget-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+.wtm-widget-table th {
+    text-align: left;
+    padding: 6px 8px;
+    border-bottom: 2px solid #e6e6e6;
+    color: #666;
+    font-weight: 600;
+}
+
+.wtm-widget-table td {
+    padding: 6px 8px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.wtm-widget-table tr:hover td {
+    background: #fafafa;
+}
+
+/* --- Progress Widget --- */
+.wtm-progress-title {
+    font-size: 13px;
+    color: #666;
+    margin-bottom: 8px;
+}
+
+.wtm-progress-track {
+    height: 8px;
+    background: #f0f0f0;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.wtm-progress-bar {
+    height: 100%;
+    background: #1890ff;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+}
+
+.wtm-progress-label {
+    font-size: 13px;
+    color: #333;
+    margin-top: 4px;
+    font-weight: 600;
+}
+
+/* --- List Widget --- */
+.wtm-list-title {
+    font-size: 13px;
+    color: #666;
+    margin-bottom: 8px;
+}
+
+.wtm-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.wtm-list-item {
+    padding: 8px 0;
+    border-bottom: 1px solid #f0f0f0;
+    font-size: 13px;
+    color: #333;
+}
+
+.wtm-list-item:last-child {
+    border-bottom: none;
+}
+
+/* --- Embed Widget --- */
+.wtm-embed-iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+/* --- Loading State --- */
+.wtm-widget-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #999;
+    font-size: 13px;
+}
+
+.wtm-widget-loading::after {
+    content: '';
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    margin-left: 8px;
+    border: 2px solid #e6e6e6;
+    border-top-color: #1890ff;
+    border-radius: 50%;
+    animation: wtm-spin 0.6s linear infinite;
+}
+
+@keyframes wtm-spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Skeleton pulse for loading placeholders */
+.wtm-skeleton {
+    background: linear-gradient(90deg, #f0f0f0 25%, #e6e6e6 50%, #f0f0f0 75%);
+    background-size: 200% 100%;
+    animation: wtm-pulse 1.5s ease-in-out infinite;
+    border-radius: 4px;
+}
+
+@keyframes wtm-pulse {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
+/* --- Error State --- */
+.wtm-widget-error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #999;
+    font-size: 13px;
+    text-align: center;
+    padding: 12px;
+}
+
+.wtm-widget-error .wtm-error-icon {
+    font-size: 24px;
+    color: #f5222d;
+    margin-bottom: 8px;
+}
+
+.wtm-widget-error .wtm-retry-btn {
+    margin-top: 8px;
+    padding: 4px 12px;
+    border: 1px solid #d9d9d9;
+    border-radius: 4px;
+    background: #fff;
+    color: #333;
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.wtm-widget-error .wtm-retry-btn:hover {
+    border-color: #1890ff;
+    color: #1890ff;
+}
+
+/* --- Gridstack Overrides --- */
+.grid-stack > .grid-stack-item > .grid-stack-item-content {
+    padding: 0;
+    overflow: visible;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    border-radius: 4px;
+}
+
+.grid-stack > .grid-stack-item.ui-draggable-dragging > .grid-stack-item-content {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}

--- a/src/WalkingTec.Mvvm.Mvc/framework_dashboard.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_dashboard.js
@@ -332,13 +332,69 @@
         }
     };
 
+    // --- DashboardEditor ----------------------------------------------------
+    var DashboardEditor = {
+        toggleEditMode: function() {
+            var newMode = !GridManager.isEditMode();
+            GridManager.setEditMode(newMode);
+            if (newMode) {
+                DashboardManager.stopRefresh();
+            } else if (_currentDashboard && _currentDashboard.refreshInterval > 0) {
+                DashboardManager.startRefresh(_currentDashboard.refreshInterval);
+            }
+        },
+
+        saveDashboard: function() {
+            if (!_currentDashboard) return Promise.resolve();
+            var layout = GridManager.saveLayout();
+            var body = {
+                name: _currentDashboard.name,
+                layout: layout,
+                widgets: _currentDashboard.widgets || {}
+            };
+            return global.fetch('/_dashboard/' + _currentDashboard.id, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body)
+            }).then(function(res) {
+                if (!res.ok) throw new Error('Save failed');
+                return res.json();
+            });
+        },
+
+        deleteDashboard: function() {
+            if (!_currentDashboard) return Promise.resolve();
+            return global.fetch('/_dashboard/' + _currentDashboard.id, {
+                method: 'DELETE'
+            }).then(function(res) {
+                if (!res.ok) throw new Error('Delete failed');
+                return res.json();
+            });
+        },
+
+        addWidget: function(widgetId, widgetDef, gridOpts) {
+            if (!_currentDashboard) return;
+            if (!_currentDashboard.widgets) _currentDashboard.widgets = {};
+            _currentDashboard.widgets[widgetId] = widgetDef;
+            if (_grid) {
+                _grid.addWidget(gridOpts || { id: widgetId, w: 4, h: 3 });
+            }
+        },
+
+        removeWidget: function(widgetId) {
+            if (!_currentDashboard || !_currentDashboard.widgets) return;
+            delete _currentDashboard.widgets[widgetId];
+        }
+    };
+
     // --- API 導出 ------------------------------------------------------------
     var api = {
         EventBus: EventBus,
         GridManager: GridManager,
         Utils: Utils,
         WidgetRendererFactory: WidgetRendererFactory,
-        DashboardManager: DashboardManager
+        DashboardManager: DashboardManager,
+        DashboardEditor: DashboardEditor
     };
 
     if (typeof global.window !== "undefined") {

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/dashboard-editor.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/dashboard-editor.test.js
@@ -1,0 +1,141 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function makeEnv(overrides = {}) {
+    const src = fs.readFileSync(
+        path.resolve(__dirname, '../../../../src/WalkingTec.Mvvm.Mvc/framework_dashboard.js'),
+        'utf8'
+    );
+    const mockGridStack = {
+        save: jest.fn(() => []),
+        load: jest.fn(),
+        removeAll: jest.fn(),
+        enable: jest.fn(),
+        disable: jest.fn(),
+        addWidget: jest.fn()
+    };
+    const fetchResponses = [];
+    const mockFetch = jest.fn(() => {
+        const resp = fetchResponses.shift() || { ok: true, json: () => Promise.resolve({}) };
+        return Promise.resolve(resp);
+    });
+    const freshCtx = vm.createContext({
+        window: {},
+        global: {},
+        console: console,
+        document: {
+            createElement: jest.fn((tag) => ({
+                tag,
+                className: '',
+                textContent: '',
+                style: {},
+                children: [],
+                appendChild: jest.fn(function (c) { this.children.push(c); return c; })
+            })),
+            getElementById: jest.fn(() => null)
+        },
+        GridStack: {
+            init: jest.fn(() => mockGridStack)
+        },
+        fetch: mockFetch,
+        setInterval: jest.fn(),
+        clearInterval: jest.fn(),
+        ...overrides,
+    });
+    freshCtx.window = freshCtx;
+    new vm.Script(src).runInContext(freshCtx);
+
+    return {
+        wd: freshCtx.WtmDashboard,
+        mockGridStack,
+        mockFetch,
+        fetchResponses,
+        ctx: freshCtx
+    };
+}
+
+describe('WtmDashboard.DashboardEditor', () => {
+    test('toggleEditMode flips GridManager edit state', () => {
+        const { wd } = makeEnv();
+        wd.GridManager.init('.grid-stack', {});
+
+        expect(wd.GridManager.isEditMode()).toBe(false);
+
+        wd.DashboardEditor.toggleEditMode();
+        expect(wd.GridManager.isEditMode()).toBe(true);
+
+        wd.DashboardEditor.toggleEditMode();
+        expect(wd.GridManager.isEditMode()).toBe(false);
+    });
+
+    test('toggleEditMode pauses refresh when entering edit mode', () => {
+        const { wd, ctx } = makeEnv();
+        wd.GridManager.init('.grid-stack', {});
+
+        // Simulate an active refresh timer
+        const stopSpy = jest.spyOn(wd.DashboardManager, 'stopRefresh');
+
+        wd.DashboardEditor.toggleEditMode(); // enter edit mode
+        expect(stopSpy).toHaveBeenCalled();
+    });
+
+    test('saveDashboard sends PUT with layout and widgets', async () => {
+        const { wd, mockGridStack, mockFetch, fetchResponses } = makeEnv();
+        wd.GridManager.init('.grid-stack', {});
+
+        // Set up a current dashboard via DashboardManager internal state
+        // We simulate by calling init with a mock fetch response
+        fetchResponses.push({
+            ok: true,
+            json: () => Promise.resolve({
+                id: 'dash-1',
+                name: 'Test',
+                widgets: {},
+                layout: []
+            })
+        });
+        await wd.DashboardManager.init('container', 'dash-1');
+
+        mockGridStack.save.mockReturnValue([{ x: 0, y: 0, w: 3, h: 2, id: 'w1' }]);
+
+        fetchResponses.push({
+            ok: true,
+            json: () => Promise.resolve({ success: true })
+        });
+
+        await wd.DashboardEditor.saveDashboard();
+
+        // The last fetch call should be PUT
+        const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+        expect(lastCall[0]).toContain('/_dashboard/dash-1');
+        expect(lastCall[1].method).toBe('PUT');
+
+        const body = JSON.parse(lastCall[1].body);
+        expect(body.layout).toEqual([{ x: 0, y: 0, w: 3, h: 2, id: 'w1' }]);
+    });
+
+    test('deleteDashboard sends DELETE request', async () => {
+        const { wd, mockFetch, fetchResponses } = makeEnv();
+        wd.GridManager.init('.grid-stack', {});
+
+        fetchResponses.push({
+            ok: true,
+            json: () => Promise.resolve({
+                id: 'dash-2',
+                name: 'ToDelete',
+                widgets: {},
+                layout: []
+            })
+        });
+        await wd.DashboardManager.init('container', 'dash-2');
+
+        fetchResponses.push({ ok: true, json: () => Promise.resolve({}) });
+
+        await wd.DashboardEditor.deleteDashboard();
+
+        const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+        expect(lastCall[0]).toContain('/_dashboard/dash-2');
+        expect(lastCall[1].method).toBe('DELETE');
+    });
+});


### PR DESCRIPTION
## Summary
- Add `DashboardEditor` module to `framework_dashboard.js`: toggle edit mode (with refresh pause/resume), save dashboard (PUT), delete dashboard (DELETE), add/remove widget helpers
- Populate `framework_dashboard.css` with complete widget styles: KPI, table, progress bar, list, embed iframe, loading spinner + skeleton pulse animation, error state with retry button, gridstack overrides
- 4 new Jest tests: edit mode toggle, refresh pause on edit, save PUT request, delete DELETE request

## Test plan
- [x] All 21 dashboard tests pass (5 suites)
- [x] .NET build succeeds (CSS embedded resource already registered in csproj)
- [ ] CI green

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)