### PR TITLE
feat(dashboard): multi-tenant support with subdirectory isolation

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Dashboard/DashboardDefinition.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/DashboardDefinition.cs
@@ -11,6 +11,7 @@ public class DashboardDefinition
     public string Id { get; set; } = "";
     public string Title { get; set; } = "";
     public string Owner { get; set; } = "";
+    public string? TenantId { get; set; }
     public SharingDefinition Sharing { get; set; } = new();
     public int RefreshInterval { get; set; } = 60;
     public List<LayoutItem> Layout { get; set; } = new();
@@ -60,6 +61,7 @@ public class DashboardSummary
     public string Id { get; set; } = "";
     public string Title { get; set; } = "";
     public string Owner { get; set; } = "";
+    public string? TenantId { get; set; }
     public SharingDefinition Sharing { get; set; } = new();
     public DateTime UpdatedAt { get; set; }
 }

--- a/src/WalkingTec.Mvvm.Core/Dashboard/IDashboardService.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/IDashboardService.cs
@@ -7,8 +7,8 @@ namespace WalkingTec.Mvvm.Core.Dashboard;
 
 public interface IDashboardService
 {
-    Task<DashboardDefinition?> GetAsync(string dashboardId);
-    Task<IReadOnlyList<DashboardSummary>> ListAsync(string userId, string[] userRoles);
+    Task<DashboardDefinition?> GetAsync(string dashboardId, string? tenantId = null);
+    Task<IReadOnlyList<DashboardSummary>> ListAsync(string userId, string[] userRoles, string? tenantId = null);
     Task<string> CreateAsync(DashboardDefinition dashboard);
     Task UpdateAsync(DashboardDefinition dashboard);
     Task DeleteAsync(string dashboardId);

--- a/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
@@ -43,7 +43,8 @@ public class JsonFileDashboardService : IDashboardService
                 Directory.CreateDirectory(_baseDir);
             }
 
-            var files = Directory.GetFiles(_baseDir, "*.json");
+            // Scan all subdirectories (tenant dirs + _default)
+            var files = Directory.GetFiles(_baseDir, "*.json", SearchOption.AllDirectories);
             foreach (var file in files)
             {
                 try
@@ -57,6 +58,7 @@ public class JsonFileDashboardService : IDashboardService
                             Id = def.Id,
                             Title = def.Title,
                             Owner = def.Owner,
+                            TenantId = def.TenantId,
                             Sharing = def.Sharing,
                             UpdatedAt = def.UpdatedAt
                         };
@@ -81,15 +83,19 @@ public class JsonFileDashboardService : IDashboardService
         return _locks.GetOrAdd(id, _ => new SemaphoreSlim(1, 1));
     }
 
-    private string GetFilePath(string id)
+    private string GetFilePath(string id, string? tenantId = null)
     {
-        return Path.Combine(_baseDir, $"{id}.json");
+        var dir = string.IsNullOrEmpty(tenantId)
+            ? Path.Combine(_baseDir, "_default")
+            : Path.Combine(_baseDir, tenantId);
+        if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+        return Path.Combine(dir, $"{id}.json");
     }
 
-    public async Task<DashboardDefinition?> GetAsync(string dashboardId)
+    public async Task<DashboardDefinition?> GetAsync(string dashboardId, string? tenantId = null)
     {
         await EnsureInitializedAsync();
-        var path = GetFilePath(dashboardId);
+        var path = GetFilePath(dashboardId, tenantId);
         if (!File.Exists(path)) return null;
 
         var lockObj = GetLock(dashboardId);
@@ -110,15 +116,21 @@ public class JsonFileDashboardService : IDashboardService
         }
     }
 
-    public async Task<IReadOnlyList<DashboardSummary>> ListAsync(string userId, string[] userRoles)
+    public async Task<IReadOnlyList<DashboardSummary>> ListAsync(string userId, string[] userRoles, string? tenantId = null)
     {
         await EnsureInitializedAsync();
-        
+
         var result = new List<DashboardSummary>();
         var isAdmin = userRoles != null && userRoles.Contains("Admin", StringComparer.OrdinalIgnoreCase);
 
         foreach (var summary in _index.Values)
         {
+            // Tenant isolation: only show dashboards from same tenant (or _default)
+            if (tenantId != null && summary.TenantId != null &&
+                !string.Equals(summary.TenantId, tenantId, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
             var isOwner = string.Equals(summary.Owner, userId, StringComparison.OrdinalIgnoreCase);
             var isPublic = string.Equals(summary.Sharing?.Mode, "public", StringComparison.OrdinalIgnoreCase);
             var hasRole = userRoles != null && summary.Sharing?.Roles?.Any(r => userRoles.Contains(r, StringComparer.OrdinalIgnoreCase)) == true;
@@ -144,7 +156,7 @@ public class JsonFileDashboardService : IDashboardService
         dashboard.CreatedAt = DateTime.UtcNow;
         dashboard.UpdatedAt = dashboard.CreatedAt;
 
-        var path = GetFilePath(dashboard.Id);
+        var path = GetFilePath(dashboard.Id, dashboard.TenantId);
         var lockObj = GetLock(dashboard.Id);
 
         await lockObj.WaitAsync();
@@ -163,6 +175,7 @@ public class JsonFileDashboardService : IDashboardService
                 Id = dashboard.Id,
                 Title = dashboard.Title,
                 Owner = dashboard.Owner,
+                TenantId = dashboard.TenantId,
                 Sharing = dashboard.Sharing ?? new SharingDefinition(),
                 UpdatedAt = dashboard.UpdatedAt
             };
@@ -186,7 +199,7 @@ public class JsonFileDashboardService : IDashboardService
 
         dashboard.UpdatedAt = DateTime.UtcNow;
 
-        var path = GetFilePath(dashboard.Id);
+        var path = GetFilePath(dashboard.Id, dashboard.TenantId);
         var lockObj = GetLock(dashboard.Id);
 
         await lockObj.WaitAsync();
@@ -205,6 +218,7 @@ public class JsonFileDashboardService : IDashboardService
                 Id = dashboard.Id,
                 Title = dashboard.Title,
                 Owner = dashboard.Owner,
+                TenantId = dashboard.TenantId,
                 Sharing = dashboard.Sharing ?? new SharingDefinition(),
                 UpdatedAt = dashboard.UpdatedAt
             };
@@ -219,7 +233,12 @@ public class JsonFileDashboardService : IDashboardService
     {
         await EnsureInitializedAsync();
 
-        var path = GetFilePath(dashboardId);
+        string? tenantId = null;
+        if (_index.TryGetValue(dashboardId, out var summary))
+        {
+            tenantId = summary.TenantId;
+        }
+        var path = GetFilePath(dashboardId, tenantId);
         var lockObj = GetLock(dashboardId);
 
         await lockObj.WaitAsync();

--- a/src/WalkingTec.Mvvm.Mvc/_DashboardController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_DashboardController.cs
@@ -31,18 +31,25 @@ namespace WalkingTec.Mvvm.Mvc
             return (userId, roles);
         }
 
+        private string GetTenantId()
+        {
+            return Wtm?.LoginUserInfo?.TenantCode ?? "";
+        }
+
         [HttpGet("list")]
         public async Task<IActionResult> List()
         {
             var (userId, roles) = GetUserInfo();
-            var list = await _dashboardService.ListAsync(userId, roles);
+            var tenantId = GetTenantId();
+            var list = await _dashboardService.ListAsync(userId, roles, tenantId);
             return Ok(list);
         }
 
         [HttpGet("{id}")]
         public async Task<IActionResult> Get(string id)
         {
-            var dashboard = await _dashboardService.GetAsync(id);
+            var tenantId = GetTenantId();
+            var dashboard = await _dashboardService.GetAsync(id, tenantId);
             if (dashboard == null) return NotFound();
 
             var (userId, roles) = GetUserInfo();
@@ -61,6 +68,7 @@ namespace WalkingTec.Mvvm.Mvc
 
             var (userId, _) = GetUserInfo();
             dashboard.Owner = userId;
+            dashboard.TenantId = GetTenantId();
 
             var id = await _dashboardService.CreateAsync(dashboard);
             return Ok(id);

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardControllerTests.cs
@@ -52,7 +52,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         public async Task List_returns_200_with_empty_list()
         {
             SetUser("bob");
-            _service.Setup(x => x.ListAsync("bob", It.IsAny<string[]>()))
+            _service.Setup(x => x.ListAsync("bob", It.IsAny<string[]>(), It.IsAny<string?>()))
                 .ReturnsAsync(new List<DashboardSummary>());
 
             var result = await _controller.List() as OkObjectResult;
@@ -78,7 +78,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         [TestMethod]
         public async Task Get_returns_404_for_unknown()
         {
-            _service.Setup(x => x.GetAsync("unknown")).ReturnsAsync((DashboardDefinition?)null);
+            _service.Setup(x => x.GetAsync("unknown", It.IsAny<string?>())).ReturnsAsync((DashboardDefinition?)null);
 
             var result = await _controller.Get("unknown") as NotFoundResult;
 
@@ -90,7 +90,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         {
             SetUser("alice");
             var def = new DashboardDefinition { Id = "id1", Owner = "bob" };
-            _service.Setup(x => x.GetAsync("id1")).ReturnsAsync(def);
+            _service.Setup(x => x.GetAsync("id1", It.IsAny<string?>())).ReturnsAsync(def);
             _service.Setup(x => x.CanAccess(def, "alice", It.IsAny<string[]>())).Returns(false);
 
             var result = await _controller.Get("id1") as ForbidResult;
@@ -104,7 +104,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             SetUser("alice");
             var existing = new DashboardDefinition { Id = "id1", Owner = "bob" };
             var update = new DashboardDefinition { Id = "id1" };
-            _service.Setup(x => x.GetAsync("id1")).ReturnsAsync(existing);
+            _service.Setup(x => x.GetAsync("id1", It.IsAny<string?>())).ReturnsAsync(existing);
             _service.Setup(x => x.CanEdit(existing, "alice", It.IsAny<string[]>())).Returns(false);
 
             var result = await _controller.Update("id1", update) as ForbidResult;
@@ -115,7 +115,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         [TestMethod]
         public async Task Delete_returns_404_for_unknown()
         {
-            _service.Setup(x => x.GetAsync("unknown")).ReturnsAsync((DashboardDefinition?)null);
+            _service.Setup(x => x.GetAsync("unknown", It.IsAny<string?>())).ReturnsAsync((DashboardDefinition?)null);
 
             var result = await _controller.Delete("unknown") as NotFoundResult;
 
@@ -127,7 +127,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         {
             SetUser("alice");
             var existing = new DashboardDefinition { Id = "id1", Owner = "bob" };
-            _service.Setup(x => x.GetAsync("id1")).ReturnsAsync(existing);
+            _service.Setup(x => x.GetAsync("id1", It.IsAny<string?>())).ReturnsAsync(existing);
             _service.Setup(x => x.CanEdit(existing, "alice", It.IsAny<string[]>())).Returns(false);
 
             var result = await _controller.Delete("id1") as ForbidResult;
@@ -138,7 +138,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         [TestMethod]
         public async Task GetWidgetData_returns_404_for_unknown_dashboard()
         {
-            _service.Setup(x => x.GetAsync("unknown")).ReturnsAsync((DashboardDefinition?)null);
+            _service.Setup(x => x.GetAsync("unknown", It.IsAny<string?>())).ReturnsAsync((DashboardDefinition?)null);
 
             var result = await _controller.GetWidgetData("unknown", "w1", CancellationToken.None) as NotFoundResult;
 
@@ -150,7 +150,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         {
             SetUser("bob");
             var def = new DashboardDefinition { Id = "id1", Owner = "bob" };
-            _service.Setup(x => x.GetAsync("id1")).ReturnsAsync(def);
+            _service.Setup(x => x.GetAsync("id1", It.IsAny<string?>())).ReturnsAsync(def);
             _service.Setup(x => x.CanAccess(def, "bob", It.IsAny<string[]>())).Returns(true);
 
             var result = await _controller.GetWidgetData("id1", "w1", CancellationToken.None) as NotFoundResult;
@@ -163,7 +163,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         {
             SetUser("alice");
             var def = new DashboardDefinition { Id = "id1", Owner = "bob" };
-            _service.Setup(x => x.GetAsync("id1")).ReturnsAsync(def);
+            _service.Setup(x => x.GetAsync("id1", It.IsAny<string?>())).ReturnsAsync(def);
             _service.Setup(x => x.CanAccess(def, "alice", It.IsAny<string[]>())).Returns(false);
 
             var result = await _controller.GetWidgetData("id1", "w1", CancellationToken.None) as ForbidResult;

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/JsonFileDashboardServiceTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/JsonFileDashboardServiceTests.cs
@@ -149,5 +149,30 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             _service.CanEdit(def, "user2", Array.Empty<string>()).Should().BeFalse();
             _service.CanEdit(def, "user2", new[] { "Manager" }).Should().BeFalse();
         }
+
+        [TestMethod]
+        public async Task Tenant_isolation_separates_dashboards()
+        {
+            await _service.CreateAsync(new DashboardDefinition { Owner = "user1", Title = "Tenant A", TenantId = "tenantA" });
+            await _service.CreateAsync(new DashboardDefinition { Owner = "user1", Title = "Tenant B", TenantId = "tenantB" });
+
+            var listA = await _service.ListAsync("user1", Array.Empty<string>(), "tenantA");
+            listA.Should().HaveCount(1);
+            listA[0].Title.Should().Be("Tenant A");
+
+            var listB = await _service.ListAsync("user1", Array.Empty<string>(), "tenantB");
+            listB.Should().HaveCount(1);
+            listB[0].Title.Should().Be("Tenant B");
+        }
+
+        [TestMethod]
+        public async Task Default_tenant_dashboards_visible_without_tenant_filter()
+        {
+            await _service.CreateAsync(new DashboardDefinition { Owner = "user1", Title = "Default" });
+
+            var list = await _service.ListAsync("user1", Array.Empty<string>());
+            list.Should().HaveCount(1);
+            list[0].Title.Should().Be("Default");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `TenantId` property to `DashboardDefinition` and `DashboardSummary`
- Update `IDashboardService.GetAsync`/`ListAsync` with optional `tenantId` parameter (backward-compatible)
- `JsonFileDashboardService` stores dashboards in `{tenantId}/` subdirectories (`_default/` for null tenant), with tenant-aware filtering in `ListAsync`
- Controller reads `TenantCode` from `LoginUserInfo` and passes to service layer
- Fix Moq expression tree CS0854 errors by explicitly passing `It.IsAny<string?>()` for optional tenantId

Closes #190

## Test plan
- [x] `Tenant_isolation_separates_dashboards` — verifies dashboards in different tenants are isolated
- [x] `Default_tenant_dashboards_visible_without_tenant_filter` — verifies null-tenant dashboards work
- [x] All 22 dashboard tests pass (8 controller + 14 service)
- [x] Build succeeds (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)