### PR TITLE
feat(dashboard): implement datasources endpoint

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
@@ -60,6 +60,12 @@ namespace WalkingTec.Mvvm.Core.Analysis
             throw new InvalidOperationException($"VM type not registered for analysis: {fullName}");
         }
 
+        /// <summary>
+        /// 回傳所有已註冊的 VM 型別（FullName → Type）。
+        /// </summary>
+        public IReadOnlyDictionary<string, Type> GetRegisteredTypes()
+            => _whitelist;
+
         private static bool IsBasePagedListVm(Type t)
         {
             var bt = t.BaseType;

--- a/src/WalkingTec.Mvvm.Mvc/_DashboardController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_DashboardController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Core.Analysis;
 using WalkingTec.Mvvm.Core.Dashboard;
 
 namespace WalkingTec.Mvvm.Mvc
@@ -17,11 +18,19 @@ namespace WalkingTec.Mvvm.Mvc
     {
         private readonly IDashboardService _dashboardService;
         private readonly DashboardOptions _options;
+        private readonly IEnumerable<IWidgetDataSource> _dataSources;
+        private readonly AnalysisVmRegistry _registry;
 
-        public _DashboardController(IDashboardService dashboardService, IOptions<DashboardOptions> options)
+        public _DashboardController(
+            IDashboardService dashboardService,
+            IOptions<DashboardOptions> options,
+            IEnumerable<IWidgetDataSource> dataSources,
+            AnalysisVmRegistry registry = null)
         {
             _dashboardService = dashboardService;
             _options = options.Value;
+            _dataSources = dataSources;
+            _registry = registry;
         }
 
         private (string userId, string[] roles) GetUserInfo()
@@ -163,8 +172,57 @@ namespace WalkingTec.Mvvm.Mvc
         [HttpGet("datasources")]
         public IActionResult GetDataSources()
         {
-            // Placeholder for MVP
-            return Ok(new List<object>());
+            var result = new List<object>();
+
+            // Custom data sources from DI
+            foreach (var ds in _dataSources)
+            {
+                result.Add(new { name = ds.Name, kind = ds.Kind.ToString().ToLowerInvariant() });
+            }
+
+            // Analysis Mode registered ListVMs
+            if (_registry != null)
+            {
+                foreach (var kvp in _registry.GetRegisteredTypes())
+                {
+                    var fields = AnalysisFieldScanner.ScanModel(
+                        GetModelType(kvp.Value)).ToList();
+
+                    result.Add(new
+                    {
+                        name = kvp.Key,
+                        kind = "analysis",
+                        dimensions = fields
+                            .Where(f => f.Kind == AnalysisFieldKind.Dimension)
+                            .Select(f => new { field = f.FieldName, displayName = f.DisplayName, isDate = f.IsDate })
+                            .ToList(),
+                        measures = fields
+                            .Where(f => f.Kind == AnalysisFieldKind.Measure)
+                            .Select(f => new { field = f.FieldName, displayName = f.DisplayName, allowedFuncs = GetAllowedFuncNames(f.AllowedFuncs) })
+                            .ToList()
+                    });
+                }
+            }
+
+            return Ok(result);
         }
+
+        private static Type GetModelType(Type vmType)
+        {
+            var t = vmType.BaseType;
+            while (t != null)
+            {
+                if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(BasePagedListVM<,>))
+                    return t.GetGenericArguments()[0];
+                t = t.BaseType;
+            }
+            return typeof(object);
+        }
+
+        private static string[] GetAllowedFuncNames(AggregateFunc funcs)
+            => Enum.GetValues<AggregateFunc>()
+                   .Where(f => funcs.HasFlag(f))
+                   .Select(f => f.ToString())
+                   .ToArray();
     }
 }

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardControllerTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -10,6 +11,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Core.Analysis;
 using WalkingTec.Mvvm.Core.Dashboard;
 using WalkingTec.Mvvm.Core.Support.Json;
 using WalkingTec.Mvvm.Mvc;
@@ -28,7 +30,9 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         {
             _service = new Mock<IDashboardService>();
             var opts = Options.Create(new DashboardOptions());
-            _controller = new _DashboardController(_service.Object, opts)
+            _controller = new _DashboardController(
+                _service.Object, opts,
+                Enumerable.Empty<IWidgetDataSource>())
             {
                 Wtm = MockWtmContext.CreateWtmContext()
             };
@@ -169,6 +173,85 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             var result = await _controller.GetWidgetData("id1", "w1", CancellationToken.None) as ForbidResult;
 
             result.Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void GetDataSources_returns_200_with_empty_list()
+        {
+            var result = _controller.GetDataSources() as OkObjectResult;
+
+            result.Should().NotBeNull();
+            result!.StatusCode.Should().Be(200);
+        }
+
+        [TestMethod]
+        public void GetDataSources_includes_custom_sources()
+        {
+            var mockSource = new Mock<IWidgetDataSource>();
+            mockSource.Setup(s => s.Name).Returns("test-source");
+            mockSource.Setup(s => s.Kind).Returns(WidgetDataSourceKind.Custom);
+
+            var opts = Options.Create(new DashboardOptions());
+            var controller = new _DashboardController(
+                _service.Object, opts,
+                new[] { mockSource.Object })
+            {
+                Wtm = MockWtmContext.CreateWtmContext()
+            };
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var result = controller.GetDataSources() as OkObjectResult;
+
+            result.Should().NotBeNull();
+            var json = System.Text.Json.JsonSerializer.Serialize(result!.Value);
+            json.Should().Contain("test-source");
+            json.Should().Contain("custom");
+        }
+
+        // Test model for analysis datasource listing
+        private class DashCtrlTestRecord : TopBasePoco
+        {
+            [Dimension(DisplayName = "City")] public string City { get; set; } = "";
+            [Measure(AllowedFuncs = AggregateFunc.Sum, DisplayName = "Revenue")]
+            public decimal Revenue { get; set; }
+        }
+
+        [EnableAnalysis]
+        private class DashCtrlTestListVM : BasePagedListVM<DashCtrlTestRecord, BaseSearcher>
+        {
+            public override IOrderedQueryable<DashCtrlTestRecord> GetSearchQuery()
+                => new List<DashCtrlTestRecord>().AsQueryable().OrderBy(x => x.ID);
+        }
+
+        [TestMethod]
+        public void GetDataSources_includes_analysis_vms()
+        {
+            var registry = new AnalysisVmRegistry();
+            registry.Build(new[] { typeof(DashboardControllerTests).Assembly });
+
+            var opts = Options.Create(new DashboardOptions());
+            var controller = new _DashboardController(
+                _service.Object, opts,
+                Enumerable.Empty<IWidgetDataSource>(),
+                registry)
+            {
+                Wtm = MockWtmContext.CreateWtmContext()
+            };
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var result = controller.GetDataSources() as OkObjectResult;
+
+            result.Should().NotBeNull();
+            var json = System.Text.Json.JsonSerializer.Serialize(result!.Value);
+            json.Should().Contain("analysis");
+            json.Should().Contain("City");
+            json.Should().Contain("Revenue");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace placeholder `GET /_dashboard/datasources` with full implementation listing custom `IWidgetDataSource` registrations and Analysis Mode ListVMs with dimension/measure metadata
- Add `GetRegisteredTypes()` to `AnalysisVmRegistry` for type enumeration (additive, non-breaking)
- Update `_DashboardController` constructor to accept `IEnumerable<IWidgetDataSource>` and optional `AnalysisVmRegistry`
- 3 new tests: empty datasources, custom source listing, analysis VM listing with field metadata

## Test plan
- [x] All 13 DashboardControllerTests pass (10 existing + 3 new)
- [x] Build succeeds (0 errors)
- [ ] CI green

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)