### PR TITLE
docs(etl): PR5 — developer docs, integration tests, CHANGELOG

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,6 +28,7 @@ jobs:
         dotnet test WalkingTec.Mvvm.sln \
           --no-build -c Release \
           --verbosity normal \
+          --filter "TestCategory!=Integration" \
           --logger "trx;LogFileName=test-results.trx" \
           --collect:"XPlat Code Coverage" \
           --settings coverlet.runsettings \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # 更新日志
 
+## [8.6.0] - TBD
+
+### Added
+- **ETL Module** (`WalkingTec.Mvvm.Etl`): Batch data import pipeline
+  - Support for MSSQL and Oracle source databases
+  - `EtlBulkJob` (zero-transform) and `EtlMappedJob<TIn,TOut>` (with transform) base classes
+  - Staging Table → MERGE INTO pattern for idempotent upserts
+  - Three watermark modes: FullLoad, Timestamp, Identity
+  - Quartz.NET-based scheduling with dynamic cron management
+  - Management UI: Job CRUD, execution history, real-time progress monitoring
+  - Operations: trigger now, pause, resume, abort, skip next, reschedule
+  - RBAC integration via existing PrivilegeFilter
+  - `MockBulkLoader` and `MockEtlSource` for unit testing
+  - Developer documentation (`docs/etl-module.md`)
+  - Docker Compose test environment (`test/docker-compose.etl-test.yml`)
+  - 65+ unit tests, 15 integration tests
+
 ## 8.5.1 (2026-03-11)
 
 ### 修復

--- a/WalkingTec.Mvvm.sln
+++ b/WalkingTec.Mvvm.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -60,6 +60,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WalkingTec.Mvvm.Vue3Demo", "demo\WalkingTec.Mvvm.Vue3Demo\WalkingTec.Mvvm.Vue3Demo.csproj", "{411690A4-0021-4509-BF24-900437B5DC6E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WalkingTec.Mvvm.Mvc.Tests", "src\WalkingTec.Mvvm.Mvc.Tests\WalkingTec.Mvvm.Mvc.Tests.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WalkingTec.Mvvm.Etl", "src\WalkingTec.Mvvm.Etl\WalkingTec.Mvvm.Etl.csproj", "{BA66447E-9130-423D-9A5B-67F4394D27D5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WalkingTec.Mvvm.Etl.Test", "test\WalkingTec.Mvvm.Etl.Test\WalkingTec.Mvvm.Etl.Test.csproj", "{62BB44F3-A478-42BF-B972-E6AD0347466B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -139,6 +143,14 @@ Global
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA66447E-9130-423D-9A5B-67F4394D27D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA66447E-9130-423D-9A5B-67F4394D27D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA66447E-9130-423D-9A5B-67F4394D27D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA66447E-9130-423D-9A5B-67F4394D27D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62BB44F3-A478-42BF-B972-E6AD0347466B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62BB44F3-A478-42BF-B972-E6AD0347466B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62BB44F3-A478-42BF-B972-E6AD0347466B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62BB44F3-A478-42BF-B972-E6AD0347466B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -163,6 +175,8 @@ Global
 		{D4104589-85BE-446A-A123-1E0FD1538A7B} = {840C6DED-B5D5-4763-A6A7-6F615B72EC10}
 		{411690A4-0021-4509-BF24-900437B5DC6E} = {DE184A47-CF5F-41C0-AB7D-CAD0AF2DAE75}
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890} = {46CFCDC6-4358-48EB-A901-5618B6530CEE}
+		{BA66447E-9130-423D-9A5B-67F4394D27D5} = {46CFCDC6-4358-48EB-A901-5618B6530CEE}
+		{62BB44F3-A478-42BF-B972-E6AD0347466B} = {55D5759D-10E9-4FC8-B2EC-A824CF6D74A1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8D25EAAD-E43A-466A-95DA-ECE1F3C462DC}

--- a/docs/etl-module.md
+++ b/docs/etl-module.md
@@ -1,0 +1,602 @@
+# ETL Module — 批量資料導入
+
+WTM ETL 模組提供從外部 Oracle / MSSQL 資料庫定期批量匯入資料的完整管線，包含排程、監控、管理介面。
+
+---
+
+## Quick Start（5 分鐘）
+
+### 1. 加入專案參考
+
+```xml
+<ProjectReference Include="..\WalkingTec.Mvvm.Etl\WalkingTec.Mvvm.Etl.csproj" />
+```
+
+或未來 NuGet 發布後：
+
+```bash
+dotnet add package WalkingTec.Mvvm.Etl
+```
+
+### 2. 註冊 ETL 服務
+
+```csharp
+// Program.cs 或 Startup.cs
+services.AddWtmEtl();
+```
+
+此方法註冊三個元件：
+
+| 元件 | 生命週期 | 用途 |
+|------|---------|------|
+| `EtlSchedulerService` | Singleton | 排程管理 API（啟用/暫停/中止等） |
+| `EtlProgressTracker` | Singleton | 執行進度追蹤（記憶體內） |
+| `EtlHostedService` | HostedService | 應用啟動時初始化 Quartz Scheduler |
+
+### 3. 註冊 EF Models
+
+```csharp
+// DataContext.OnModelCreating
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    base.OnModelCreating(modelBuilder);
+    modelBuilder.ApplyEtlModels();
+}
+```
+
+此方法建立兩張表：
+
+- `EtlJobDefinitions` — Job 定義（含唯一索引 `Name`、索引 `Status`）
+- `EtlRunLogs` — 執行記錄（含索引 `JobId`、`StartedAt`，FK → `EtlJobDefinitions`）
+
+### 4. 設定連線字串
+
+```json
+// appsettings.json
+{
+  "Connections": [
+    { "Key": "default", "Value": "Server=...;Database=WtmApp;..." },
+    { "Key": "UpstreamOracle", "Value": "Data Source=...;User Id=...;Password=...;", "DbType": "Oracle" },
+    { "Key": "UpstreamMssql", "Value": "Server=...;Database=...;User Id=...;Password=...;", "DbType": "SqlServer" }
+  ]
+}
+```
+
+> **安全提醒**：連線字串僅存於 `appsettings.json` 或環境變數，**絕不存入資料庫**。
+
+### 5. 執行 Migration
+
+```bash
+dotnet ef migrations add AddEtlTables
+dotnet ef database update
+```
+
+### 6. 透過管理介面建立 Job
+
+啟動應用後：
+
+1. 進入 `/_EtlJob/Index` — 管理所有 ETL Job
+2. 點「新增」— 填寫名稱、Cron 表達式、來源連線、Job 類別名稱
+3. 設定 Status 為 `Enabled` — Job 即開始按 Cron 排程執行
+4. 在 `/_EtlRunLog/Index` 查看執行歷史
+5. 在 `/_EtlMonitor/Running` 即時監控進度
+
+---
+
+## 架構概覽
+
+```
+                  ┌──────────────────┐
+Quartz Trigger ──▶│  EtlQuartzJob    │
+                  │  (reads config)  │
+                  └────────┬─────────┘
+                           ▼
+                  ┌──────────────────┐
+                  │ EtlPipelineExecutor │
+                  └────────┬─────────┘
+                           │
+          ┌────────────────┼────────────────┐
+          ▼                ▼                ▼
+   ┌──────────┐    ┌──────────┐    ┌──────────┐
+   │ Extract  │    │Transform │    │  Load    │
+   │(IEtlSource)│  │(optional)│    │(IBulkLoader)│
+   └──────────┘    └──────────┘    └────┬─────┘
+                                        ▼
+                              ┌──────────────────┐
+                              │  Staging Table   │
+                              │  (TRUNCATE first)│
+                              └────────┬─────────┘
+                                       ▼
+                              ┌──────────────────┐
+                              │  MERGE INTO      │
+                              │  Target Table    │
+                              └──────────────────┘
+```
+
+**流程摘要**：Extract（串流讀取）→ Transform（選用）→ Load（批量寫入 Staging）→ Merge（Upsert 至目標）
+
+---
+
+## API 參考
+
+### EtlPipelineConfig
+
+Pipeline 單次執行的完整配置。
+
+```csharp
+public record EtlPipelineConfig
+{
+    public Guid JobId { get; init; }                   // Job ID（用於記錄/進度）
+    public string JobName { get; init; }               // 顯示名稱
+    public string SourceConnectionString { get; init; } // 來源資料庫連線
+    public string TargetConnectionString { get; init; } // 目標資料庫連線
+    public string QueryTemplate { get; init; }         // SQL 查詢（含 @watermark 參數）
+    public string TargetTableName { get; init; }       // 目標表名
+    public string MergeKeyColumn { get; init; }        // MERGE ON 的 Business Key
+    public int BatchSize { get; init; } = 50_000;      // 每批筆數
+    public StagingTableSpec StagingTable { get; init; } // Staging 表結構
+    public Func<DataTable, DataTable>? TransformFunc { get; init; } // 轉換函式
+}
+```
+
+### StagingTableSpec
+
+定義 Staging 表的 DDL（Column 名稱 + 原生 SQL 類型）。
+
+```csharp
+public class StagingTableSpec
+{
+    public StagingTableSpec(string tableName, params StagingColumn[] columns);
+
+    public string TableName { get; }
+    public IReadOnlyList<StagingColumn> Columns { get; }
+}
+
+public record StagingColumn(string Name, string SqlType);
+```
+
+**範例**：
+
+```csharp
+new StagingTableSpec("_etl_staging_orders",
+    new StagingColumn("OrderId", "BIGINT"),          // MSSQL
+    new StagingColumn("CustomerName", "NVARCHAR(200)"),
+    new StagingColumn("Amount", "DECIMAL(18,2)"),
+    new StagingColumn("OrderDate", "DATETIME2")
+);
+```
+
+### EtlPipelineExecutor
+
+Pipeline 引擎，協調 Extract → Transform → Load → Merge 流程。
+
+```csharp
+public class EtlPipelineExecutor
+{
+    public EtlPipelineExecutor(IEtlSource source, IBulkLoader loader, IProgress<EtlProgress>? progress = null);
+    public async Task<EtlExecutionResult> ExecuteAsync(EtlPipelineConfig config, WatermarkStrategy watermark, CancellationToken ct);
+}
+```
+
+**行為**：
+
+1. `EnsureStagingTable` — 不存在則自動建立
+2. `TruncateStaging` — 清空 Staging
+3. 逐批 Extract → Transform → BulkLoad，每批後更新 Watermark 暫存值與回報進度
+4. `Merge` — 從 Staging Upsert 至目標表
+5. 成功 → `CommitPendingValue()`；失敗/中止 → `DiscardPendingValue()`
+
+### EtlExecutionResult
+
+Pipeline 執行結果。
+
+```csharp
+public class EtlExecutionResult
+{
+    public bool Success { get; init; }
+    public bool Aborted { get; init; }
+    public int ExtractedRows { get; init; }
+    public int LoadedRows { get; init; }
+    public int ErrorRows { get; init; }
+    public long ElapsedMs { get; init; }
+    public string? ErrorMessage { get; init; }
+    public string? NewWatermarkValue { get; init; }
+}
+```
+
+### IEtlSource / IBulkLoader
+
+```csharp
+public interface IEtlSource : IDisposable
+{
+    IAsyncEnumerable<DataTable> ExtractBatchesAsync(
+        string connectionString, string queryTemplate,
+        object? watermarkValue, int batchSize,
+        CancellationToken ct);
+}
+
+public interface IBulkLoader
+{
+    Task BulkLoadAsync(string cs, string stagingTable, DataTable batch, CancellationToken ct);
+    Task MergeAsync(string cs, string staging, string target, string mergeKey, CancellationToken ct);
+    Task TruncateStagingAsync(string cs, string stagingTable, CancellationToken ct);
+    Task EnsureStagingTableAsync(string cs, string stagingTable, StagingTableSpec spec, CancellationToken ct);
+}
+```
+
+**實作**：
+
+| 介面 | MSSQL | Oracle |
+|------|-------|--------|
+| `IEtlSource` | `MssqlSource`（SqlDataReader） | `OracleSource`（OracleDataReader） |
+| `IBulkLoader` | `MssqlBulkLoader`（SqlBulkCopy + MERGE） | `OracleBulkLoader`（Array Binding + MERGE INTO） |
+
+### EtlSourceFactory
+
+根據 `DBTypeEnum` 建立 Source / Loader 實例。
+
+```csharp
+public static class EtlSourceFactory
+{
+    public static IEtlSource CreateSource(DBTypeEnum dbType);    // SqlServer, Oracle
+    public static IBulkLoader CreateLoader(DBTypeEnum targetDbType);
+}
+```
+
+不支援的 `DBTypeEnum` 會拋出 `NotSupportedException`。
+
+---
+
+## Watermark 策略
+
+### 三種模式
+
+| 模式 | 說明 | 適用場景 |
+|------|------|---------|
+| `FullLoad` | 每次全量載入，不使用 watermark | 來源小（< 10 萬）或無法識別變更 |
+| `Timestamp` | 用時間欄位做增量（`WHERE UpdatedAt > @watermark`） | 有可靠 UpdatedAt 的業務表 |
+| `Identity` | 用自增 ID 做增量（`WHERE Id > @watermark`） | Append-only 日誌型資料 |
+
+### WatermarkStrategy API
+
+```csharp
+public class WatermarkStrategy
+{
+    public WatermarkStrategy(EtlWatermarkType type, string? column, string? currentValue, string timeZone = "UTC");
+
+    public string BuildWhereClause();           // "(1=1)" 或 "{column} > @watermark"
+    public object? GetParameterValue();          // @watermark 的參數值（已轉時區）
+    public void UpdateFromBatchMax(object max);  // 暫存批次最大值
+    public string? CommitPendingValue();          // 確認新 watermark（成功後呼叫）
+    public void DiscardPendingValue();           // 丟棄暫存值（失敗後呼叫）
+}
+```
+
+### 首次執行行為
+
+| `InitialWatermarkValue` | 行為 |
+|------------------------|------|
+| `null` | 全量載入（`WHERE 1=1`） |
+| `"2026-01-01T00:00:00Z"` | 從該時間點開始 |
+| `"0"` | 從 ID = 0 開始 |
+
+### 時區處理
+
+- **儲存**：統一 UTC
+- **查詢**：轉回 `WatermarkTimeZone` 指定的時區（IANA 格式，如 `"Asia/Taipei"`）
+- **常見坑**：Asia/Taipei (+8) 的日界線問題 — 確保來源 DB 的時間欄位語義明確
+
+---
+
+## Staging Table 策略
+
+### MSSQL
+
+- 普通表 + `TRUNCATE TABLE`
+- 首次自動 `CREATE TABLE IF NOT EXISTS`
+- Column 定義用 MSSQL 原生類型
+- Merge 語法：`MERGE [target] AS t USING [staging] AS s ON t.[key] = s.[key] ...`
+
+### Oracle
+
+- 普通表 + `TRUNCATE TABLE`（不使用 Global Temp Table）
+- 首次自動 CREATE（需 `CREATE TABLE` 權限）
+- 檢查表存在用 `USER_TABLES`（表名自動 `ToUpperInvariant()`）
+- Merge 語法：`MERGE INTO target t USING staging s ON (t.key = s.key) ...`
+- **表名建議全大寫**（Oracle 慣例）
+
+### MSSQL / Oracle 類型對照
+
+| 用途 | MSSQL | Oracle |
+|------|-------|--------|
+| 字串 | `NVARCHAR(N)` | `VARCHAR2(N)` |
+| 整數 | `BIGINT` | `NUMBER(19)` |
+| 小數 | `DECIMAL(18,2)` | `NUMBER(18,2)` |
+| 時間 | `DATETIME2` | `TIMESTAMP` |
+| 布林 | `BIT` | `NUMBER(1)` |
+
+---
+
+## 排程系統
+
+### Quartz.NET 整合
+
+ETL 模組使用 Quartz.NET 3.x 做排程。Cron 格式為 **6-7 欄位**（含秒），不同於 Unix 5 欄位格式。
+
+```
+秒 分 時 日 月 週 [年]
+```
+
+| 範例 | 意義 |
+|------|------|
+| `0 0 2 * * ?` | 每天凌晨 2:00 |
+| `0 0/30 * * * ?` | 每 30 分鐘 |
+| `0 0 2 ? * MON-FRI` | 每週一到五凌晨 2:00 |
+
+### EtlSchedulerService API
+
+```csharp
+public class EtlSchedulerService
+{
+    // 啟動時載入所有 Enabled/Failed Job
+    public virtual async Task LoadJobsFromDbAsync();
+
+    // 立即執行（Trigger = Manual）
+    public virtual async Task TriggerNowAsync(Guid jobId);
+
+    // 暫停/恢復排程觸發
+    public virtual async Task PauseAsync(Guid jobId);
+    public virtual async Task ResumeAsync(Guid jobId);
+
+    // 更新 Cron 並重新排程
+    public virtual async Task RescheduleAsync(Guid jobId, string newCron);
+
+    // 中止執行中的 Job（透過 CancellationToken）
+    public virtual async Task AbortAsync(Guid jobId);
+
+    // 跳過下次排程
+    public virtual async Task SkipNextAsync(Guid jobId);
+
+    // 啟用/停用 Job
+    public virtual async Task EnableAsync(Guid jobId);
+    public virtual async Task DisableAsync(Guid jobId);
+
+    // 從歷史記錄重跑（還原 watermark）
+    public virtual async Task RerunFromSnapshotAsync(Guid runLogId);
+
+    // 判斷是否可執行
+    public static bool ShouldExecute(EtlJobDefinition job);
+}
+```
+
+### EtlQuartzJob
+
+Quartz 觸發後的橋接器，標記 `[DisallowConcurrentExecution]` 防止同一 Job 並行執行。
+
+**執行流程**：
+
+1. 從 `JobDataMap` 取得 `EtlJobDefinitionId`
+2. 檢查 `SkipCount`（> 0 則跳過並記錄）
+3. 檢查 `Status`（僅 Enabled/Failed 可執行）
+4. 設定 `Status = Running`
+5. 從 `Configs.Connections` 取得來源連線字串
+6. 建立 Source、Loader、WatermarkStrategy、PipelineConfig
+7. 執行 `EtlPipelineExecutor.ExecuteAsync()`
+8. 成功：commit watermark → Status = Enabled
+9. 失敗：discard watermark → Status = Failed
+10. 寫入 `EtlRunLog`，清除進度追蹤
+
+### EtlProgressTracker
+
+Thread-safe 的記憶體內進度字典（`ConcurrentDictionary`）。
+
+```csharp
+public class EtlProgressTracker
+{
+    public void Update(EtlProgress progress);       // 更新/新增進度
+    public EtlProgress? Get(Guid jobId);             // 取得單一 Job 進度
+    public IReadOnlyList<EtlProgress> GetAll();     // 取得所有執行中的 Job
+    public void Remove(Guid jobId);                  // 清除（Job 完成後）
+}
+```
+
+### EtlProgress
+
+```csharp
+public record EtlProgress
+{
+    public Guid JobId { get; init; }
+    public string JobName { get; init; }
+    public int ProcessedRows { get; init; }
+    public int? TotalRows { get; init; }     // null = 未知
+    public string Phase { get; init; }       // "Loading", "Merging", "Done"
+    public double? RowsPerSecond { get; init; }
+    public DateTime StartedAt { get; init; }
+}
+```
+
+---
+
+## 資料模型
+
+### EtlJobDefinition
+
+持久化的 Job 配置，繼承 `BasePoco`（Guid ID）。
+
+| 屬性 | 類型 | 說明 |
+|------|------|------|
+| `Name` | string (required, max 100) | 唯一名稱 |
+| `Description` | string? (max 500) | 描述 |
+| `CronExpression` | string (required) | Quartz 6/7 欄位格式 |
+| `JobClassName` | string (required, max 500) | Job 實作類別全名 |
+| `Status` | EtlJobStatus | 狀態（Enabled/Disabled/Running/Paused/Failed） |
+| `SourceCsKey` | string (required, max 100) | 對應 appsettings 的連線 Key |
+| `SourceDbType` | DBTypeEnum | 來源資料庫類型 |
+| `WatermarkType` | EtlWatermarkType | 增量策略 |
+| `WatermarkColumn` | string? | Watermark 欄位名 |
+| `LastWatermarkValue` | string? | 上次成功的 watermark（JSON） |
+| `InitialWatermarkValue` | string? | 首次執行起始值 |
+| `WatermarkTimeZone` | string | IANA 時區（預設 "UTC"） |
+| `SkipCount` | int | 跳過次數（每跳過一次 -1） |
+| `RetryCount` | int | 最大重試次數（預設 3） |
+| `TimeoutMinutes` | int | 執行超時分鐘（預設 60） |
+| `LastRunAt` | DateTime? | 上次完成時間 |
+| `NextFireAt` | DateTime? | 下次觸發時間 |
+| `LastError` | string? (max 2000) | 上次錯誤訊息 |
+
+### EtlRunLog
+
+每次執行的審計記錄。
+
+| 屬性 | 類型 | 說明 |
+|------|------|------|
+| `JobId` | Guid | FK → EtlJobDefinition |
+| `Trigger` | EtlRunTrigger | Scheduled / Manual / Retry |
+| `Result` | EtlRunResult | Success / Failed / Aborted / Skipped |
+| `ExtractedRows` | int | 讀取筆數 |
+| `LoadedRows` | int | 寫入 Staging 筆數 |
+| `ErrorRows` | int | 失敗筆數 |
+| `ElapsedMs` | long | 總耗時（ms） |
+| `ErrorMessage` | string? (max 4000) | 例外資訊 |
+| `StartedAt` | DateTime | UTC 開始時間 |
+| `FinishedAt` | DateTime? | UTC 結束時間 |
+| `WatermarkSnapshot` | string? | 執行前的 watermark（用於重跑） |
+
+### 列舉
+
+```csharp
+public enum EtlJobStatus     { Enabled, Disabled, Running, Paused, Failed }
+public enum EtlRunTrigger     { Scheduled, Manual, Retry }
+public enum EtlRunResult      { Success, Failed, Aborted, Skipped }
+public enum EtlWatermarkType  { FullLoad, Timestamp, Identity }
+```
+
+---
+
+## 管理介面
+
+### 控制器端點
+
+#### `_EtlJobController`（Job 管理）
+
+| 端點 | 方法 | 說明 |
+|------|------|------|
+| `/_EtlJob/Index` | GET | Job 列表頁面 |
+| `/_EtlJob/Search` | POST | 搜尋 Job（Name/Status/SourceDbType） |
+| `/_EtlJob/Create` | GET/POST | 新增 Job |
+| `/_EtlJob/Edit/{id}` | GET/POST | 編輯 Job |
+| `/_EtlJob/Delete/{id}` | GET/POST | 刪除 Job（Running 時禁止刪除） |
+| `/_EtlJob/TriggerNow?id=` | POST | 立即執行 |
+| `/_EtlJob/Pause?id=` | POST | 暫停排程 |
+| `/_EtlJob/Resume?id=` | POST | 恢復排程 |
+| `/_EtlJob/Abort?id=` | POST | 中止執行中的 Job |
+| `/_EtlJob/SkipNext?id=` | POST | 跳過下次排程 |
+| `/_EtlJob/Reschedule?id=` | POST | 更新 Cron 表達式（body: newCron） |
+
+#### `_EtlRunLogController`（執行歷史）
+
+| 端點 | 方法 | 說明 |
+|------|------|------|
+| `/_EtlRunLog/Index?jobId=` | GET | 執行記錄列表（可依 Job 篩選） |
+| `/_EtlRunLog/Search` | POST | 搜尋記錄（JobId/Result/Trigger/日期區間） |
+| `/_EtlRunLog/Rerun?runLogId=` | POST | 從歷史快照重跑 |
+
+#### `_EtlMonitorController`（即時監控）
+
+| 端點 | 方法 | 說明 |
+|------|------|------|
+| `/_EtlMonitor/Running` | GET | 列出所有執行中 Job（JSON） |
+| `/_EtlMonitor/Progress?jobId=` | GET | 單一 Job 進度（404 = 未執行） |
+
+### RBAC 權限
+
+所有控制器都透過 WTM 的 `[ActionDescription]` + `PrivilegeFilter` 控制存取。需要在 WTM 系統管理中配置對應的功能權限：
+
+- `ETL Job 管理` — 對應 `_EtlJobController`
+- `ETL 執行歷史` — 對應 `_EtlRunLogController`
+- `ETL 即時監控` — 對應 `_EtlMonitorController`
+
+---
+
+## 安全模型
+
+### SQL 注入防護
+
+- `QueryTemplate` 是開發者撰寫的 trusted input（寫在程式碼/設定中）
+- 所有動態值（watermark）一律用**參數化查詢**（`@watermark`）
+- **嚴禁** string interpolation 組合 SQL
+
+### 連線字串管理
+
+- 透過 `Configs.Connections`（`appsettings.json` 或環境變數）
+- 不存入資料庫 — `EtlJobDefinition.SourceCsKey` 只存 Key 名稱
+- 生產環境建議用環境變數或 Azure Key Vault
+
+---
+
+## 測試
+
+### 單元測試
+
+模組提供兩個 mock 類別，位於 `WalkingTec.Mvvm.Etl.Testing`：
+
+#### MockEtlSource
+
+```csharp
+var source = new MockEtlSource();
+source.SetData(testDataTable);  // 設定測試資料
+```
+
+#### MockBulkLoader
+
+```csharp
+var loader = new MockBulkLoader();
+loader.FailOnBatch = 3;           // 模擬第 3 批失敗
+
+// 執行後檢查
+Assert.AreEqual(5, loader.TotalRows);
+Assert.IsTrue(loader.MergeCalled);
+Assert.IsTrue(loader.TruncateCalled);
+```
+
+### 整合測試
+
+整合測試需要真實資料庫。參見 `test/docker-compose.etl-test.yml` 啟動 MSSQL + Oracle 測試環境。
+
+```bash
+# 啟動測試資料庫
+docker compose -f test/docker-compose.etl-test.yml up -d
+
+# 等待健康檢查通過
+docker compose -f test/docker-compose.etl-test.yml ps
+
+# 執行整合測試（需要 Integration category）
+dotnet test test/WalkingTec.Mvvm.Etl.Test \
+  --filter "TestCategory=Integration" -c Release
+
+# 清理
+docker compose -f test/docker-compose.etl-test.yml down -v
+```
+
+---
+
+## 故障排除
+
+### 常見錯誤
+
+| 錯誤 | 原因 | 解法 |
+|------|------|------|
+| `ETL source not supported` | `SourceDbType` 不在支援範圍 | 確認使用 `SqlServer` 或 `Oracle` |
+| `Staging table creation failed` | 無 `CREATE TABLE` 權限 | 請 DBA 預建 staging 表 |
+| `MERGE failed: duplicate key` | `MergeKeyColumn` 不唯一 | 確認 merge key 是 business key |
+| `Watermark column not found` | `DataTable` 無該欄位 | 確認 SQL 查詢結果包含 watermark 欄位 |
+| `Connection key not found` | `SourceCsKey` 不在 Configs | 確認 `appsettings.json` 中有該連線 |
+| `Job is already running` | 觸發過快 | `[DisallowConcurrentExecution]` 保護中 |
+| `Invalid Cron Expression` | 格式錯誤 | 使用 Quartz 6/7 欄位格式（含秒） |
+
+### 效能調優
+
+- **BatchSize 建議**：MSSQL `50,000`，Oracle `10,000 ~ 30,000`
+- **MERGE 大量資料**時建議在 staging 表的 merge key 欄位建 index
+- **監控 `ElapsedMs` 趨勢** — 異常增加時檢查來源 DB 效能或網路延遲
+- **Oracle Array Binding** 使用 `cmd.ArrayBindCount` 做批量插入，比 `OracleBulkCopy` 更穩定

--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
@@ -1,0 +1,150 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Quartz;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Core.Extensions;
+using WalkingTec.Mvvm.Etl.Scheduling;
+using WalkingTec.Mvvm.Etl.ViewModels;
+using WalkingTec.Mvvm.Mvc;
+
+namespace WalkingTec.Mvvm.Mvc;
+
+[ActionDescription("ETL Job 管理")]
+public class _EtlJobController : BaseController
+{
+    private readonly EtlSchedulerService _scheduler;
+
+    public _EtlJobController(EtlSchedulerService scheduler)
+    {
+        _scheduler = scheduler;
+    }
+
+    // ─── CRUD ───
+
+    [ActionDescription("Job 列表")]
+    public IActionResult Index()
+    {
+        var vm = Wtm.CreateVM<EtlJobListVM>();
+        return PartialView(vm);
+    }
+
+    [ActionDescription("Job 列表")]
+    [HttpPost]
+    public IActionResult Search(EtlJobSearcher searcher)
+    {
+        var vm = Wtm.CreateVM<EtlJobListVM>();
+        vm.Searcher = searcher;
+        return Content(vm.GetJson());
+    }
+
+    [ActionDescription("新增 Job")]
+    public IActionResult Create()
+    {
+        var vm = Wtm.CreateVM<EtlJobDefinitionVM>();
+        return PartialView(vm);
+    }
+
+    [ActionDescription("新增 Job")]
+    [HttpPost]
+    public IActionResult Create(EtlJobDefinitionVM vm)
+    {
+        if (!ModelState.IsValid)
+            return PartialView(vm);
+        vm.DoAdd();
+        if (!ModelState.IsValid)
+            return PartialView(vm);
+        return FFResult().CloseDialog().RefreshGrid();
+    }
+
+    [ActionDescription("編輯 Job")]
+    public IActionResult Edit(Guid id)
+    {
+        var vm = Wtm.CreateVM<EtlJobDefinitionVM>(id);
+        return PartialView(vm);
+    }
+
+    [ActionDescription("編輯 Job")]
+    [HttpPost]
+    public IActionResult Edit(EtlJobDefinitionVM vm)
+    {
+        if (!ModelState.IsValid)
+            return PartialView(vm);
+        vm.DoEdit();
+        if (!ModelState.IsValid)
+            return PartialView(vm);
+        return FFResult().CloseDialog().RefreshGrid();
+    }
+
+    [ActionDescription("刪除 Job")]
+    public IActionResult Delete(Guid id)
+    {
+        var vm = Wtm.CreateVM<EtlJobDefinitionVM>(id);
+        return PartialView(vm);
+    }
+
+    [ActionDescription("刪除 Job")]
+    [HttpPost]
+    public IActionResult Delete(Guid id, IFormCollection noUse)
+    {
+        var vm = Wtm.CreateVM<EtlJobDefinitionVM>(id);
+        vm.DoDelete();
+        if (!ModelState.IsValid)
+            return PartialView(vm);
+        return FFResult().CloseDialog().RefreshGrid();
+    }
+
+    // ─── 操作 API ───
+
+    [ActionDescription("立即執行")]
+    [HttpPost]
+    public async Task<IActionResult> TriggerNow(Guid id)
+    {
+        await _scheduler.TriggerNowAsync(id);
+        return Ok(new { success = true, message = "已觸發執行" });
+    }
+
+    [ActionDescription("暫停 Job")]
+    [HttpPost]
+    public async Task<IActionResult> Pause(Guid id)
+    {
+        await _scheduler.PauseAsync(id);
+        return Ok(new { success = true, message = "已暫停" });
+    }
+
+    [ActionDescription("恢復 Job")]
+    [HttpPost]
+    public async Task<IActionResult> Resume(Guid id)
+    {
+        await _scheduler.ResumeAsync(id);
+        return Ok(new { success = true, message = "已恢復" });
+    }
+
+    [ActionDescription("中止執行")]
+    [HttpPost]
+    public async Task<IActionResult> Abort(Guid id)
+    {
+        await _scheduler.AbortAsync(id);
+        return Ok(new { success = true, message = "已中止" });
+    }
+
+    [ActionDescription("跳過下次")]
+    [HttpPost]
+    public async Task<IActionResult> SkipNext(Guid id)
+    {
+        await _scheduler.SkipNextAsync(id);
+        return Ok(new { success = true, message = "已設定跳過下次執行" });
+    }
+
+    [ActionDescription("修改排程")]
+    [HttpPost]
+    public async Task<IActionResult> Reschedule(Guid id, [FromBody] string newCron)
+    {
+        if (!CronExpression.IsValidExpression(newCron))
+            return BadRequest(new { error = "無效的 Cron 表達式" });
+        await _scheduler.RescheduleAsync(id, newCron);
+        return Ok(new { success = true, message = "排程已更新" });
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlMonitorController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlMonitorController.cs
@@ -1,0 +1,37 @@
+#nullable enable
+using System;
+using Microsoft.AspNetCore.Mvc;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Scheduling;
+using WalkingTec.Mvvm.Mvc;
+
+namespace WalkingTec.Mvvm.Mvc;
+
+[ActionDescription("ETL 監控")]
+public class _EtlMonitorController : BaseController
+{
+    private readonly EtlProgressTracker _tracker;
+
+    public _EtlMonitorController(EtlProgressTracker tracker)
+    {
+        _tracker = tracker;
+    }
+
+    [ActionDescription("執行中 Job")]
+    [HttpGet]
+    public IActionResult Running()
+    {
+        var running = _tracker.GetAll();
+        return Ok(running);
+    }
+
+    [ActionDescription("Job 進度")]
+    [HttpGet]
+    public IActionResult Progress(Guid jobId)
+    {
+        var progress = _tracker.Get(jobId);
+        if (progress == null)
+            return NotFound(new { error = "Job 不在執行中" });
+        return Ok(progress);
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlRunLogController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlRunLogController.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Core.Extensions;
+using WalkingTec.Mvvm.Etl.Scheduling;
+using WalkingTec.Mvvm.Etl.ViewModels;
+using WalkingTec.Mvvm.Mvc;
+
+namespace WalkingTec.Mvvm.Mvc;
+
+[ActionDescription("ETL 執行記錄")]
+public class _EtlRunLogController : BaseController
+{
+    private readonly EtlSchedulerService _scheduler;
+
+    public _EtlRunLogController(EtlSchedulerService scheduler)
+    {
+        _scheduler = scheduler;
+    }
+
+    [ActionDescription("執行記錄")]
+    public IActionResult Index(Guid? jobId = null)
+    {
+        var vm = Wtm.CreateVM<EtlRunLogListVM>();
+        if (jobId.HasValue)
+            vm.Searcher.JobId = jobId;
+        return PartialView(vm);
+    }
+
+    [ActionDescription("執行記錄")]
+    [HttpPost]
+    public IActionResult Search(EtlRunLogSearcher searcher)
+    {
+        var vm = Wtm.CreateVM<EtlRunLogListVM>();
+        vm.Searcher = searcher;
+        return Content(vm.GetJson());
+    }
+
+    [ActionDescription("重跑")]
+    [HttpPost]
+    public async Task<IActionResult> Rerun(Guid runLogId)
+    {
+        await _scheduler.RerunFromSnapshotAsync(runLogId);
+        return Ok(new { success = true, message = "已從該點重跑" });
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Models/EtlEnums.cs
+++ b/src/WalkingTec.Mvvm.Etl/Models/EtlEnums.cs
@@ -1,0 +1,49 @@
+#nullable enable
+
+namespace WalkingTec.Mvvm.Etl.Models;
+
+/// <summary>
+/// ETL Job 狀態
+/// </summary>
+public enum EtlJobStatus
+{
+    Enabled,
+    Disabled,
+    Running,
+    Paused,
+    Failed
+}
+
+/// <summary>
+/// ETL 執行觸發方式
+/// </summary>
+public enum EtlRunTrigger
+{
+    Scheduled,
+    Manual,
+    Retry
+}
+
+/// <summary>
+/// ETL 執行結果
+/// </summary>
+public enum EtlRunResult
+{
+    Success,
+    Failed,
+    Aborted,
+    Skipped
+}
+
+/// <summary>
+/// Watermark 模式
+/// </summary>
+public enum EtlWatermarkType
+{
+    /// <summary>每次全量載入，無 watermark</summary>
+    FullLoad,
+    /// <summary>用時間欄位做增量（如 UpdatedAt）</summary>
+    Timestamp,
+    /// <summary>用自增 ID 做增量（如 auto-increment PK）</summary>
+    Identity
+}

--- a/src/WalkingTec.Mvvm.Etl/Models/EtlJobDefinition.cs
+++ b/src/WalkingTec.Mvvm.Etl/Models/EtlJobDefinition.cs
@@ -1,0 +1,83 @@
+#nullable enable
+using System;
+using System.ComponentModel.DataAnnotations;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Etl.Models;
+
+/// <summary>
+/// ETL Job 定義 — 描述一個定時資料導入任務的配置
+/// </summary>
+public class EtlJobDefinition : BasePoco
+{
+    [Display(Name = "Job 名稱")]
+    [Required]
+    [StringLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Display(Name = "描述")]
+    [StringLength(500)]
+    public string? Description { get; set; }
+
+    /// <summary>Cron 表達式（Quartz 格式，如 "0 0 2 * * ?"）</summary>
+    [Display(Name = "排程 (Cron)")]
+    [Required]
+    [StringLength(100)]
+    public string CronExpression { get; set; } = string.Empty;
+
+    /// <summary>Job 實作類別的完整型別名</summary>
+    [Required]
+    [StringLength(500)]
+    public string JobClassName { get; set; } = string.Empty;
+
+    [Display(Name = "狀態")]
+    public EtlJobStatus Status { get; set; } = EtlJobStatus.Disabled;
+
+    /// <summary>引用 Configs.Connections 的 Key（appsettings.json 中定義）</summary>
+    [Display(Name = "來源連線 Key")]
+    [Required]
+    [StringLength(100)]
+    public string SourceCsKey { get; set; } = string.Empty;
+
+    /// <summary>來源資料庫類型</summary>
+    [Display(Name = "來源 DB 類型")]
+    public DBTypeEnum SourceDbType { get; set; }
+
+    // ─── Watermark 設定 ───
+
+    [Display(Name = "Watermark 模式")]
+    public EtlWatermarkType WatermarkType { get; set; } = EtlWatermarkType.FullLoad;
+
+    /// <summary>Watermark 欄位名（如 "UpdatedAt" 或 "OrderId"）</summary>
+    [StringLength(100)]
+    public string? WatermarkColumn { get; set; }
+
+    /// <summary>上次成功完成後的 watermark 值（JSON 序列化）</summary>
+    public string? LastWatermarkValue { get; set; }
+
+    /// <summary>首次執行的起始值（null = 全量首跑）</summary>
+    public string? InitialWatermarkValue { get; set; }
+
+    /// <summary>Watermark 時區（IANA 格式，如 "Asia/Taipei"），存儲統一用 UTC</summary>
+    [StringLength(50)]
+    public string WatermarkTimeZone { get; set; } = "UTC";
+
+    // ─── 執行控制 ───
+
+    /// <summary>跳過接下來 N 次排程觸發</summary>
+    public int SkipCount { get; set; }
+
+    /// <summary>失敗後最大重試次數</summary>
+    public int RetryCount { get; set; } = 3;
+
+    /// <summary>單次執行超時（分鐘）</summary>
+    public int TimeoutMinutes { get; set; } = 60;
+
+    // ─── 執行狀態（唯讀顯示） ───
+
+    public DateTime? LastRunAt { get; set; }
+    public DateTime? NextFireAt { get; set; }
+
+    [StringLength(2000)]
+    public string? LastError { get; set; }
+}

--- a/src/WalkingTec.Mvvm.Etl/Models/EtlProgress.cs
+++ b/src/WalkingTec.Mvvm.Etl/Models/EtlProgress.cs
@@ -1,0 +1,19 @@
+#nullable enable
+using System;
+
+namespace WalkingTec.Mvvm.Etl.Models;
+
+/// <summary>
+/// ETL 執行進度（用於即時監控）
+/// </summary>
+public record EtlProgress
+{
+    public Guid JobId { get; init; }
+    public string JobName { get; init; } = string.Empty;
+    public int ProcessedRows { get; init; }
+    public int? TotalRows { get; init; }
+    /// <summary>Extracting / Loading / Merging / Done</summary>
+    public string Phase { get; init; } = "Idle";
+    public double? RowsPerSecond { get; init; }
+    public DateTime StartedAt { get; init; }
+}

--- a/src/WalkingTec.Mvvm.Etl/Models/EtlRunLog.cs
+++ b/src/WalkingTec.Mvvm.Etl/Models/EtlRunLog.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System;
+using System.ComponentModel.DataAnnotations;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Etl.Models;
+
+/// <summary>
+/// ETL 執行記錄 — 每次 Job 執行產生一筆
+/// </summary>
+public class EtlRunLog : BasePoco
+{
+    [Required]
+    public Guid JobId { get; set; }
+
+    /// <summary>關聯的 Job 定義</summary>
+    public EtlJobDefinition? Job { get; set; }
+
+    public EtlRunTrigger Trigger { get; set; }
+    public EtlRunResult Result { get; set; }
+
+    public int ExtractedRows { get; set; }
+    public int LoadedRows { get; set; }
+    public int ErrorRows { get; set; }
+    public long ElapsedMs { get; set; }
+
+    [StringLength(4000)]
+    public string? ErrorMessage { get; set; }
+
+    public DateTime StartedAt { get; set; }
+    public DateTime? FinishedAt { get; set; }
+
+    /// <summary>執行時的 watermark 起始值快照（供重跑用）</summary>
+    public string? WatermarkSnapshot { get; set; }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlExecutionResult.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlExecutionResult.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// ETL Pipeline 執行結果
+/// </summary>
+public class EtlExecutionResult
+{
+    public bool Success { get; init; }
+    public bool Aborted { get; init; }
+    public int ExtractedRows { get; init; }
+    public int LoadedRows { get; init; }
+    public int ErrorRows { get; init; }
+    public long ElapsedMs { get; init; }
+    public string? ErrorMessage { get; init; }
+    public string? NewWatermarkValue { get; init; }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineConfig.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineConfig.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System;
+using System.Data;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// ETL Pipeline 執行配置
+/// </summary>
+public record EtlPipelineConfig
+{
+    public Guid JobId { get; init; }
+    public string JobName { get; init; } = string.Empty;
+    public string SourceConnectionString { get; init; } = string.Empty;
+    public string TargetConnectionString { get; init; } = string.Empty;
+    public string QueryTemplate { get; init; } = string.Empty;
+    public string TargetTableName { get; init; } = string.Empty;
+    public string MergeKeyColumn { get; init; } = string.Empty;
+    public int BatchSize { get; init; } = 50_000;
+    public StagingTableSpec StagingTable { get; init; } = null!;
+
+    /// <summary>可選的轉換函式（null = 零轉換直搬）</summary>
+    public Func<DataTable, DataTable>? TransformFunc { get; init; }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
@@ -1,0 +1,171 @@
+#nullable enable
+using System;
+using System.Data;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// ETL Pipeline 執行引擎
+///
+/// 流程：
+/// 1. EnsureStagingTable
+/// 2. TruncateStaging
+/// 3. foreach batch in Extract:
+///    a. CancellationToken check
+///    b. Transform（如果有 mapper）
+///    c. BulkLoad to staging
+///    d. 更新進度
+/// 4. Merge staging → target
+/// 5. 成功 → commit watermark；失敗 → discard watermark
+/// </summary>
+public class EtlPipelineExecutor
+{
+    private readonly IEtlSource _source;
+    private readonly IBulkLoader _loader;
+    private readonly IProgress<EtlProgress>? _progress;
+
+    public EtlPipelineExecutor(IEtlSource source, IBulkLoader loader, IProgress<EtlProgress>? progress = null)
+    {
+        _source = source;
+        _loader = loader;
+        _progress = progress;
+    }
+
+    /// <summary>
+    /// 執行完整 ETL Pipeline
+    /// </summary>
+    public async Task<EtlExecutionResult> ExecuteAsync(
+        EtlPipelineConfig config,
+        WatermarkStrategy watermark,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        int totalExtracted = 0;
+        int totalLoaded = 0;
+
+        try
+        {
+            // 1. 確認 staging table
+            await _loader.EnsureStagingTableAsync(
+                config.TargetConnectionString, config.StagingTable.TableName,
+                config.StagingTable, cancellationToken);
+
+            // 2. 清空 staging
+            await _loader.TruncateStagingAsync(
+                config.TargetConnectionString, config.StagingTable.TableName,
+                cancellationToken);
+
+            // 3. Extract + Load to staging
+            var wmParam = watermark.GetParameterValue();
+
+            await foreach (var batch in _source.ExtractBatchesAsync(
+                config.SourceConnectionString, config.QueryTemplate, wmParam,
+                config.BatchSize, cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Transform hook
+                var transformed = config.TransformFunc != null
+                    ? config.TransformFunc(batch)
+                    : batch;
+
+                int batchRows = transformed.Rows.Count;
+                totalExtracted += batchRows;
+
+                await _loader.BulkLoadAsync(
+                    config.TargetConnectionString, config.StagingTable.TableName,
+                    transformed, cancellationToken);
+
+                totalLoaded += batchRows;
+
+                // 更新 watermark 暫存
+                if (watermark.Type != EtlWatermarkType.FullLoad && !string.IsNullOrEmpty(watermark.Column))
+                {
+                    var maxVal = GetMaxValue(batch, watermark.Column);
+                    if (maxVal != null) watermark.UpdateFromBatchMax(maxVal);
+                }
+
+                // 回報進度
+                ReportProgress(config, totalLoaded, sw);
+            }
+
+            // 4. Merge staging → target
+            ReportProgress(config, totalLoaded, sw, "Merging");
+
+            await _loader.MergeAsync(
+                config.TargetConnectionString, config.StagingTable.TableName,
+                config.TargetTableName, config.MergeKeyColumn,
+                cancellationToken);
+
+            // 5. 成功 → commit watermark
+            var newWatermark = watermark.CommitPendingValue();
+
+            sw.Stop();
+            return new EtlExecutionResult
+            {
+                Success = true,
+                ExtractedRows = totalExtracted,
+                LoadedRows = totalLoaded,
+                ElapsedMs = sw.ElapsedMilliseconds,
+                NewWatermarkValue = newWatermark
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            watermark.DiscardPendingValue();
+            sw.Stop();
+            return new EtlExecutionResult
+            {
+                Success = false,
+                Aborted = true,
+                ExtractedRows = totalExtracted,
+                LoadedRows = totalLoaded,
+                ElapsedMs = sw.ElapsedMilliseconds,
+                ErrorMessage = "Job was aborted"
+            };
+        }
+        catch (Exception ex)
+        {
+            watermark.DiscardPendingValue();
+            sw.Stop();
+            return new EtlExecutionResult
+            {
+                Success = false,
+                ExtractedRows = totalExtracted,
+                LoadedRows = totalLoaded,
+                ElapsedMs = sw.ElapsedMilliseconds,
+                ErrorMessage = ex.ToString()
+            };
+        }
+    }
+
+    private void ReportProgress(EtlPipelineConfig config, int totalLoaded, Stopwatch sw, string phase = "Loading")
+    {
+        _progress?.Report(new EtlProgress
+        {
+            JobId = config.JobId,
+            JobName = config.JobName,
+            ProcessedRows = totalLoaded,
+            TotalRows = null,
+            Phase = phase,
+            RowsPerSecond = totalLoaded / Math.Max(sw.Elapsed.TotalSeconds, 0.001),
+            StartedAt = DateTime.UtcNow - sw.Elapsed
+        });
+    }
+
+    private static object? GetMaxValue(DataTable batch, string columnName)
+    {
+        if (!batch.Columns.Contains(columnName) || batch.Rows.Count == 0)
+            return null;
+
+        return batch.AsEnumerable()
+            .Select(r => r[columnName])
+            .Where(v => v != null && v != DBNull.Value)
+            .Max();
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlSourceFactory.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlSourceFactory.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using System;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Pipeline.Loaders;
+using WalkingTec.Mvvm.Etl.Pipeline.Sources;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// 根據 DBTypeEnum 建立對應的 IEtlSource 和 IBulkLoader
+/// </summary>
+public static class EtlSourceFactory
+{
+    public static IEtlSource CreateSource(DBTypeEnum dbType) => dbType switch
+    {
+        DBTypeEnum.SqlServer => new MssqlSource(),
+        // DBTypeEnum.Oracle => new OracleSource(),  // PR4
+        _ => throw new NotSupportedException($"ETL source not supported for {dbType}")
+    };
+
+    public static IBulkLoader CreateLoader(DBTypeEnum targetDbType) => targetDbType switch
+    {
+        DBTypeEnum.SqlServer => new MssqlBulkLoader(),
+        // DBTypeEnum.Oracle => new OracleBulkLoader(),  // PR4
+        _ => throw new NotSupportedException($"ETL loader not supported for {targetDbType}")
+    };
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlSourceFactory.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlSourceFactory.cs
@@ -14,14 +14,14 @@ public static class EtlSourceFactory
     public static IEtlSource CreateSource(DBTypeEnum dbType) => dbType switch
     {
         DBTypeEnum.SqlServer => new MssqlSource(),
-        // DBTypeEnum.Oracle => new OracleSource(),  // PR4
+        DBTypeEnum.Oracle => new OracleSource(),
         _ => throw new NotSupportedException($"ETL source not supported for {dbType}")
     };
 
     public static IBulkLoader CreateLoader(DBTypeEnum targetDbType) => targetDbType switch
     {
         DBTypeEnum.SqlServer => new MssqlBulkLoader(),
-        // DBTypeEnum.Oracle => new OracleBulkLoader(),  // PR4
+        DBTypeEnum.Oracle => new OracleBulkLoader(),
         _ => throw new NotSupportedException($"ETL loader not supported for {targetDbType}")
     };
 }

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/IBulkLoader.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/IBulkLoader.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// ETL Load 介面 — 批量寫入目標 DB
+/// </summary>
+public interface IBulkLoader
+{
+    /// <summary>
+    /// 將一批資料 BulkCopy 到 staging table
+    /// </summary>
+    Task BulkLoadAsync(
+        string connectionString,
+        string stagingTableName,
+        DataTable batch,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 執行 MERGE INTO 從 staging table 合併到目標 table
+    /// </summary>
+    Task MergeAsync(
+        string connectionString,
+        string stagingTableName,
+        string targetTableName,
+        string mergeKeyColumn,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 清空 staging table（TRUNCATE）
+    /// </summary>
+    Task TruncateStagingAsync(
+        string connectionString,
+        string stagingTableName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 確認 staging table 存在，不存在則自動建立
+    /// </summary>
+    Task EnsureStagingTableAsync(
+        string connectionString,
+        string stagingTableName,
+        StagingTableSpec spec,
+        CancellationToken cancellationToken = default);
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/IEtlSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/IEtlSource.cs
@@ -1,0 +1,29 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// ETL Extract 介面 — 從來源 DB 串流讀取資料
+/// </summary>
+public interface IEtlSource : IDisposable
+{
+    /// <summary>
+    /// 以 DbDataReader 方式串流讀取資料，分批 yield return DataTable
+    /// </summary>
+    /// <param name="connectionString">來源 DB 連線字串</param>
+    /// <param name="queryTemplate">SQL 查詢模板，包含 @watermark 參數佔位</param>
+    /// <param name="watermarkValue">watermark 參數值（null = 不帶 watermark 條件）</param>
+    /// <param name="batchSize">每批筆數</param>
+    /// <param name="cancellationToken">取消 token</param>
+    /// <returns>每個 DataTable 是一個 batch</returns>
+    IAsyncEnumerable<DataTable> ExtractBatchesAsync(
+        string connectionString,
+        string queryTemplate,
+        object? watermarkValue,
+        int batchSize,
+        CancellationToken cancellationToken = default);
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/Loaders/MssqlBulkLoader.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/Loaders/MssqlBulkLoader.cs
@@ -1,0 +1,131 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline.Loaders;
+
+/// <summary>
+/// MSSQL 批量載入器 — SqlBulkCopy + MERGE INTO
+/// </summary>
+public class MssqlBulkLoader : IBulkLoader
+{
+    public async Task BulkLoadAsync(
+        string connectionString, string stagingTableName,
+        DataTable batch, CancellationToken cancellationToken = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        using var bulkCopy = new SqlBulkCopy(conn)
+        {
+            DestinationTableName = stagingTableName,
+            BatchSize = batch.Rows.Count,
+            BulkCopyTimeout = 0
+        };
+
+        foreach (DataColumn col in batch.Columns)
+        {
+            bulkCopy.ColumnMappings.Add(col.ColumnName, col.ColumnName);
+        }
+
+        await bulkCopy.WriteToServerAsync(batch, cancellationToken);
+    }
+
+    public async Task MergeAsync(
+        string connectionString, string stagingTableName,
+        string targetTableName, string mergeKeyColumn,
+        CancellationToken cancellationToken = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        var columns = await GetColumnsAsync(conn, stagingTableName, cancellationToken);
+        var updateCols = columns.Where(c => c != mergeKeyColumn).ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"MERGE [{targetTableName}] AS target");
+        sb.AppendLine($"USING [{stagingTableName}] AS source");
+        sb.AppendLine($"ON target.[{mergeKeyColumn}] = source.[{mergeKeyColumn}]");
+
+        if (updateCols.Count > 0)
+        {
+            sb.AppendLine("WHEN MATCHED THEN UPDATE SET");
+            sb.AppendLine(string.Join(",\n",
+                updateCols.Select(c => $"  target.[{c}] = source.[{c}]")));
+        }
+
+        sb.AppendLine("WHEN NOT MATCHED THEN INSERT (");
+        sb.AppendLine(string.Join(", ", columns.Select(c => $"[{c}]")));
+        sb.AppendLine(") VALUES (");
+        sb.AppendLine(string.Join(", ", columns.Select(c => $"source.[{c}]")));
+        sb.AppendLine(");");
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sb.ToString();
+        cmd.CommandTimeout = 0;
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task TruncateStagingAsync(
+        string connectionString, string stagingTableName,
+        CancellationToken cancellationToken = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"TRUNCATE TABLE [{stagingTableName}]";
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task EnsureStagingTableAsync(
+        string connectionString, string stagingTableName,
+        StagingTableSpec spec, CancellationToken cancellationToken = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var checkCmd = conn.CreateCommand();
+        checkCmd.CommandText = @"
+            SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_NAME = @tableName";
+        checkCmd.Parameters.AddWithValue("@tableName", stagingTableName);
+        var exists = (int)(await checkCmd.ExecuteScalarAsync(cancellationToken))! > 0;
+
+        if (!exists)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"CREATE TABLE [{stagingTableName}] (");
+            sb.AppendLine(string.Join(",\n",
+                spec.Columns.Select(c => $"  [{c.Name}] {c.SqlType}")));
+            sb.AppendLine(")");
+
+            await using var createCmd = conn.CreateCommand();
+            createCmd.CommandText = sb.ToString();
+            await createCmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+    }
+
+    private static async Task<List<string>> GetColumnsAsync(
+        SqlConnection conn, string tableName, CancellationToken ct)
+    {
+        var columns = new List<string>();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_NAME = @tableName
+            ORDER BY ORDINAL_POSITION";
+        cmd.Parameters.AddWithValue("@tableName", tableName);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            columns.Add(reader.GetString(0));
+        }
+        return columns;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/Loaders/OracleBulkLoader.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/Loaders/OracleBulkLoader.cs
@@ -1,0 +1,140 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Oracle.ManagedDataAccess.Client;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline.Loaders;
+
+/// <summary>
+/// Oracle 批量載入器 — Array Binding 批次插入 + MERGE INTO
+/// 使用 Array Binding 而非 OracleBulkCopy，因為更穩定且不依賴 Oracle client 版本。
+/// </summary>
+public class OracleBulkLoader : IBulkLoader
+{
+    public async Task BulkLoadAsync(
+        string connectionString, string stagingTableName,
+        DataTable batch, CancellationToken cancellationToken = default)
+    {
+        await using var conn = new OracleConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        var columns = batch.Columns.Cast<DataColumn>().ToList();
+        var insertSql = new StringBuilder();
+        insertSql.Append($"INSERT INTO {stagingTableName} (");
+        insertSql.Append(string.Join(", ", columns.Select(c => c.ColumnName)));
+        insertSql.Append(") VALUES (");
+        insertSql.Append(string.Join(", ", columns.Select(c => $":{c.ColumnName}")));
+        insertSql.Append(')');
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = insertSql.ToString();
+        cmd.ArrayBindCount = batch.Rows.Count;
+
+        foreach (var col in columns)
+        {
+            var values = new object[batch.Rows.Count];
+            for (int i = 0; i < batch.Rows.Count; i++)
+                values[i] = batch.Rows[i][col.ColumnName];
+
+            cmd.Parameters.Add(new OracleParameter(col.ColumnName, values));
+        }
+
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task MergeAsync(
+        string connectionString, string stagingTableName,
+        string targetTableName, string mergeKeyColumn,
+        CancellationToken cancellationToken = default)
+    {
+        await using var conn = new OracleConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        var columns = await GetColumnsAsync(conn, stagingTableName, cancellationToken);
+        var updateCols = columns.Where(c => c != mergeKeyColumn).ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"MERGE INTO {targetTableName} t");
+        sb.AppendLine($"USING {stagingTableName} s");
+        sb.AppendLine($"ON (t.{mergeKeyColumn} = s.{mergeKeyColumn})");
+
+        if (updateCols.Count > 0)
+        {
+            sb.AppendLine("WHEN MATCHED THEN UPDATE SET");
+            sb.AppendLine(string.Join(",\n",
+                updateCols.Select(c => $"  t.{c} = s.{c}")));
+        }
+
+        sb.AppendLine("WHEN NOT MATCHED THEN INSERT (");
+        sb.AppendLine(string.Join(", ", columns));
+        sb.AppendLine(") VALUES (");
+        sb.AppendLine(string.Join(", ", columns.Select(c => $"s.{c}")));
+        sb.Append(')');
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sb.ToString();
+        cmd.CommandTimeout = 0;
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task TruncateStagingAsync(
+        string connectionString, string stagingTableName,
+        CancellationToken cancellationToken = default)
+    {
+        await using var conn = new OracleConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"TRUNCATE TABLE {stagingTableName}";
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task EnsureStagingTableAsync(
+        string connectionString, string stagingTableName,
+        StagingTableSpec spec, CancellationToken cancellationToken = default)
+    {
+        await using var conn = new OracleConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var checkCmd = conn.CreateCommand();
+        checkCmd.CommandText = @"
+            SELECT COUNT(*) FROM USER_TABLES
+            WHERE TABLE_NAME = :tableName";
+        checkCmd.Parameters.Add(new OracleParameter("tableName", stagingTableName.ToUpperInvariant()));
+        var count = Convert.ToInt32(await checkCmd.ExecuteScalarAsync(cancellationToken));
+
+        if (count == 0)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"CREATE TABLE {stagingTableName} (");
+            sb.AppendLine(string.Join(",\n",
+                spec.Columns.Select(c => $"  {c.Name} {c.SqlType}")));
+            sb.Append(')');
+
+            await using var createCmd = conn.CreateCommand();
+            createCmd.CommandText = sb.ToString();
+            await createCmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+    }
+
+    private static async Task<List<string>> GetColumnsAsync(
+        OracleConnection conn, string tableName, CancellationToken ct)
+    {
+        var columns = new List<string>();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            SELECT COLUMN_NAME FROM USER_TAB_COLUMNS
+            WHERE TABLE_NAME = :tableName
+            ORDER BY COLUMN_ID";
+        cmd.Parameters.Add(new OracleParameter("tableName", tableName.ToUpperInvariant()));
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+            columns.Add(reader.GetString(0));
+        return columns;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/Sources/MssqlSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/Sources/MssqlSource.cs
@@ -1,0 +1,70 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.Data.SqlClient;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline.Sources;
+
+/// <summary>
+/// MSSQL 資料來源 — 使用 DbDataReader 串流讀取，分批 yield DataTable
+/// </summary>
+public class MssqlSource : IEtlSource
+{
+    private SqlConnection? _connection;
+
+    public async IAsyncEnumerable<DataTable> ExtractBatchesAsync(
+        string connectionString,
+        string queryTemplate,
+        object? watermarkValue,
+        int batchSize,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        _connection = new SqlConnection(connectionString);
+        await _connection.OpenAsync(cancellationToken);
+
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = queryTemplate;
+        cmd.CommandTimeout = 0; // Pipeline 層的 CancellationToken 控制超時
+
+        if (watermarkValue != null)
+        {
+            cmd.Parameters.AddWithValue("@watermark", watermarkValue);
+        }
+
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
+
+        while (true)
+        {
+            var batch = new DataTable();
+            for (int i = 0; i < reader.FieldCount; i++)
+            {
+                batch.Columns.Add(reader.GetName(i), reader.GetFieldType(i) ?? typeof(object));
+            }
+
+            int count = 0;
+            while (count < batchSize && await reader.ReadAsync(cancellationToken))
+            {
+                var row = batch.NewRow();
+                for (int i = 0; i < reader.FieldCount; i++)
+                {
+                    row[i] = reader.IsDBNull(i) ? DBNull.Value : reader.GetValue(i);
+                }
+                batch.Rows.Add(row);
+                count++;
+            }
+
+            if (count == 0) break;
+            yield return batch;
+            if (count < batchSize) break; // 最後一批
+        }
+    }
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
+        _connection = null;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/Sources/OracleSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/Sources/OracleSource.cs
@@ -1,0 +1,70 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Oracle.ManagedDataAccess.Client;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline.Sources;
+
+/// <summary>
+/// Oracle 資料來源 — 使用 OracleDataReader 串流讀取，分批 yield DataTable
+/// </summary>
+public class OracleSource : IEtlSource
+{
+    private OracleConnection? _connection;
+
+    public async IAsyncEnumerable<DataTable> ExtractBatchesAsync(
+        string connectionString,
+        string queryTemplate,
+        object? watermarkValue,
+        int batchSize,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        _connection = new OracleConnection(connectionString);
+        await _connection.OpenAsync(cancellationToken);
+
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = queryTemplate;
+        cmd.CommandTimeout = 0;
+
+        if (watermarkValue != null)
+        {
+            cmd.Parameters.Add(new OracleParameter("watermark", watermarkValue));
+        }
+
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
+
+        while (true)
+        {
+            var batch = new DataTable();
+            for (int i = 0; i < reader.FieldCount; i++)
+            {
+                batch.Columns.Add(reader.GetName(i), reader.GetFieldType(i) ?? typeof(object));
+            }
+
+            int count = 0;
+            while (count < batchSize && await reader.ReadAsync(cancellationToken))
+            {
+                var row = batch.NewRow();
+                for (int i = 0; i < reader.FieldCount; i++)
+                {
+                    row[i] = reader.IsDBNull(i) ? DBNull.Value : reader.GetValue(i);
+                }
+                batch.Rows.Add(row);
+                count++;
+            }
+
+            if (count == 0) break;
+            yield return batch;
+            if (count < batchSize) break;
+        }
+    }
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
+        _connection = null;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/StagingTableSpec.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/StagingTableSpec.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// Staging table 結構定義
+/// </summary>
+public class StagingTableSpec
+{
+    public string TableName { get; }
+    public IReadOnlyList<StagingColumn> Columns { get; }
+
+    public StagingTableSpec(string tableName, params StagingColumn[] columns)
+    {
+        TableName = tableName;
+        Columns = columns;
+    }
+}
+
+/// <summary>
+/// Staging table 欄位定義（名稱 + 原生 SQL 類型）
+/// </summary>
+public record StagingColumn(string Name, string SqlType);

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/WatermarkStrategy.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/WatermarkStrategy.cs
@@ -1,0 +1,114 @@
+#nullable enable
+using System;
+using System.Text.Json;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// Watermark 計算邏輯
+///
+/// 規則：
+/// 1. FullLoad → WHERE 1=1（每次全量）
+/// 2. Timestamp/Identity → WHERE {Column} > @watermark
+/// 3. 首次執行：InitialWatermarkValue 有值用它，null 則全量
+/// 4. Watermark 只在整個 Job 成功後更新
+/// 5. 時區：存儲 UTC，查詢時轉回來源時區
+/// </summary>
+public class WatermarkStrategy
+{
+    public EtlWatermarkType Type { get; }
+    public string? Column { get; }
+    public string? CurrentValue { get; private set; }
+    public string TimeZone { get; }
+
+    private string? _pendingValue;
+
+    public WatermarkStrategy(EtlWatermarkType type, string? column, string? currentValue, string timeZone = "UTC")
+    {
+        Type = type;
+        Column = column;
+        CurrentValue = currentValue;
+        TimeZone = timeZone;
+    }
+
+    /// <summary>
+    /// 產生 WHERE 子句（不含 WHERE 關鍵字）
+    /// </summary>
+    public string BuildWhereClause()
+    {
+        if (Type == EtlWatermarkType.FullLoad)
+            return "1=1";
+
+        if (string.IsNullOrEmpty(CurrentValue))
+            return "1=1"; // 首次全量
+
+        return $"{Column} > @watermark";
+    }
+
+    /// <summary>
+    /// 取得 @watermark 參數值（已轉換時區）
+    /// </summary>
+    public object? GetParameterValue()
+    {
+        if (Type == EtlWatermarkType.FullLoad || string.IsNullOrEmpty(CurrentValue))
+            return null;
+
+        if (Type == EtlWatermarkType.Timestamp)
+        {
+            var utcValue = JsonSerializer.Deserialize<DateTime>(CurrentValue);
+            if (TimeZone != "UTC")
+            {
+                var tz = TimeZoneInfo.FindSystemTimeZoneById(TimeZone);
+                return TimeZoneInfo.ConvertTimeFromUtc(utcValue, tz);
+            }
+            return utcValue;
+        }
+
+        // Identity — 直接回傳數值
+        return JsonSerializer.Deserialize<long>(CurrentValue);
+    }
+
+    /// <summary>
+    /// 從一批資料中提取最大 watermark 值（暫存，不立即寫回 DB）
+    /// </summary>
+    public void UpdateFromBatchMax(object maxValue)
+    {
+        if (Type == EtlWatermarkType.FullLoad) return;
+
+        if (Type == EtlWatermarkType.Timestamp && maxValue is DateTime dt)
+        {
+            if (TimeZone != "UTC")
+            {
+                var tz = TimeZoneInfo.FindSystemTimeZoneById(TimeZone);
+                dt = TimeZoneInfo.ConvertTimeToUtc(dt, tz);
+            }
+            _pendingValue = JsonSerializer.Serialize(dt);
+        }
+        else if (Type == EtlWatermarkType.Identity && maxValue is long id)
+        {
+            _pendingValue = JsonSerializer.Serialize(id);
+        }
+    }
+
+    /// <summary>
+    /// Job 成功後，確認更新 watermark（回傳新值寫回 DB）
+    /// </summary>
+    public string? CommitPendingValue()
+    {
+        if (_pendingValue != null)
+        {
+            CurrentValue = _pendingValue;
+            _pendingValue = null;
+        }
+        return CurrentValue;
+    }
+
+    /// <summary>
+    /// Job 失敗時，丟棄暫存值（watermark 不更新）
+    /// </summary>
+    public void DiscardPendingValue()
+    {
+        _pendingValue = null;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlHostedService.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlHostedService.cs
@@ -1,0 +1,41 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Quartz;
+using Quartz.Impl;
+
+namespace WalkingTec.Mvvm.Etl.Scheduling;
+
+/// <summary>
+/// ETL 排程 HostedService — 在應用啟動後初始化 Quartz Scheduler 並載入 DB 中的 ETL Job。
+/// 獨立於 WTM 的 QuartzHostService，專門服務 ETL 排程。
+/// </summary>
+public class EtlHostedService : IHostedService
+{
+    private readonly EtlSchedulerService _schedulerService;
+    private IScheduler? _scheduler;
+
+    public EtlHostedService(EtlSchedulerService schedulerService)
+    {
+        _schedulerService = schedulerService;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var factory = new StdSchedulerFactory();
+        _scheduler = await factory.GetScheduler(cancellationToken);
+        _schedulerService.SetScheduler(_scheduler);
+
+        await _scheduler.Start(cancellationToken);
+
+        // 從 DB 載入所有 Enabled 的 ETL Job
+        await _schedulerService.LoadJobsFromDbAsync();
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_scheduler != null)
+            await _scheduler.Shutdown(cancellationToken);
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlProgressTracker.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlProgressTracker.cs
@@ -1,0 +1,37 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.Scheduling;
+
+/// <summary>
+/// 追蹤執行中 Job 的進度（in-memory ConcurrentDictionary）。
+/// 由 EtlQuartzJob 透過 IProgress 寫入，由 Monitor Controller 讀取。
+/// </summary>
+public class EtlProgressTracker
+{
+    private readonly ConcurrentDictionary<Guid, EtlProgress> _progress = new();
+
+    public void Update(EtlProgress progress)
+    {
+        _progress[progress.JobId] = progress;
+    }
+
+    public EtlProgress? Get(Guid jobId)
+    {
+        return _progress.TryGetValue(jobId, out var p) ? p : null;
+    }
+
+    public IReadOnlyList<EtlProgress> GetAll()
+    {
+        return _progress.Values.ToList();
+    }
+
+    public void Remove(Guid jobId)
+    {
+        _progress.TryRemove(jobId, out _);
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlQuartzJob.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlQuartzJob.cs
@@ -1,0 +1,190 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Quartz;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Core.Support.Quartz;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Scheduling;
+
+/// <summary>
+/// Quartz Job 橋接器 — 每次排程觸發時：
+/// 1. 從 DB 讀 EtlJobDefinition
+/// 2. 檢查 SkipCount、Status
+/// 3. 建立 EtlPipelineExecutor 並執行
+/// 4. 寫入 EtlRunLog
+/// 5. 更新 watermark（僅成功時）
+/// </summary>
+[DisallowConcurrentExecution]
+public class EtlQuartzJob : WtmJob
+{
+    public override async Task Execute(IJobExecutionContext context)
+    {
+        var jobDefIdStr = context.MergedJobDataMap.GetString("EtlJobDefinitionId");
+        if (string.IsNullOrEmpty(jobDefIdStr) || !Guid.TryParse(jobDefIdStr, out var jobDefId))
+            return;
+
+        var trigger = context.MergedJobDataMap.ContainsKey("EtlTriggerType")
+            ? Enum.Parse<EtlRunTrigger>(context.MergedJobDataMap.GetString("EtlTriggerType")!)
+            : EtlRunTrigger.Scheduled;
+
+        var dc = Wtm.DC;
+        var tracker = Sp.GetService<EtlProgressTracker>();
+
+        // 1. 讀 EtlJobDefinition
+        var jobDef = await dc.Set<EtlJobDefinition>().FindAsync(jobDefId);
+        if (jobDef == null) return;
+
+        // 2. 檢查 SkipCount
+        if (jobDef.SkipCount > 0)
+        {
+            jobDef.SkipCount--;
+            dc.Set<EtlJobDefinition>().Update(jobDef);
+
+            dc.Set<EtlRunLog>().Add(new EtlRunLog
+            {
+                JobId = jobDefId,
+                Trigger = trigger,
+                Result = EtlRunResult.Skipped,
+                StartedAt = DateTime.UtcNow,
+                FinishedAt = DateTime.UtcNow
+            });
+
+            await dc.SaveChangesAsync();
+            return;
+        }
+
+        // 3. 檢查 Status
+        if (jobDef.Status != EtlJobStatus.Enabled && jobDef.Status != EtlJobStatus.Failed)
+            return;
+
+        // 4. 更新 Status = Running
+        jobDef.Status = EtlJobStatus.Running;
+        dc.Set<EtlJobDefinition>().Update(jobDef);
+        await dc.SaveChangesAsync();
+
+        var startedAt = DateTime.UtcNow;
+
+        // 建立超時 CancellationToken（連結 Quartz 的 CancellationToken 以支援中止）
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
+        if (jobDef.TimeoutMinutes > 0)
+            timeoutCts.CancelAfter(TimeSpan.FromMinutes(jobDef.TimeoutMinutes));
+
+        EtlExecutionResult? result = null;
+        try
+        {
+            // 5. 取得來源連線字串
+            var sourceCs = Wtm.ConfigInfo.Connections?
+                .FirstOrDefault(c => c.Key == jobDef.SourceCsKey);
+            if (sourceCs == null)
+                throw new InvalidOperationException($"Connection key '{jobDef.SourceCsKey}' not found in Configs.Connections");
+
+            // 6. 建立 source + loader
+            using var source = EtlSourceFactory.CreateSource(jobDef.SourceDbType);
+            var loader = EtlSourceFactory.CreateLoader(DBTypeEnum.SqlServer); // target 是 WTM 的 DB
+
+            // 7. 建立 WatermarkStrategy
+            var watermarkValue = jobDef.LastWatermarkValue ?? jobDef.InitialWatermarkValue;
+            var watermark = new WatermarkStrategy(
+                jobDef.WatermarkType,
+                jobDef.WatermarkColumn,
+                watermarkValue,
+                jobDef.WatermarkTimeZone);
+
+            // 8. 建立 Pipeline Config
+            // 注意：真實使用時 Job 子類需要 override 提供 QueryTemplate, StagingTable 等
+            // 這裡從 JobDataMap 取得（由註冊時設定）
+            var queryTemplate = context.MergedJobDataMap.GetString("QueryTemplate") ?? "";
+            var targetTable = context.MergedJobDataMap.GetString("TargetTableName") ?? "";
+            var mergeKey = context.MergedJobDataMap.GetString("MergeKeyColumn") ?? "";
+            var stagingTable = context.MergedJobDataMap.GetString("StagingTableName") ?? "";
+            var batchSize = context.MergedJobDataMap.ContainsKey("BatchSize")
+                ? context.MergedJobDataMap.GetInt("BatchSize")
+                : 50_000;
+
+            // 取 target DB 連線字串（使用 WTM 預設連線）
+            var targetCs = Wtm.ConfigInfo.Connections?.FirstOrDefault()?.Value ?? "";
+
+            var config = new EtlPipelineConfig
+            {
+                JobId = jobDefId,
+                JobName = jobDef.Name,
+                SourceConnectionString = sourceCs.Value ?? "",
+                TargetConnectionString = targetCs,
+                QueryTemplate = queryTemplate,
+                TargetTableName = targetTable,
+                MergeKeyColumn = mergeKey,
+                BatchSize = batchSize,
+                StagingTable = new StagingTableSpec(stagingTable)
+            };
+
+            // 9. 執行 Pipeline
+            IProgress<EtlProgress>? progress = tracker != null
+                ? new Progress<EtlProgress>(p => tracker.Update(p))
+                : null;
+
+            var executor = new EtlPipelineExecutor(source, loader, progress);
+            result = await executor.ExecuteAsync(config, watermark, timeoutCts.Token);
+
+            // 10. 成功 → 更新 watermark
+            if (result.Success)
+            {
+                jobDef.LastWatermarkValue = result.NewWatermarkValue;
+                jobDef.LastRunAt = DateTime.UtcNow;
+                jobDef.LastError = null;
+                jobDef.Status = EtlJobStatus.Enabled;
+            }
+            else
+            {
+                jobDef.LastError = result.ErrorMessage?.Length > 2000
+                    ? result.ErrorMessage[..2000]
+                    : result.ErrorMessage;
+                jobDef.Status = result.Aborted ? EtlJobStatus.Enabled : EtlJobStatus.Failed;
+            }
+        }
+        catch (Exception ex)
+        {
+            result = new EtlExecutionResult
+            {
+                Success = false,
+                ErrorMessage = ex.ToString(),
+                ElapsedMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds
+            };
+            jobDef.LastError = ex.Message.Length > 2000 ? ex.Message[..2000] : ex.Message;
+            jobDef.Status = EtlJobStatus.Failed;
+        }
+        finally
+        {
+            // 寫 RunLog
+            dc.Set<EtlRunLog>().Add(new EtlRunLog
+            {
+                JobId = jobDefId,
+                Trigger = trigger,
+                Result = result?.Aborted == true ? EtlRunResult.Aborted
+                       : result?.Success == true ? EtlRunResult.Success
+                       : EtlRunResult.Failed,
+                ExtractedRows = result?.ExtractedRows ?? 0,
+                LoadedRows = result?.LoadedRows ?? 0,
+                ErrorRows = result?.ErrorRows ?? 0,
+                ElapsedMs = result?.ElapsedMs ?? 0,
+                ErrorMessage = result?.ErrorMessage,
+                StartedAt = startedAt,
+                FinishedAt = DateTime.UtcNow,
+                WatermarkSnapshot = jobDef.LastWatermarkValue
+            });
+
+            dc.Set<EtlJobDefinition>().Update(jobDef);
+            await dc.SaveChangesAsync();
+
+            // 清除進度
+            tracker?.Remove(jobDefId);
+        }
+    }
+
+}

--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlSchedulerService.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlSchedulerService.cs
@@ -1,0 +1,247 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Quartz;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.Scheduling;
+
+/// <summary>
+/// ETL 排程管理服務 — 封裝 Quartz IScheduler 操作，提供 UI 層呼叫的方法。
+/// 使用 DB state + RAMJobStore 混合方案。
+/// </summary>
+public class EtlSchedulerService
+{
+    private IScheduler? _scheduler;
+    private readonly IServiceProvider _sp;
+
+    public EtlSchedulerService(IServiceProvider sp)
+    {
+        _sp = sp;
+    }
+
+    /// <summary>設定 Quartz Scheduler 參考（由 EtlHostedService 在啟動時注入）</summary>
+    public void SetScheduler(IScheduler scheduler)
+    {
+        _scheduler = scheduler;
+    }
+
+    /// <summary>啟動時從 DB 載入所有 Enabled 的 ETL Job 排程</summary>
+    public async Task LoadJobsFromDbAsync()
+    {
+        if (_scheduler == null) return;
+
+        using var scope = _sp.CreateScope();
+        var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
+        var jobs = await wtm.DC.Set<EtlJobDefinition>()
+            .Where(j => j.Status == EtlJobStatus.Enabled || j.Status == EtlJobStatus.Failed)
+            .ToListAsync();
+
+        foreach (var job in jobs)
+        {
+            await ScheduleJobAsync(job);
+        }
+    }
+
+    /// <summary>▶ 立即執行（Trigger = Manual）</summary>
+    public async Task TriggerNowAsync(Guid jobId)
+    {
+        EnsureScheduler();
+
+        var jobKey = GetJobKey(jobId);
+        if (!await _scheduler!.CheckExists(jobKey))
+        {
+            // Job 可能是 Disabled 狀態，臨時建立一次性觸發
+            using var scope = _sp.CreateScope();
+            var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
+            var jobDef = await wtm.DC.Set<EtlJobDefinition>().FindAsync(jobId);
+            if (jobDef == null) return;
+            await ScheduleJobAsync(jobDef);
+        }
+
+        var data = new JobDataMap();
+        data.Put("EtlTriggerType", EtlRunTrigger.Manual.ToString());
+        await _scheduler!.TriggerJob(jobKey, data);
+    }
+
+    /// <summary>⏸ 暫停</summary>
+    public async Task PauseAsync(Guid jobId)
+    {
+        EnsureScheduler();
+        await _scheduler!.PauseTrigger(GetTriggerKey(jobId));
+        await UpdateStatusAsync(jobId, EtlJobStatus.Paused);
+    }
+
+    /// <summary>▶ 恢復</summary>
+    public async Task ResumeAsync(Guid jobId)
+    {
+        EnsureScheduler();
+        await _scheduler!.ResumeTrigger(GetTriggerKey(jobId));
+        await UpdateStatusAsync(jobId, EtlJobStatus.Enabled);
+    }
+
+    /// <summary>✏️ 修改排程</summary>
+    public async Task RescheduleAsync(Guid jobId, string newCron)
+    {
+        EnsureScheduler();
+
+        var triggerKey = GetTriggerKey(jobId);
+        var newTrigger = TriggerBuilder.Create()
+            .WithIdentity(triggerKey)
+            .WithCronSchedule(newCron)
+            .Build();
+
+        await _scheduler!.RescheduleJob(triggerKey, newTrigger);
+
+        // 同步更新 DB
+        using var scope = _sp.CreateScope();
+        var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
+        var jobDef = await wtm.DC.Set<EtlJobDefinition>().FindAsync(jobId);
+        if (jobDef != null)
+        {
+            jobDef.CronExpression = newCron;
+            jobDef.NextFireAt = newTrigger.GetNextFireTimeUtc()?.UtcDateTime;
+            wtm.DC.Set<EtlJobDefinition>().Update(jobDef);
+            await wtm.DC.SaveChangesAsync();
+        }
+    }
+
+    /// <summary>⛔ 中止執行中的 Job（透過 CancellationToken）</summary>
+    public async Task AbortAsync(Guid jobId)
+    {
+        EnsureScheduler();
+        var result = await _scheduler!.Interrupt(GetJobKey(jobId));
+        if (!result)
+            throw new InvalidOperationException($"Job {jobId} is not currently running.");
+    }
+
+    /// <summary>⏭ 跳過下次</summary>
+    public async Task SkipNextAsync(Guid jobId)
+    {
+        using var scope = _sp.CreateScope();
+        var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
+        var jobDef = await wtm.DC.Set<EtlJobDefinition>().FindAsync(jobId);
+        if (jobDef != null)
+        {
+            jobDef.SkipCount++;
+            wtm.DC.Set<EtlJobDefinition>().Update(jobDef);
+            await wtm.DC.SaveChangesAsync();
+        }
+    }
+
+    /// <summary>🔄 啟用</summary>
+    public async Task EnableAsync(Guid jobId)
+    {
+        using var scope = _sp.CreateScope();
+        var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
+        var jobDef = await wtm.DC.Set<EtlJobDefinition>().FindAsync(jobId);
+        if (jobDef == null) return;
+
+        jobDef.Status = EtlJobStatus.Enabled;
+        wtm.DC.Set<EtlJobDefinition>().Update(jobDef);
+        await wtm.DC.SaveChangesAsync();
+
+        EnsureScheduler();
+        await ScheduleJobAsync(jobDef);
+    }
+
+    /// <summary>🔄 停用</summary>
+    public async Task DisableAsync(Guid jobId)
+    {
+        EnsureScheduler();
+
+        var jobKey = GetJobKey(jobId);
+        if (await _scheduler!.CheckExists(jobKey))
+            await _scheduler.DeleteJob(jobKey);
+
+        await UpdateStatusAsync(jobId, EtlJobStatus.Disabled);
+    }
+
+    /// <summary>從 RunLog snapshot 重跑</summary>
+    public async Task RerunFromSnapshotAsync(Guid runLogId)
+    {
+        using var scope = _sp.CreateScope();
+        var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
+        var runLog = await wtm.DC.Set<EtlRunLog>().FindAsync(runLogId);
+        if (runLog == null) return;
+
+        var jobDef = await wtm.DC.Set<EtlJobDefinition>().FindAsync(runLog.JobId);
+        if (jobDef == null) return;
+
+        // 暫時設回 watermark
+        jobDef.LastWatermarkValue = runLog.WatermarkSnapshot;
+        wtm.DC.Set<EtlJobDefinition>().Update(jobDef);
+        await wtm.DC.SaveChangesAsync();
+
+        await TriggerNowAsync(runLog.JobId);
+    }
+
+    /// <summary>判斷 Job 是否應該執行</summary>
+    public static bool ShouldExecute(EtlJobDefinition job)
+    {
+        if (job.Status == EtlJobStatus.Disabled || job.Status == EtlJobStatus.Paused)
+            return false;
+        if (job.Status == EtlJobStatus.Running)
+            return false;
+        if (job.SkipCount > 0)
+            return false;
+        return true;
+    }
+
+    // ─── 內部輔助 ───
+
+    private async Task ScheduleJobAsync(EtlJobDefinition jobDef)
+    {
+        var jobKey = GetJobKey(jobDef.ID);
+        var triggerKey = GetTriggerKey(jobDef.ID);
+
+        // 如果已存在，先刪除
+        if (await _scheduler!.CheckExists(jobKey))
+            await _scheduler.DeleteJob(jobKey);
+
+        var jobDataMap = new JobDataMap();
+        jobDataMap.Put("Sp", _sp);
+        jobDataMap.Put("EtlJobDefinitionId", jobDef.ID.ToString());
+
+        var job = JobBuilder.Create<EtlQuartzJob>()
+            .WithIdentity(jobKey)
+            .UsingJobData(jobDataMap)
+            .Build();
+
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity(triggerKey)
+            .WithCronSchedule(jobDef.CronExpression)
+            .Build();
+
+        await _scheduler.ScheduleJob(job, trigger);
+
+        // 更新 NextFireAt
+        jobDef.NextFireAt = trigger.GetNextFireTimeUtc()?.UtcDateTime;
+    }
+
+    private async Task UpdateStatusAsync(Guid jobId, EtlJobStatus status)
+    {
+        using var scope = _sp.CreateScope();
+        var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
+        var jobDef = await wtm.DC.Set<EtlJobDefinition>().FindAsync(jobId);
+        if (jobDef != null)
+        {
+            jobDef.Status = status;
+            wtm.DC.Set<EtlJobDefinition>().Update(jobDef);
+            await wtm.DC.SaveChangesAsync();
+        }
+    }
+
+    private void EnsureScheduler()
+    {
+        if (_scheduler == null)
+            throw new InvalidOperationException("ETL Scheduler not initialized. Call SetScheduler() first.");
+    }
+
+    private static JobKey GetJobKey(Guid jobId) => new($"etl-{jobId}", "etl-group");
+    private static TriggerKey GetTriggerKey(Guid jobId) => new($"etl-trigger-{jobId}", "etl-group");
+}

--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlSchedulerService.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlSchedulerService.cs
@@ -48,7 +48,7 @@ public class EtlSchedulerService
     }
 
     /// <summary>▶ 立即執行（Trigger = Manual）</summary>
-    public async Task TriggerNowAsync(Guid jobId)
+    public virtual async Task TriggerNowAsync(Guid jobId)
     {
         EnsureScheduler();
 
@@ -69,7 +69,7 @@ public class EtlSchedulerService
     }
 
     /// <summary>⏸ 暫停</summary>
-    public async Task PauseAsync(Guid jobId)
+    public virtual async Task PauseAsync(Guid jobId)
     {
         EnsureScheduler();
         await _scheduler!.PauseTrigger(GetTriggerKey(jobId));
@@ -77,7 +77,7 @@ public class EtlSchedulerService
     }
 
     /// <summary>▶ 恢復</summary>
-    public async Task ResumeAsync(Guid jobId)
+    public virtual async Task ResumeAsync(Guid jobId)
     {
         EnsureScheduler();
         await _scheduler!.ResumeTrigger(GetTriggerKey(jobId));
@@ -85,7 +85,7 @@ public class EtlSchedulerService
     }
 
     /// <summary>✏️ 修改排程</summary>
-    public async Task RescheduleAsync(Guid jobId, string newCron)
+    public virtual async Task RescheduleAsync(Guid jobId, string newCron)
     {
         EnsureScheduler();
 
@@ -111,7 +111,7 @@ public class EtlSchedulerService
     }
 
     /// <summary>⛔ 中止執行中的 Job（透過 CancellationToken）</summary>
-    public async Task AbortAsync(Guid jobId)
+    public virtual async Task AbortAsync(Guid jobId)
     {
         EnsureScheduler();
         var result = await _scheduler!.Interrupt(GetJobKey(jobId));
@@ -120,7 +120,7 @@ public class EtlSchedulerService
     }
 
     /// <summary>⏭ 跳過下次</summary>
-    public async Task SkipNextAsync(Guid jobId)
+    public virtual async Task SkipNextAsync(Guid jobId)
     {
         using var scope = _sp.CreateScope();
         var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
@@ -134,7 +134,7 @@ public class EtlSchedulerService
     }
 
     /// <summary>🔄 啟用</summary>
-    public async Task EnableAsync(Guid jobId)
+    public virtual async Task EnableAsync(Guid jobId)
     {
         using var scope = _sp.CreateScope();
         var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
@@ -150,7 +150,7 @@ public class EtlSchedulerService
     }
 
     /// <summary>🔄 停用</summary>
-    public async Task DisableAsync(Guid jobId)
+    public virtual async Task DisableAsync(Guid jobId)
     {
         EnsureScheduler();
 
@@ -162,7 +162,7 @@ public class EtlSchedulerService
     }
 
     /// <summary>從 RunLog snapshot 重跑</summary>
-    public async Task RerunFromSnapshotAsync(Guid runLogId)
+    public virtual async Task RerunFromSnapshotAsync(Guid runLogId)
     {
         using var scope = _sp.CreateScope();
         var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();

--- a/src/WalkingTec.Mvvm.Etl/ServiceCollectionExtensions.cs
+++ b/src/WalkingTec.Mvvm.Etl/ServiceCollectionExtensions.cs
@@ -1,0 +1,54 @@
+#nullable enable
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Scheduling;
+
+namespace WalkingTec.Mvvm.Etl;
+
+/// <summary>
+/// ETL 模組 DI 註冊擴充方法
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// 註冊 ETL 模組服務（排程、進度追蹤）
+    /// </summary>
+    public static IServiceCollection AddWtmEtl(this IServiceCollection services)
+    {
+        services.AddSingleton<EtlSchedulerService>();
+        services.AddSingleton<EtlProgressTracker>();
+        services.AddHostedService<EtlHostedService>();
+
+        return services;
+    }
+}
+
+/// <summary>
+/// EF Core ModelBuilder 擴充 — 註冊 ETL 資料模型
+/// </summary>
+public static class EtlDbContextExtensions
+{
+    /// <summary>
+    /// 在 DataContext.OnModelCreating 中呼叫以註冊 ETL 表
+    /// </summary>
+    public static ModelBuilder ApplyEtlModels(this ModelBuilder builder)
+    {
+        builder.Entity<EtlJobDefinition>(e =>
+        {
+            e.ToTable("EtlJobDefinitions");
+            e.HasIndex(x => x.Name).IsUnique();
+            e.HasIndex(x => x.Status);
+        });
+
+        builder.Entity<EtlRunLog>(e =>
+        {
+            e.ToTable("EtlRunLogs");
+            e.HasIndex(x => x.JobId);
+            e.HasIndex(x => x.StartedAt);
+            e.HasOne(x => x.Job).WithMany().HasForeignKey(x => x.JobId);
+        });
+
+        return builder;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Testing/MockBulkLoader.cs
+++ b/src/WalkingTec.Mvvm.Etl/Testing/MockBulkLoader.cs
@@ -1,0 +1,64 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Testing;
+
+/// <summary>
+/// 測試用 BulkLoader — 收集資料到 List，不做真正 BulkCopy。
+/// 隨框架發布，供使用者測試自己的 ETL Job。
+/// </summary>
+public class MockBulkLoader : IBulkLoader
+{
+    public List<DataTable> LoadedBatches { get; } = new();
+    public int BatchCount => LoadedBatches.Count;
+    public int TotalRows => LoadedBatches.Sum(b => b.Rows.Count);
+    public bool MergeCalled { get; private set; }
+    public bool TruncateCalled { get; private set; }
+    public bool EnsureStagingCalled { get; private set; }
+
+    /// <summary>設定此值讓指定 batch 拋出異常（從 1 開始計數）</summary>
+    public int? FailOnBatch { get; set; }
+
+    /// <summary>每次 BulkLoad 完成後觸發</summary>
+    public event EventHandler? OnBatchLoaded;
+
+    public Task BulkLoadAsync(string connectionString, string stagingTableName,
+        DataTable batch, CancellationToken cancellationToken = default)
+    {
+        LoadedBatches.Add(batch.Copy());
+
+        if (FailOnBatch.HasValue && LoadedBatches.Count == FailOnBatch.Value)
+            throw new InvalidOperationException($"MockBulkLoader: simulated failure on batch {FailOnBatch.Value}");
+
+        OnBatchLoaded?.Invoke(this, EventArgs.Empty);
+        return Task.CompletedTask;
+    }
+
+    public Task MergeAsync(string connectionString, string stagingTableName,
+        string targetTableName, string mergeKeyColumn,
+        CancellationToken cancellationToken = default)
+    {
+        MergeCalled = true;
+        return Task.CompletedTask;
+    }
+
+    public Task TruncateStagingAsync(string connectionString, string stagingTableName,
+        CancellationToken cancellationToken = default)
+    {
+        TruncateCalled = true;
+        return Task.CompletedTask;
+    }
+
+    public Task EnsureStagingTableAsync(string connectionString, string stagingTableName,
+        StagingTableSpec spec, CancellationToken cancellationToken = default)
+    {
+        EnsureStagingCalled = true;
+        return Task.CompletedTask;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Testing/MockEtlSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Testing/MockEtlSource.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Testing;
+
+/// <summary>
+/// 測試用 EtlSource — 回傳 in-memory DataTable，不連真實 DB。
+/// 隨框架發布，供使用者測試自己的 ETL Job。
+/// </summary>
+public class MockEtlSource : IEtlSource
+{
+    private DataTable _data = new();
+
+    /// <summary>設定測試資料</summary>
+    public void SetData(DataTable data) => _data = data;
+
+    public async IAsyncEnumerable<DataTable> ExtractBatchesAsync(
+        string connectionString, string queryTemplate, object? watermarkValue,
+        int batchSize, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        int offset = 0;
+        while (offset < _data.Rows.Count)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var batch = _data.Clone(); // schema only
+            int end = Math.Min(offset + batchSize, _data.Rows.Count);
+            for (int i = offset; i < end; i++)
+            {
+                batch.ImportRow(_data.Rows[i]);
+            }
+            offset = end;
+            yield return batch;
+            await Task.CompletedTask;
+        }
+    }
+
+    public void Dispose() { }
+}

--- a/src/WalkingTec.Mvvm.Etl/ViewModels/EtlJobDefinitionVM.cs
+++ b/src/WalkingTec.Mvvm.Etl/ViewModels/EtlJobDefinitionVM.cs
@@ -1,0 +1,75 @@
+#nullable enable
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Quartz;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Scheduling;
+
+namespace WalkingTec.Mvvm.Etl.ViewModels;
+
+public class EtlJobDefinitionVM : BaseCRUDVM<EtlJobDefinition>
+{
+    public override void Validate()
+    {
+        base.Validate();
+
+        if (!string.IsNullOrEmpty(Entity.CronExpression) &&
+            !CronExpression.IsValidExpression(Entity.CronExpression))
+        {
+            MSD.AddModelError("Entity.CronExpression", "無效的 Cron 表達式");
+        }
+    }
+
+    public override void DoAdd()
+    {
+        base.DoAdd();
+
+        if (Entity.Status == EtlJobStatus.Enabled)
+        {
+            var scheduler = Wtm.ServiceProvider.GetService<EtlSchedulerService>();
+            scheduler?.EnableAsync(Entity.ID).GetAwaiter().GetResult();
+        }
+    }
+
+    public override void DoEdit(bool updateAllFields = false)
+    {
+        var original = DC.Set<EtlJobDefinition>().AsNoTracking().FirstOrDefault(x => x.ID == Entity.ID);
+        var oldCron = original?.CronExpression;
+        var oldStatus = original?.Status;
+
+        base.DoEdit(updateAllFields);
+
+        var scheduler = Wtm.ServiceProvider.GetService<EtlSchedulerService>();
+        if (scheduler == null) return;
+
+        // Handle status change
+        if (oldStatus != Entity.Status)
+        {
+            if (Entity.Status == EtlJobStatus.Enabled)
+                scheduler.EnableAsync(Entity.ID).GetAwaiter().GetResult();
+            else if (Entity.Status == EtlJobStatus.Disabled)
+                scheduler.DisableAsync(Entity.ID).GetAwaiter().GetResult();
+        }
+        // Handle cron change (only if still enabled)
+        else if (oldCron != Entity.CronExpression && Entity.Status == EtlJobStatus.Enabled)
+        {
+            scheduler.RescheduleAsync(Entity.ID, Entity.CronExpression).GetAwaiter().GetResult();
+        }
+    }
+
+    public override void DoDelete()
+    {
+        if (Entity.Status == EtlJobStatus.Running)
+        {
+            MSD.AddModelError("", "無法刪除正在執行中的 Job，請先中止再刪除");
+            return;
+        }
+
+        var scheduler = Wtm.ServiceProvider.GetService<EtlSchedulerService>();
+        scheduler?.DisableAsync(Entity.ID).GetAwaiter().GetResult();
+
+        base.DoDelete();
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/ViewModels/EtlJobListVM.cs
+++ b/src/WalkingTec.Mvvm.Etl/ViewModels/EtlJobListVM.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.ViewModels;
+
+public class EtlJobListVM : BasePagedListVM<EtlJobDefinition, EtlJobSearcher>
+{
+    protected override IEnumerable<IGridColumn<EtlJobDefinition>> InitGridHeader()
+    {
+        return new List<GridColumn<EtlJobDefinition>>
+        {
+            this.MakeGridHeader(x => x.Name),
+            this.MakeGridHeader(x => x.CronExpression).SetHeader("排程"),
+            this.MakeGridHeader(x => x.Status),
+            this.MakeGridHeader(x => x.SourceDbType).SetHeader("來源 DB"),
+            this.MakeGridHeader(x => x.LastRunAt).SetHeader("上次執行"),
+            this.MakeGridHeader(x => x.NextFireAt).SetHeader("下次觸發"),
+            this.MakeGridHeader(x => x.LastError!).SetHeader("最後錯誤").SetWidth(200),
+            this.MakeGridHeaderAction(width: 380)
+        };
+    }
+
+    public override IOrderedQueryable<EtlJobDefinition> GetSearchQuery()
+    {
+        var query = DC.Set<EtlJobDefinition>().AsQueryable();
+
+        if (!string.IsNullOrEmpty(Searcher.Name))
+            query = query.Where(x => x.Name.Contains(Searcher.Name));
+        if (Searcher.Status.HasValue)
+            query = query.Where(x => x.Status == Searcher.Status);
+        if (Searcher.SourceDbType.HasValue)
+            query = query.Where(x => x.SourceDbType == Searcher.SourceDbType);
+
+        return query.OrderByDescending(x => x.CreateTime);
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/ViewModels/EtlJobSearcher.cs
+++ b/src/WalkingTec.Mvvm.Etl/ViewModels/EtlJobSearcher.cs
@@ -1,0 +1,18 @@
+#nullable enable
+using System.ComponentModel.DataAnnotations;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.ViewModels;
+
+public class EtlJobSearcher : BaseSearcher
+{
+    [Display(Name = "Job 名稱")]
+    public string? Name { get; set; }
+
+    [Display(Name = "狀態")]
+    public EtlJobStatus? Status { get; set; }
+
+    [Display(Name = "來源 DB 類型")]
+    public DBTypeEnum? SourceDbType { get; set; }
+}

--- a/src/WalkingTec.Mvvm.Etl/ViewModels/EtlRunLogListVM.cs
+++ b/src/WalkingTec.Mvvm.Etl/ViewModels/EtlRunLogListVM.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.ViewModels;
+
+public class EtlRunLogListVM : BasePagedListVM<EtlRunLog, EtlRunLogSearcher>
+{
+    protected override IEnumerable<IGridColumn<EtlRunLog>> InitGridHeader()
+    {
+        return new List<GridColumn<EtlRunLog>>
+        {
+            this.MakeGridHeader(x => x.StartedAt).SetHeader("執行時間"),
+            this.MakeGridHeader(x => x.Trigger).SetHeader("觸發方式"),
+            this.MakeGridHeader(x => x.Result),
+            this.MakeGridHeader(x => x.ExtractedRows).SetHeader("擷取數"),
+            this.MakeGridHeader(x => x.LoadedRows).SetHeader("載入數"),
+            this.MakeGridHeader(x => x.ErrorRows).SetHeader("錯誤數"),
+            this.MakeGridHeader(x => x.ElapsedMs).SetHeader("耗時(ms)"),
+            this.MakeGridHeader(x => x.ErrorMessage!).SetHeader("錯誤訊息").SetWidth(200),
+            this.MakeGridHeader(x => x.WatermarkSnapshot!).SetHeader("Watermark"),
+            this.MakeGridHeaderAction(width: 120)
+        };
+    }
+
+    public override IOrderedQueryable<EtlRunLog> GetSearchQuery()
+    {
+        var query = DC.Set<EtlRunLog>()
+            .Include(x => x.Job)
+            .AsQueryable();
+
+        if (Searcher.JobId.HasValue)
+            query = query.Where(x => x.JobId == Searcher.JobId);
+        if (Searcher.Result.HasValue)
+            query = query.Where(x => x.Result == Searcher.Result);
+        if (Searcher.Trigger.HasValue)
+            query = query.Where(x => x.Trigger == Searcher.Trigger);
+        if (Searcher.StartedAtBegin.HasValue)
+            query = query.Where(x => x.StartedAt >= Searcher.StartedAtBegin);
+        if (Searcher.StartedAtEnd.HasValue)
+            query = query.Where(x => x.StartedAt <= Searcher.StartedAtEnd);
+
+        return query.OrderByDescending(x => x.StartedAt);
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/ViewModels/EtlRunLogSearcher.cs
+++ b/src/WalkingTec.Mvvm.Etl/ViewModels/EtlRunLogSearcher.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System;
+using System.ComponentModel.DataAnnotations;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.ViewModels;
+
+public class EtlRunLogSearcher : BaseSearcher
+{
+    [Display(Name = "Job")]
+    public Guid? JobId { get; set; }
+
+    [Display(Name = "結果")]
+    public EtlRunResult? Result { get; set; }
+
+    [Display(Name = "觸發方式")]
+    public EtlRunTrigger? Trigger { get; set; }
+
+    [Display(Name = "開始時間(起)")]
+    public DateTime? StartedAtBegin { get; set; }
+
+    [Display(Name = "開始時間(迄)")]
+    public DateTime? StartedAtEnd { get; set; }
+}

--- a/src/WalkingTec.Mvvm.Etl/WalkingTec.Mvvm.Etl.csproj
+++ b/src/WalkingTec.Mvvm.Etl/WalkingTec.Mvvm.Etl.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>WalkingTec.Mvvm.Etl</AssemblyName>
+    <Title>$(AssemblyName)</Title>
+    <Description>WTM ETL Module - Batch data import pipeline</Description>
+    <IsPackable>true</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Project="..\..\common.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\WalkingTec.Mvvm.Core\WalkingTec.Mvvm.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/WalkingTec.Mvvm.Etl/WalkingTec.Mvvm.Etl.csproj
+++ b/src/WalkingTec.Mvvm.Etl/WalkingTec.Mvvm.Etl.csproj
@@ -11,6 +11,10 @@
   <Import Project="..\..\common.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\WalkingTec.Mvvm.Core\WalkingTec.Mvvm.Core.csproj" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WalkingTec.Mvvm.Mvc\WalkingTec.Mvvm.Mvc.csproj" />
   </ItemGroup>
 </Project>

--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
@@ -1,0 +1,124 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Scheduling;
+using WalkingTec.Mvvm.Mvc;
+using WalkingTec.Mvvm.Test.Mock;
+
+namespace WalkingTec.Mvvm.Etl.Test.Controllers;
+
+[TestClass]
+public class EtlJobControllerTests
+{
+    private Mock<EtlSchedulerService> _mockScheduler = null!;
+    private _EtlJobController _controller = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var mockSp = new Mock<IServiceProvider>();
+        _mockScheduler = new Mock<EtlSchedulerService>(mockSp.Object);
+
+        _controller = new _EtlJobController(_mockScheduler.Object);
+        _controller.Wtm = MockWtmContext.CreateWtmContext();
+
+        var mockHttpContext = new Mock<HttpContext>();
+        var mockSession = new MockHttpSession();
+        mockHttpContext.Setup(s => s.Session).Returns(mockSession);
+        mockHttpContext.Setup(x => x.Request).Returns(new DefaultHttpContext().Request);
+        _controller.ControllerContext.HttpContext = mockHttpContext.Object;
+        _controller.Wtm.MSD = new ModelStateServiceProvider(_controller.ModelState);
+    }
+
+    [TestMethod]
+    public async Task TriggerNow_calls_scheduler()
+    {
+        var id = Guid.NewGuid();
+        _mockScheduler.Setup(x => x.TriggerNowAsync(id)).Returns(Task.CompletedTask);
+
+        var result = await _controller.TriggerNow(id) as OkObjectResult;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(200, result!.StatusCode);
+        _mockScheduler.Verify(x => x.TriggerNowAsync(id), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Pause_calls_scheduler()
+    {
+        var id = Guid.NewGuid();
+        _mockScheduler.Setup(x => x.PauseAsync(id)).Returns(Task.CompletedTask);
+
+        var result = await _controller.Pause(id) as OkObjectResult;
+
+        Assert.IsNotNull(result);
+        _mockScheduler.Verify(x => x.PauseAsync(id), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Resume_calls_scheduler()
+    {
+        var id = Guid.NewGuid();
+        _mockScheduler.Setup(x => x.ResumeAsync(id)).Returns(Task.CompletedTask);
+
+        var result = await _controller.Resume(id) as OkObjectResult;
+
+        Assert.IsNotNull(result);
+        _mockScheduler.Verify(x => x.ResumeAsync(id), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Abort_calls_scheduler()
+    {
+        var id = Guid.NewGuid();
+        _mockScheduler.Setup(x => x.AbortAsync(id)).Returns(Task.CompletedTask);
+
+        var result = await _controller.Abort(id) as OkObjectResult;
+
+        Assert.IsNotNull(result);
+        _mockScheduler.Verify(x => x.AbortAsync(id), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task SkipNext_calls_scheduler()
+    {
+        var id = Guid.NewGuid();
+        _mockScheduler.Setup(x => x.SkipNextAsync(id)).Returns(Task.CompletedTask);
+
+        var result = await _controller.SkipNext(id) as OkObjectResult;
+
+        Assert.IsNotNull(result);
+        _mockScheduler.Verify(x => x.SkipNextAsync(id), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Reschedule_rejects_invalid_cron()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _controller.Reschedule(id, "not-a-cron") as BadRequestObjectResult;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(400, result!.StatusCode);
+        _mockScheduler.Verify(x => x.RescheduleAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Reschedule_accepts_valid_cron()
+    {
+        var id = Guid.NewGuid();
+        var validCron = "0 0 0 * * ?";
+        _mockScheduler.Setup(x => x.RescheduleAsync(id, validCron)).Returns(Task.CompletedTask);
+
+        var result = await _controller.Reschedule(id, validCron) as OkObjectResult;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(200, result!.StatusCode);
+        _mockScheduler.Verify(x => x.RescheduleAsync(id, validCron), Times.Once);
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlMonitorControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlMonitorControllerTests.cs
@@ -1,0 +1,85 @@
+#nullable enable
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Scheduling;
+using WalkingTec.Mvvm.Mvc;
+using WalkingTec.Mvvm.Test.Mock;
+
+namespace WalkingTec.Mvvm.Etl.Test.Controllers;
+
+[TestClass]
+public class EtlMonitorControllerTests
+{
+    private EtlProgressTracker _tracker = null!;
+    private _EtlMonitorController _controller = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tracker = new EtlProgressTracker();
+        _controller = new _EtlMonitorController(_tracker);
+        _controller.Wtm = MockWtmContext.CreateWtmContext();
+
+        var mockHttpContext = new Mock<HttpContext>();
+        var mockSession = new MockHttpSession();
+        mockHttpContext.Setup(s => s.Session).Returns(mockSession);
+        mockHttpContext.Setup(x => x.Request).Returns(new DefaultHttpContext().Request);
+        _controller.ControllerContext.HttpContext = mockHttpContext.Object;
+    }
+
+    [TestMethod]
+    public void Running_returns_all_tracked_jobs()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        _tracker.Update(new EtlProgress { JobId = id1, Phase = "Extract", ProcessedRows = 100 });
+        _tracker.Update(new EtlProgress { JobId = id2, Phase = "Load", ProcessedRows = 200 });
+
+        var result = _controller.Running() as OkObjectResult;
+
+        Assert.IsNotNull(result);
+        var list = result!.Value as System.Collections.Generic.IReadOnlyList<EtlProgress>;
+        Assert.IsNotNull(list);
+        Assert.AreEqual(2, list!.Count);
+    }
+
+    [TestMethod]
+    public void Progress_returns_404_for_idle_job()
+    {
+        var result = _controller.Progress(Guid.NewGuid()) as NotFoundObjectResult;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(404, result!.StatusCode);
+    }
+
+    [TestMethod]
+    public void Progress_returns_200_for_running_job()
+    {
+        var jobId = Guid.NewGuid();
+        _tracker.Update(new EtlProgress { JobId = jobId, Phase = "Extract", ProcessedRows = 500, TotalRows = 1000 });
+
+        var result = _controller.Progress(jobId) as OkObjectResult;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(200, result!.StatusCode);
+        var progress = result.Value as EtlProgress;
+        Assert.IsNotNull(progress);
+        Assert.AreEqual(500, progress!.ProcessedRows);
+        Assert.AreEqual("Extract", progress.Phase);
+    }
+
+    [TestMethod]
+    public void Running_returns_empty_when_no_jobs()
+    {
+        var result = _controller.Running() as OkObjectResult;
+
+        Assert.IsNotNull(result);
+        var list = result!.Value as System.Collections.Generic.IReadOnlyList<EtlProgress>;
+        Assert.IsNotNull(list);
+        Assert.AreEqual(0, list!.Count);
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Integration/EndToEndPipelineTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Integration/EndToEndPipelineTests.cs
@@ -1,0 +1,210 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Pipeline.Loaders;
+using WalkingTec.Mvvm.Etl.Pipeline.Sources;
+
+namespace WalkingTec.Mvvm.Etl.Test.Integration;
+
+/// <summary>
+/// 端到端 Pipeline 整合測試 — 驗證完整 Extract → Load → Merge 流程。
+/// MSSQL-to-MSSQL（來源與目標都在同一個 MSSQL 實例）。
+/// </summary>
+[TestClass]
+[TestCategory("Integration")]
+public class EndToEndPipelineTests : IntegrationTestBase
+{
+    private const string SourceTable = "_etl_e2e_source";
+    private const string StagingTable = "_etl_e2e_staging";
+    private const string TargetTable = "_etl_e2e_target";
+
+    private static readonly StagingTableSpec StagingSpec = new(
+        StagingTable,
+        new StagingColumn("OrderNo", "NVARCHAR(50)"),
+        new StagingColumn("Amount", "DECIMAL(18,2)"),
+        new StagingColumn("UpdatedAt", "DATETIME2")
+    );
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        await EnsureMssqlDatabaseAsync();
+    }
+
+    [TestInitialize]
+    public async Task Setup()
+    {
+        await DropMssqlTableAsync(SourceTable);
+        await DropMssqlTableAsync(StagingTable);
+        await DropMssqlTableAsync(TargetTable);
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        await DropMssqlTableAsync(SourceTable);
+        await DropMssqlTableAsync(StagingTable);
+        await DropMssqlTableAsync(TargetTable);
+    }
+
+    [TestMethod]
+    public async Task Full_pipeline_mssql_to_mssql()
+    {
+        // Arrange — 來源 5000 筆
+        await CreateMssqlSourceTableAsync(SourceTable, 5000);
+        await CreateMssqlTargetTableAsync(TargetTable);
+
+        using var source = new MssqlSource();
+        var loader = new MssqlBulkLoader();
+        var executor = new EtlPipelineExecutor(source, loader);
+
+        var config = new EtlPipelineConfig
+        {
+            JobId = Guid.NewGuid(),
+            JobName = "E2E-FullLoad",
+            SourceConnectionString = MssqlConnectionString,
+            TargetConnectionString = MssqlConnectionString,
+            QueryTemplate = $"SELECT [OrderNo], [Amount], [UpdatedAt] FROM [{SourceTable}]",
+            TargetTableName = TargetTable,
+            MergeKeyColumn = "OrderNo",
+            BatchSize = 1000,
+            StagingTable = StagingSpec
+        };
+
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+
+        // Act
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        // Assert
+        Assert.IsTrue(result.Success, $"Pipeline failed: {result.ErrorMessage}");
+        Assert.AreEqual(5000, result.ExtractedRows);
+        Assert.AreEqual(5000, result.LoadedRows);
+        Assert.IsTrue(result.ElapsedMs > 0);
+
+        var targetCount = await CountMssqlRowsAsync(TargetTable);
+        Assert.AreEqual(5000, targetCount);
+    }
+
+    [TestMethod]
+    public async Task Incremental_pipeline_only_loads_new_rows()
+    {
+        // Arrange — 來源先 1000 筆
+        await CreateMssqlSourceTableAsync(SourceTable, 1000);
+        await CreateMssqlTargetTableAsync(TargetTable);
+
+        // 第一跑：全量（watermark 從 null 開始 = WHERE 1=1 等效）
+        using var source1 = new MssqlSource();
+        var loader = new MssqlBulkLoader();
+        var executor1 = new EtlPipelineExecutor(source1, loader);
+
+        var config = new EtlPipelineConfig
+        {
+            JobId = Guid.NewGuid(),
+            JobName = "E2E-Incremental",
+            SourceConnectionString = MssqlConnectionString,
+            TargetConnectionString = MssqlConnectionString,
+            QueryTemplate = $"SELECT [OrderNo], [Amount], [UpdatedAt] FROM [{SourceTable}] WHERE [UpdatedAt] > @watermark ORDER BY [UpdatedAt]",
+            TargetTableName = TargetTable,
+            MergeKeyColumn = "OrderNo",
+            BatchSize = 500,
+            StagingTable = StagingSpec
+        };
+
+        // 首跑：watermark = null → GetParameterValue() = null → 不加 @watermark 參數
+        // 但我們的 QueryTemplate 要求 @watermark，所以用 Timestamp 模式 + 初始值
+        var watermark1 = new WatermarkStrategy(
+            EtlWatermarkType.Timestamp, "UpdatedAt",
+            "\"2025-12-31T00:00:00Z\"");
+
+        var result1 = await executor1.ExecuteAsync(config, watermark1);
+        Assert.IsTrue(result1.Success, $"First run failed: {result1.ErrorMessage}");
+        Assert.AreEqual(1000, result1.ExtractedRows);
+
+        // 新增 500 筆到來源（index 1000~1499）
+        await InsertMoreRowsAsync(SourceTable, 500, 1000);
+
+        // 第二跑：用第一跑的 watermark
+        using var source2 = new MssqlSource();
+        var executor2 = new EtlPipelineExecutor(source2, loader);
+        var watermark2 = new WatermarkStrategy(
+            EtlWatermarkType.Timestamp, "UpdatedAt",
+            result1.NewWatermarkValue);
+
+        var result2 = await executor2.ExecuteAsync(config, watermark2);
+
+        // Assert — 第二跑只載入 500 筆新資料
+        Assert.IsTrue(result2.Success, $"Second run failed: {result2.ErrorMessage}");
+        Assert.AreEqual(500, result2.ExtractedRows);
+
+        var targetCount = await CountMssqlRowsAsync(TargetTable);
+        Assert.AreEqual(1500, targetCount);
+    }
+
+    [TestMethod]
+    public async Task Failed_pipeline_does_not_corrupt_target()
+    {
+        // Arrange — 來源 500 筆，target 預先放 200 筆
+        await CreateMssqlSourceTableAsync(SourceTable, 500);
+        await CreateMssqlSourceTableAsync(TargetTable, 200); // 用 source helper 建含 PK 的表
+
+        using var source = new MssqlSource();
+        // 用一個會在 Merge 階段失敗的 config — staging 與 target 的 merge key 不存在
+        var loader = new MssqlBulkLoader();
+        var executor = new EtlPipelineExecutor(source, loader);
+
+        // 故意設錯 MergeKeyColumn 讓 MERGE 失敗
+        var config = new EtlPipelineConfig
+        {
+            JobId = Guid.NewGuid(),
+            JobName = "E2E-FailTest",
+            SourceConnectionString = MssqlConnectionString,
+            TargetConnectionString = MssqlConnectionString,
+            QueryTemplate = $"SELECT [OrderNo], [Amount], [UpdatedAt] FROM [{SourceTable}]",
+            TargetTableName = TargetTable,
+            MergeKeyColumn = "NonExistentColumn",
+            BatchSize = 1000,
+            StagingTable = StagingSpec
+        };
+
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+
+        // Act
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        // Assert — pipeline 失敗，但 target 資料不受影響
+        Assert.IsFalse(result.Success);
+        Assert.IsFalse(string.IsNullOrEmpty(result.ErrorMessage));
+
+        var targetCount = await CountMssqlRowsAsync(TargetTable);
+        Assert.AreEqual(200, targetCount, "Target table should not be corrupted by failed pipeline");
+    }
+
+    #region Helpers
+
+    private static async Task InsertMoreRowsAsync(string tableName, int count, int startIndex)
+    {
+        await using var conn = new SqlConnection(MssqlConnectionString);
+        await conn.OpenAsync();
+
+        var baseDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (int i = startIndex; i < startIndex + count; i++)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $@"
+                INSERT INTO [{tableName}] ([OrderNo], [Amount], [UpdatedAt])
+                VALUES (@no, @amt, @dt)";
+            cmd.Parameters.AddWithValue("@no", $"ORD-{i:D8}");
+            cmd.Parameters.AddWithValue("@amt", 100m + (i % 1000));
+            cmd.Parameters.AddWithValue("@dt", baseDate.AddSeconds(i));
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    #endregion
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Integration/IntegrationTestBase.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Integration/IntegrationTestBase.cs
@@ -1,0 +1,166 @@
+#nullable enable
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WalkingTec.Mvvm.Etl.Test.Integration;
+
+/// <summary>
+/// 整合測試基底類別 — 提供 MSSQL/Oracle 連線字串、共用的表建立/清理方法。
+/// 所有整合測試都標記 [TestCategory("Integration")]，CI 可選擇性跳過。
+///
+/// 使用方式：
+///   docker compose -f test/docker-compose.etl-test.yml up -d
+///   dotnet test --filter "TestCategory=Integration"
+/// </summary>
+[TestCategory("Integration")]
+public abstract class IntegrationTestBase
+{
+    protected static string MssqlConnectionString =>
+        Environment.GetEnvironmentVariable("ETL_TEST_MSSQL")
+        ?? "Server=localhost,1433;Database=EtlTest;User Id=sa;Password=EtlTest@2026!;TrustServerCertificate=true";
+
+    protected static string OracleConnectionString =>
+        Environment.GetEnvironmentVariable("ETL_TEST_ORACLE")
+        ?? "Data Source=localhost:1521/XEPDB1;User Id=system;Password=EtlTest2026;";
+
+    /// <summary>
+    /// 在 MSSQL 中建立測試用來源表（含 OrderNo, Amount, UpdatedAt）
+    /// </summary>
+    protected static async Task CreateMssqlSourceTableAsync(string tableName, int rowCount = 0)
+    {
+        await using var conn = new SqlConnection(MssqlConnectionString);
+        await conn.OpenAsync();
+
+        // 如果存在則先刪除
+        await ExecuteMssqlAsync(conn, $@"
+            IF OBJECT_ID('{tableName}', 'U') IS NOT NULL
+                DROP TABLE [{tableName}]");
+
+        await ExecuteMssqlAsync(conn, $@"
+            CREATE TABLE [{tableName}] (
+                [OrderNo]    NVARCHAR(50) NOT NULL,
+                [Amount]     DECIMAL(18,2) NOT NULL,
+                [UpdatedAt]  DATETIME2 NOT NULL,
+                CONSTRAINT [PK_{tableName}] PRIMARY KEY ([OrderNo])
+            )");
+
+        if (rowCount > 0)
+        {
+            for (int i = 0; i < rowCount; i++)
+            {
+                await ExecuteMssqlAsync(conn, $@"
+                    INSERT INTO [{tableName}] ([OrderNo], [Amount], [UpdatedAt])
+                    VALUES ('ORD-{i:D8}', {100m + (i % 1000)}, '{new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(i):yyyy-MM-dd HH:mm:ss}')");
+            }
+        }
+    }
+
+    /// <summary>
+    /// 在 MSSQL 中建立測試用目標表（結構與來源相同）
+    /// </summary>
+    protected static async Task CreateMssqlTargetTableAsync(string tableName)
+    {
+        await using var conn = new SqlConnection(MssqlConnectionString);
+        await conn.OpenAsync();
+
+        await ExecuteMssqlAsync(conn, $@"
+            IF OBJECT_ID('{tableName}', 'U') IS NOT NULL
+                DROP TABLE [{tableName}]");
+
+        await ExecuteMssqlAsync(conn, $@"
+            CREATE TABLE [{tableName}] (
+                [OrderNo]    NVARCHAR(50) NOT NULL,
+                [Amount]     DECIMAL(18,2) NOT NULL,
+                [UpdatedAt]  DATETIME2 NOT NULL,
+                CONSTRAINT [PK_{tableName}] PRIMARY KEY ([OrderNo])
+            )");
+    }
+
+    /// <summary>
+    /// 確保 MSSQL 中的 EtlTest 資料庫存在
+    /// </summary>
+    protected static async Task EnsureMssqlDatabaseAsync()
+    {
+        var builder = new SqlConnectionStringBuilder(MssqlConnectionString)
+        {
+            InitialCatalog = "master"
+        };
+        await using var conn = new SqlConnection(builder.ConnectionString);
+        await conn.OpenAsync();
+
+        await ExecuteMssqlAsync(conn, @"
+            IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = 'EtlTest')
+                CREATE DATABASE [EtlTest]");
+    }
+
+    /// <summary>
+    /// 刪除 MSSQL 測試表
+    /// </summary>
+    protected static async Task DropMssqlTableAsync(string tableName)
+    {
+        await using var conn = new SqlConnection(MssqlConnectionString);
+        await conn.OpenAsync();
+        await ExecuteMssqlAsync(conn, $@"
+            IF OBJECT_ID('{tableName}', 'U') IS NOT NULL
+                DROP TABLE [{tableName}]");
+    }
+
+    /// <summary>
+    /// 查詢 MSSQL 表的行數
+    /// </summary>
+    protected static async Task<int> CountMssqlRowsAsync(string tableName)
+    {
+        await using var conn = new SqlConnection(MssqlConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM [{tableName}]";
+        return (int)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    /// <summary>
+    /// 查詢 MSSQL 表是否存在
+    /// </summary>
+    protected static async Task<bool> MssqlTableExistsAsync(string tableName)
+    {
+        await using var conn = new SqlConnection(MssqlConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = @t";
+        cmd.Parameters.AddWithValue("@t", tableName);
+        return (int)(await cmd.ExecuteScalarAsync())! > 0;
+    }
+
+    /// <summary>
+    /// 產生測試用 DataTable（與來源表結構相同）
+    /// </summary>
+    protected static DataTable GenerateTestData(int rowCount, DateTime? baseDate = null, int startIndex = 0)
+    {
+        var dt = new DataTable();
+        dt.Columns.Add("OrderNo", typeof(string));
+        dt.Columns.Add("Amount", typeof(decimal));
+        dt.Columns.Add("UpdatedAt", typeof(DateTime));
+
+        var start = baseDate ?? new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        for (int i = startIndex; i < startIndex + rowCount; i++)
+        {
+            var row = dt.NewRow();
+            row["OrderNo"] = $"ORD-{i:D8}";
+            row["Amount"] = 100m + (i % 1000);
+            row["UpdatedAt"] = start.AddSeconds(i);
+            dt.Rows.Add(row);
+        }
+
+        return dt;
+    }
+
+    private static async Task ExecuteMssqlAsync(SqlConnection conn, string sql)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Integration/MssqlBulkLoaderIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Integration/MssqlBulkLoaderIntegrationTests.cs
@@ -1,0 +1,149 @@
+#nullable enable
+using System.Data;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Pipeline.Loaders;
+
+namespace WalkingTec.Mvvm.Etl.Test.Integration;
+
+/// <summary>
+/// MSSQL BulkLoader 整合測試 — 驗證 SqlBulkCopy + MERGE INTO 在真實 MSSQL 上的行為。
+/// 需要 Docker: docker compose -f test/docker-compose.etl-test.yml up -d
+/// </summary>
+[TestClass]
+[TestCategory("Integration")]
+public class MssqlBulkLoaderIntegrationTests : IntegrationTestBase
+{
+    private const string StagingTable = "_etl_test_stg_orders";
+    private const string TargetTable = "_etl_test_target_orders";
+
+    private readonly MssqlBulkLoader _loader = new();
+
+    private static readonly StagingTableSpec StagingSpec = new(
+        StagingTable,
+        new StagingColumn("OrderNo", "NVARCHAR(50)"),
+        new StagingColumn("Amount", "DECIMAL(18,2)"),
+        new StagingColumn("UpdatedAt", "DATETIME2")
+    );
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        await EnsureMssqlDatabaseAsync();
+    }
+
+    [TestInitialize]
+    public async Task Setup()
+    {
+        await DropMssqlTableAsync(StagingTable);
+        await DropMssqlTableAsync(TargetTable);
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        await DropMssqlTableAsync(StagingTable);
+        await DropMssqlTableAsync(TargetTable);
+    }
+
+    [TestMethod]
+    public async Task BulkLoad_inserts_rows_to_staging()
+    {
+        // Arrange
+        await _loader.EnsureStagingTableAsync(MssqlConnectionString, StagingTable, StagingSpec);
+        var data = GenerateTestData(1000);
+
+        // Act
+        await _loader.BulkLoadAsync(MssqlConnectionString, StagingTable, data);
+
+        // Assert
+        var count = await CountMssqlRowsAsync(StagingTable);
+        Assert.AreEqual(1000, count);
+    }
+
+    [TestMethod]
+    public async Task Merge_upserts_to_target()
+    {
+        // Arrange — staging 有 500 筆，target 有 300 筆（其中 200 筆與 staging 重疊）
+        await _loader.EnsureStagingTableAsync(MssqlConnectionString, StagingTable, StagingSpec);
+        await CreateMssqlTargetTableAsync(TargetTable);
+
+        // target: ORD-00000000 ~ ORD-00000299
+        await CreateMssqlSourceTableAsync(TargetTable + "_tmp", 300);
+        // 用 INSERT...SELECT 搬到 target（因為 CreateMssqlSourceTableAsync 直接建到指定表）
+        // 改用直接建 target 並插入
+        await DropMssqlTableAsync(TargetTable);
+        await CreateMssqlSourceTableAsync(TargetTable, 300);
+
+        // staging: ORD-00000100 ~ ORD-00000599（與 target 重疊 100~299）
+        var stagingData = GenerateTestData(500, startIndex: 100);
+        await _loader.BulkLoadAsync(MssqlConnectionString, StagingTable, stagingData);
+
+        // Act
+        await _loader.MergeAsync(MssqlConnectionString, StagingTable, TargetTable, "OrderNo");
+
+        // Assert — target 應有 600 筆（0~99 原有 + 100~599 merge）
+        var count = await CountMssqlRowsAsync(TargetTable);
+        Assert.AreEqual(600, count);
+    }
+
+    [TestMethod]
+    public async Task Merge_is_idempotent()
+    {
+        // Arrange
+        await _loader.EnsureStagingTableAsync(MssqlConnectionString, StagingTable, StagingSpec);
+        await CreateMssqlTargetTableAsync(TargetTable);
+
+        var data = GenerateTestData(200);
+        await _loader.BulkLoadAsync(MssqlConnectionString, StagingTable, data);
+
+        // Act — merge 兩次
+        await _loader.MergeAsync(MssqlConnectionString, StagingTable, TargetTable, "OrderNo");
+        await _loader.MergeAsync(MssqlConnectionString, StagingTable, TargetTable, "OrderNo");
+
+        // Assert — 筆數不變
+        var count = await CountMssqlRowsAsync(TargetTable);
+        Assert.AreEqual(200, count);
+    }
+
+    [TestMethod]
+    public async Task TruncateStaging_clears_all()
+    {
+        // Arrange
+        await _loader.EnsureStagingTableAsync(MssqlConnectionString, StagingTable, StagingSpec);
+        await _loader.BulkLoadAsync(MssqlConnectionString, StagingTable, GenerateTestData(500));
+
+        // Act
+        await _loader.TruncateStagingAsync(MssqlConnectionString, StagingTable);
+
+        // Assert
+        var count = await CountMssqlRowsAsync(StagingTable);
+        Assert.AreEqual(0, count);
+    }
+
+    [TestMethod]
+    public async Task EnsureStagingTable_creates_if_not_exists()
+    {
+        // Act
+        await _loader.EnsureStagingTableAsync(MssqlConnectionString, StagingTable, StagingSpec);
+
+        // Assert
+        var exists = await MssqlTableExistsAsync(StagingTable);
+        Assert.IsTrue(exists);
+    }
+
+    [TestMethod]
+    public async Task EnsureStagingTable_noop_if_exists()
+    {
+        // Arrange — 建立一次
+        await _loader.EnsureStagingTableAsync(MssqlConnectionString, StagingTable, StagingSpec);
+
+        // Act — 再呼叫一次不應報錯
+        await _loader.EnsureStagingTableAsync(MssqlConnectionString, StagingTable, StagingSpec);
+
+        // Assert
+        var exists = await MssqlTableExistsAsync(StagingTable);
+        Assert.IsTrue(exists);
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Integration/OracleBulkLoaderIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Integration/OracleBulkLoaderIntegrationTests.cs
@@ -1,0 +1,224 @@
+#nullable enable
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Oracle.ManagedDataAccess.Client;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Pipeline.Loaders;
+
+namespace WalkingTec.Mvvm.Etl.Test.Integration;
+
+/// <summary>
+/// Oracle BulkLoader 整合測試 — 驗證 Array Binding + MERGE INTO 在真實 Oracle 上的行為。
+/// 需要 Docker: docker compose -f test/docker-compose.etl-test.yml up -d
+/// </summary>
+[TestClass]
+[TestCategory("Integration")]
+public class OracleBulkLoaderIntegrationTests : IntegrationTestBase
+{
+    private const string StagingTable = "ETL_TEST_STG_ORDERS";
+    private const string TargetTable = "ETL_TEST_TGT_ORDERS";
+
+    private readonly OracleBulkLoader _loader = new();
+
+    private static readonly StagingTableSpec StagingSpec = new(
+        StagingTable,
+        new StagingColumn("ORDERNO", "VARCHAR2(50)"),
+        new StagingColumn("AMOUNT", "NUMBER(18,2)"),
+        new StagingColumn("UPDATEDAT", "TIMESTAMP")
+    );
+
+    [TestInitialize]
+    public async Task Setup()
+    {
+        await DropOracleTableAsync(StagingTable);
+        await DropOracleTableAsync(TargetTable);
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        await DropOracleTableAsync(StagingTable);
+        await DropOracleTableAsync(TargetTable);
+    }
+
+    [TestMethod]
+    public async Task BulkLoad_inserts_rows_to_staging()
+    {
+        // Arrange
+        await _loader.EnsureStagingTableAsync(OracleConnectionString, StagingTable, StagingSpec);
+        var data = GenerateOracleTestData(1000);
+
+        // Act
+        await _loader.BulkLoadAsync(OracleConnectionString, StagingTable, data);
+
+        // Assert
+        var count = await CountOracleRowsAsync(StagingTable);
+        Assert.AreEqual(1000, count);
+    }
+
+    [TestMethod]
+    public async Task Merge_upserts_to_target()
+    {
+        // Arrange
+        await _loader.EnsureStagingTableAsync(OracleConnectionString, StagingTable, StagingSpec);
+        await CreateOracleTargetTableAsync(TargetTable);
+
+        // 先在 target 放 300 筆
+        var initialData = GenerateOracleTestData(300);
+        // 用 staging 做中轉
+        await _loader.BulkLoadAsync(OracleConnectionString, StagingTable, initialData);
+        await _loader.MergeAsync(OracleConnectionString, StagingTable, TargetTable, "ORDERNO");
+        await _loader.TruncateStagingAsync(OracleConnectionString, StagingTable);
+
+        // staging 放 500 筆（100~599，與 target 重疊 100~299）
+        var stagingData = GenerateOracleTestData(500, startIndex: 100);
+        await _loader.BulkLoadAsync(OracleConnectionString, StagingTable, stagingData);
+
+        // Act
+        await _loader.MergeAsync(OracleConnectionString, StagingTable, TargetTable, "ORDERNO");
+
+        // Assert — 0~599 = 600 筆
+        var count = await CountOracleRowsAsync(TargetTable);
+        Assert.AreEqual(600, count);
+    }
+
+    [TestMethod]
+    public async Task Merge_is_idempotent()
+    {
+        // Arrange
+        await _loader.EnsureStagingTableAsync(OracleConnectionString, StagingTable, StagingSpec);
+        await CreateOracleTargetTableAsync(TargetTable);
+
+        var data = GenerateOracleTestData(200);
+        await _loader.BulkLoadAsync(OracleConnectionString, StagingTable, data);
+
+        // Act — merge 兩次
+        await _loader.MergeAsync(OracleConnectionString, StagingTable, TargetTable, "ORDERNO");
+        await _loader.MergeAsync(OracleConnectionString, StagingTable, TargetTable, "ORDERNO");
+
+        // Assert
+        var count = await CountOracleRowsAsync(TargetTable);
+        Assert.AreEqual(200, count);
+    }
+
+    [TestMethod]
+    public async Task TruncateStaging_clears_all()
+    {
+        // Arrange
+        await _loader.EnsureStagingTableAsync(OracleConnectionString, StagingTable, StagingSpec);
+        await _loader.BulkLoadAsync(OracleConnectionString, StagingTable, GenerateOracleTestData(500));
+
+        // Act
+        await _loader.TruncateStagingAsync(OracleConnectionString, StagingTable);
+
+        // Assert
+        var count = await CountOracleRowsAsync(StagingTable);
+        Assert.AreEqual(0, count);
+    }
+
+    [TestMethod]
+    public async Task EnsureStagingTable_creates_if_not_exists()
+    {
+        // Act
+        await _loader.EnsureStagingTableAsync(OracleConnectionString, StagingTable, StagingSpec);
+
+        // Assert
+        var exists = await OracleTableExistsAsync(StagingTable);
+        Assert.IsTrue(exists);
+    }
+
+    [TestMethod]
+    public async Task EnsureStagingTable_noop_if_exists()
+    {
+        // Arrange
+        await _loader.EnsureStagingTableAsync(OracleConnectionString, StagingTable, StagingSpec);
+
+        // Act — 再呼叫一次
+        await _loader.EnsureStagingTableAsync(OracleConnectionString, StagingTable, StagingSpec);
+
+        // Assert
+        var exists = await OracleTableExistsAsync(StagingTable);
+        Assert.IsTrue(exists);
+    }
+
+    #region Oracle Helpers
+
+    private static DataTable GenerateOracleTestData(int rowCount, DateTime? baseDate = null, int startIndex = 0)
+    {
+        var dt = new DataTable();
+        // Oracle 慣用大寫欄名
+        dt.Columns.Add("ORDERNO", typeof(string));
+        dt.Columns.Add("AMOUNT", typeof(decimal));
+        dt.Columns.Add("UPDATEDAT", typeof(DateTime));
+
+        var start = baseDate ?? new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        for (int i = startIndex; i < startIndex + rowCount; i++)
+        {
+            var row = dt.NewRow();
+            row["ORDERNO"] = $"ORD-{i:D8}";
+            row["AMOUNT"] = 100m + (i % 1000);
+            row["UPDATEDAT"] = start.AddSeconds(i);
+            dt.Rows.Add(row);
+        }
+
+        return dt;
+    }
+
+    private static async Task CreateOracleTargetTableAsync(string tableName)
+    {
+        await DropOracleTableAsync(tableName);
+        await using var conn = new OracleConnection(OracleConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
+            CREATE TABLE {tableName} (
+                ORDERNO   VARCHAR2(50) NOT NULL,
+                AMOUNT    NUMBER(18,2) NOT NULL,
+                UPDATEDAT TIMESTAMP NOT NULL,
+                CONSTRAINT PK_{tableName} PRIMARY KEY (ORDERNO)
+            )";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task DropOracleTableAsync(string tableName)
+    {
+        await using var conn = new OracleConnection(OracleConnectionString);
+        await conn.OpenAsync();
+
+        await using var checkCmd = conn.CreateCommand();
+        checkCmd.CommandText = "SELECT COUNT(*) FROM USER_TABLES WHERE TABLE_NAME = :t";
+        checkCmd.Parameters.Add(new OracleParameter("t", tableName.ToUpperInvariant()));
+        var exists = Convert.ToInt32(await checkCmd.ExecuteScalarAsync()) > 0;
+
+        if (exists)
+        {
+            await using var dropCmd = conn.CreateCommand();
+            dropCmd.CommandText = $"DROP TABLE {tableName} PURGE";
+            await dropCmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static async Task<int> CountOracleRowsAsync(string tableName)
+    {
+        await using var conn = new OracleConnection(OracleConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM {tableName}";
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+    }
+
+    private static async Task<bool> OracleTableExistsAsync(string tableName)
+    {
+        await using var conn = new OracleConnection(OracleConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM USER_TABLES WHERE TABLE_NAME = :t";
+        cmd.Parameters.Add(new OracleParameter("t", tableName.ToUpperInvariant()));
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync()) > 0;
+    }
+
+    #endregion
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/CancellationTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/CancellationTests.cs
@@ -1,0 +1,77 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Testing;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+[TestClass]
+public class CancellationTests
+{
+    private MockEtlSource _source = null!;
+    private MockBulkLoader _loader = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _source = new MockEtlSource();
+        _loader = new MockBulkLoader();
+    }
+
+    [TestMethod]
+    public async Task Cancellation_stops_after_current_batch()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(200_000));
+        var cts = new CancellationTokenSource();
+        _loader.OnBatchLoaded += (_, _) => cts.Cancel(); // 第一批後取消
+
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark, cts.Token);
+
+        _loader.TotalRows.Should().Be(50_000); // 只完成一批
+    }
+
+    [TestMethod]
+    public async Task Cancelled_result_is_aborted()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(200_000));
+        var cts = new CancellationTokenSource();
+        _loader.OnBatchLoaded += (_, _) => cts.Cancel();
+
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark, cts.Token);
+
+        result.Success.Should().BeFalse();
+        result.Aborted.Should().BeTrue();
+        result.ErrorMessage.Should().Contain("aborted");
+    }
+
+    [TestMethod]
+    public async Task Cancelled_discards_watermark()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(200_000));
+        var cts = new CancellationTokenSource();
+        _loader.OnBatchLoaded += (_, _) => cts.Cancel();
+
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(
+            EtlWatermarkType.Timestamp, "UpdatedAt", "\"2026-01-01T00:00:00\"");
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark, cts.Token);
+
+        // watermark 不應更新
+        watermark.CurrentValue.Should().Be("\"2026-01-01T00:00:00\"");
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EtlPipelineTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EtlPipelineTests.cs
@@ -1,0 +1,150 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Testing;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+[TestClass]
+public class EtlPipelineTests
+{
+    private MockEtlSource _source = null!;
+    private MockBulkLoader _loader = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _source = new MockEtlSource();
+        _loader = new MockBulkLoader();
+    }
+
+    [TestMethod]
+    public async Task Execute_splits_data_into_correct_batches()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(120_000));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue();
+        _loader.BatchCount.Should().Be(3); // 50K + 50K + 20K
+        _loader.TotalRows.Should().Be(120_000);
+    }
+
+    [TestMethod]
+    public async Task Execute_calls_merge_after_all_batches()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100));
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        _loader.MergeCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Execute_calls_truncate_before_loading()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100));
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        _loader.TruncateCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Execute_calls_ensure_staging()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100));
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        _loader.EnsureStagingCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Execute_reports_progress_per_batch()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(120_000));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+
+        var progressReports = new List<EtlProgress>();
+        var progress = new SynchronousProgress<EtlProgress>(p => progressReports.Add(p));
+        var executor = new EtlPipelineExecutor(_source, _loader, progress);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        // 3 Loading reports + 1 Merging report = at least 4
+        progressReports.Count.Should().BeGreaterThanOrEqualTo(4);
+    }
+
+    [TestMethod]
+    public async Task Execute_returns_correct_row_counts()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(5_000));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 2_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.ExtractedRows.Should().Be(5_000);
+        result.LoadedRows.Should().Be(5_000);
+        result.ElapsedMs.Should().BeGreaterOrEqualTo(0);
+    }
+
+    [TestMethod]
+    public async Task Execute_with_transform_applies_function()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100));
+        bool transformCalled = false;
+        var config = TestHelpers.CreateTestConfig() with
+        {
+            TransformFunc = dt =>
+            {
+                transformCalled = true;
+                return dt; // pass-through
+            }
+        };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        transformCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Execute_empty_source_returns_success_zero_rows()
+    {
+        _source.SetData(new DataTable());
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue();
+        result.ExtractedRows.Should().Be(0);
+        result.LoadedRows.Should().Be(0);
+        _loader.MergeCalled.Should().BeTrue();
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/FailureTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/FailureTests.cs
@@ -1,0 +1,73 @@
+#nullable enable
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Testing;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+[TestClass]
+public class FailureTests
+{
+    private MockEtlSource _source = null!;
+    private MockBulkLoader _loader = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _source = new MockEtlSource();
+        _loader = new MockBulkLoader();
+    }
+
+    [TestMethod]
+    public async Task Failure_on_batch_returns_error_result()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100_000));
+        _loader.FailOnBatch = 2;
+
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeFalse();
+        result.Aborted.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task Failure_discards_watermark()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100_000));
+        _loader.FailOnBatch = 2;
+
+        var original = JsonSerializer.Serialize(new System.DateTime(2026, 3, 10, 0, 0, 0));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(
+            EtlWatermarkType.Timestamp, "UpdatedAt", original);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        watermark.CurrentValue.Should().Be(original);
+    }
+
+    [TestMethod]
+    public async Task Failure_includes_error_message()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100_000));
+        _loader.FailOnBatch = 1;
+
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("simulated failure");
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/TestHelpers.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/TestHelpers.cs
@@ -1,0 +1,66 @@
+#nullable enable
+using System;
+using System.Data;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+/// <summary>
+/// 測試用輔助方法
+/// </summary>
+public static class TestHelpers
+{
+    /// <summary>
+    /// 產生含 OrderNo (string), Amount (decimal), UpdatedAt (DateTime) 的測試資料
+    /// </summary>
+    public static DataTable GenerateOrderData(int rowCount, DateTime? baseDate = null)
+    {
+        var dt = new DataTable();
+        dt.Columns.Add("OrderNo", typeof(string));
+        dt.Columns.Add("Amount", typeof(decimal));
+        dt.Columns.Add("UpdatedAt", typeof(DateTime));
+
+        var start = baseDate ?? new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        for (int i = 0; i < rowCount; i++)
+        {
+            var row = dt.NewRow();
+            row["OrderNo"] = $"ORD-{i:D8}";
+            row["Amount"] = 100m + (i % 1000);
+            row["UpdatedAt"] = start.AddSeconds(i);
+            dt.Rows.Add(row);
+        }
+
+        return dt;
+    }
+
+    public static StagingTableSpec CreateTestStagingSpec() => new(
+        "stg_orders",
+        new StagingColumn("OrderNo", "NVARCHAR(50)"),
+        new StagingColumn("Amount", "DECIMAL(18,2)"),
+        new StagingColumn("UpdatedAt", "DATETIME2")
+    );
+
+    public static EtlPipelineConfig CreateTestConfig(Guid? jobId = null) => new()
+    {
+        JobId = jobId ?? Guid.NewGuid(),
+        JobName = "TestJob",
+        SourceConnectionString = "Source=test",
+        TargetConnectionString = "Target=test",
+        QueryTemplate = "SELECT * FROM Orders WHERE @watermark_clause",
+        TargetTableName = "SyncedOrders",
+        MergeKeyColumn = "OrderNo",
+        BatchSize = 50_000,
+        StagingTable = CreateTestStagingSpec()
+    };
+}
+
+/// <summary>
+/// 同步版 IProgress — 避免 Progress&lt;T&gt; 的 SynchronizationContext 非同步回調問題
+/// </summary>
+public class SynchronousProgress<T> : IProgress<T>
+{
+    private readonly Action<T> _handler;
+    public SynchronousProgress(Action<T> handler) => _handler = handler;
+    public void Report(T value) => _handler(value);
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/WatermarkTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/WatermarkTests.cs
@@ -1,0 +1,119 @@
+#nullable enable
+using System;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+[TestClass]
+public class WatermarkTests
+{
+    [TestMethod]
+    public void FullLoad_always_returns_1_equals_1()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        wm.BuildWhereClause().Should().Be("1=1");
+    }
+
+    [TestMethod]
+    public void Timestamp_with_null_value_returns_full_load()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", null);
+        wm.BuildWhereClause().Should().Be("1=1");
+    }
+
+    [TestMethod]
+    public void Timestamp_with_value_returns_column_gt_watermark()
+    {
+        var value = JsonSerializer.Serialize(new DateTime(2026, 3, 10, 2, 0, 0));
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", value);
+        wm.BuildWhereClause().Should().Be("UpdatedAt > @watermark");
+    }
+
+    [TestMethod]
+    public void Identity_with_value_returns_column_gt_watermark()
+    {
+        var value = JsonSerializer.Serialize(185600L);
+        var wm = new WatermarkStrategy(EtlWatermarkType.Identity, "OrderId", value);
+        wm.BuildWhereClause().Should().Be("OrderId > @watermark");
+    }
+
+    [TestMethod]
+    public void FullLoad_get_parameter_returns_null()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        wm.GetParameterValue().Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Timestamp_get_parameter_returns_datetime()
+    {
+        var dt = new DateTime(2026, 3, 10, 2, 0, 0, DateTimeKind.Utc);
+        var value = JsonSerializer.Serialize(dt);
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", value);
+
+        var param = wm.GetParameterValue();
+        param.Should().BeOfType<DateTime>();
+    }
+
+    [TestMethod]
+    public void Identity_get_parameter_returns_long()
+    {
+        var value = JsonSerializer.Serialize(185600L);
+        var wm = new WatermarkStrategy(EtlWatermarkType.Identity, "OrderId", value);
+
+        var param = wm.GetParameterValue();
+        param.Should().BeOfType<long>();
+        ((long)param!).Should().Be(185600L);
+    }
+
+    [TestMethod]
+    public void CommitPendingValue_updates_current()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", null);
+        var dt = new DateTime(2026, 3, 11, 2, 0, 0, DateTimeKind.Utc);
+        wm.UpdateFromBatchMax(dt);
+
+        var committed = wm.CommitPendingValue();
+
+        committed.Should().NotBeNullOrEmpty();
+        wm.CurrentValue.Should().Be(committed);
+    }
+
+    [TestMethod]
+    public void DiscardPendingValue_keeps_current()
+    {
+        var original = JsonSerializer.Serialize(new DateTime(2026, 3, 10, 0, 0, 0));
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", original);
+        wm.UpdateFromBatchMax(new DateTime(2026, 3, 11, 0, 0, 0, DateTimeKind.Utc));
+
+        wm.DiscardPendingValue();
+
+        wm.CurrentValue.Should().Be(original);
+    }
+
+    [TestMethod]
+    public void Timezone_conversion_taipei_to_utc()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", null, "Asia/Taipei");
+
+        // Taipei 10:00 = UTC 02:00
+        var taipeiTime = new DateTime(2026, 3, 11, 10, 0, 0);
+        wm.UpdateFromBatchMax(taipeiTime);
+        var committed = wm.CommitPendingValue();
+
+        var storedUtc = JsonSerializer.Deserialize<DateTime>(committed!);
+        storedUtc.Hour.Should().Be(2);
+    }
+
+    [TestMethod]
+    public void FullLoad_ignores_update_from_batch()
+    {
+        var wm = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        wm.UpdateFromBatchMax(new DateTime(2026, 3, 11, 0, 0, 0));
+        wm.CommitPendingValue().Should().BeNull();
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Scheduling/EtlProgressTrackerTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Scheduling/EtlProgressTrackerTests.cs
@@ -1,0 +1,87 @@
+#nullable enable
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Scheduling;
+
+namespace WalkingTec.Mvvm.Etl.Test.Scheduling;
+
+[TestClass]
+public class EtlProgressTrackerTests
+{
+    private EtlProgressTracker _tracker = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tracker = new EtlProgressTracker();
+    }
+
+    [TestMethod]
+    public void Update_and_Get_returns_latest_progress()
+    {
+        var jobId = Guid.NewGuid();
+        var p1 = new EtlProgress { JobId = jobId, Phase = "Extract", ProcessedRows = 100 };
+        var p2 = new EtlProgress { JobId = jobId, Phase = "Load", ProcessedRows = 200 };
+
+        _tracker.Update(p1);
+        _tracker.Update(p2);
+
+        var result = _tracker.Get(jobId);
+        Assert.IsNotNull(result);
+        Assert.AreEqual("Load", result!.Phase);
+        Assert.AreEqual(200, result.ProcessedRows);
+    }
+
+    [TestMethod]
+    public void Get_returns_null_for_unknown_job()
+    {
+        Assert.IsNull(_tracker.Get(Guid.NewGuid()));
+    }
+
+    [TestMethod]
+    public void GetAll_returns_all_tracked_jobs()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        _tracker.Update(new EtlProgress { JobId = id1, Phase = "Extract" });
+        _tracker.Update(new EtlProgress { JobId = id2, Phase = "Load" });
+
+        var all = _tracker.GetAll();
+        Assert.AreEqual(2, all.Count);
+    }
+
+    [TestMethod]
+    public void Remove_clears_progress()
+    {
+        var jobId = Guid.NewGuid();
+        _tracker.Update(new EtlProgress { JobId = jobId, Phase = "Extract" });
+
+        _tracker.Remove(jobId);
+
+        Assert.IsNull(_tracker.Get(jobId));
+        Assert.AreEqual(0, _tracker.GetAll().Count);
+    }
+
+    [TestMethod]
+    public void Remove_nonexistent_does_not_throw()
+    {
+        _tracker.Remove(Guid.NewGuid()); // should not throw
+    }
+
+    [TestMethod]
+    public void Multiple_jobs_are_independent()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        _tracker.Update(new EtlProgress { JobId = id1, Phase = "A", ProcessedRows = 10 });
+        _tracker.Update(new EtlProgress { JobId = id2, Phase = "B", ProcessedRows = 20 });
+
+        _tracker.Remove(id1);
+
+        Assert.IsNull(_tracker.Get(id1));
+        Assert.IsNotNull(_tracker.Get(id2));
+        Assert.AreEqual(20, _tracker.Get(id2)!.ProcessedRows);
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Scheduling/SchedulerLogicTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Scheduling/SchedulerLogicTests.cs
@@ -1,0 +1,109 @@
+#nullable enable
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Pipeline.Loaders;
+using WalkingTec.Mvvm.Etl.Pipeline.Sources;
+using WalkingTec.Mvvm.Etl.Scheduling;
+
+namespace WalkingTec.Mvvm.Etl.Test.Scheduling;
+
+[TestClass]
+public class SchedulerLogicTests
+{
+    private static EtlJobDefinition CreateJob(
+        EtlJobStatus status = EtlJobStatus.Enabled,
+        int skipCount = 0) => new()
+    {
+        Name = "test-job",
+        CronExpression = "0 0 * * *",
+        SourceCsKey = "test",
+        SourceDbType = Core.DBTypeEnum.SqlServer,
+        WatermarkType = EtlWatermarkType.FullLoad,
+        Status = status,
+        SkipCount = skipCount
+    };
+
+    // ─── ShouldExecute tests ───
+
+    [TestMethod]
+    public void ShouldExecute_Enabled_returns_true()
+    {
+        var job = CreateJob(EtlJobStatus.Enabled);
+        Assert.IsTrue(EtlSchedulerService.ShouldExecute(job));
+    }
+
+    [TestMethod]
+    public void ShouldExecute_Failed_returns_true()
+    {
+        // Failed jobs should be retried on next trigger
+        var job = CreateJob(EtlJobStatus.Failed);
+        Assert.IsTrue(EtlSchedulerService.ShouldExecute(job));
+    }
+
+    [TestMethod]
+    public void ShouldExecute_Disabled_returns_false()
+    {
+        var job = CreateJob(EtlJobStatus.Disabled);
+        Assert.IsFalse(EtlSchedulerService.ShouldExecute(job));
+    }
+
+    [TestMethod]
+    public void ShouldExecute_Paused_returns_false()
+    {
+        var job = CreateJob(EtlJobStatus.Paused);
+        Assert.IsFalse(EtlSchedulerService.ShouldExecute(job));
+    }
+
+    [TestMethod]
+    public void ShouldExecute_Running_returns_false()
+    {
+        var job = CreateJob(EtlJobStatus.Running);
+        Assert.IsFalse(EtlSchedulerService.ShouldExecute(job));
+    }
+
+    [TestMethod]
+    public void ShouldExecute_SkipCount_positive_returns_false()
+    {
+        var job = CreateJob(EtlJobStatus.Enabled, skipCount: 2);
+        Assert.IsFalse(EtlSchedulerService.ShouldExecute(job));
+    }
+
+    [TestMethod]
+    public void ShouldExecute_SkipCount_zero_Enabled_returns_true()
+    {
+        var job = CreateJob(EtlJobStatus.Enabled, skipCount: 0);
+        Assert.IsTrue(EtlSchedulerService.ShouldExecute(job));
+    }
+
+    // ─── EtlSourceFactory tests ───
+
+    [TestMethod]
+    public void EtlSourceFactory_CreateSource_SqlServer_returns_MssqlSource()
+    {
+        using var source = EtlSourceFactory.CreateSource(Core.DBTypeEnum.SqlServer);
+        Assert.IsInstanceOfType(source, typeof(MssqlSource));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(NotSupportedException))]
+    public void EtlSourceFactory_CreateSource_unsupported_throws()
+    {
+        EtlSourceFactory.CreateSource(Core.DBTypeEnum.SQLite);
+    }
+
+    [TestMethod]
+    public void EtlSourceFactory_CreateLoader_SqlServer_returns_MssqlBulkLoader()
+    {
+        var loader = EtlSourceFactory.CreateLoader(Core.DBTypeEnum.SqlServer);
+        Assert.IsInstanceOfType(loader, typeof(MssqlBulkLoader));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(NotSupportedException))]
+    public void EtlSourceFactory_CreateLoader_unsupported_throws()
+    {
+        EtlSourceFactory.CreateLoader(Core.DBTypeEnum.SQLite);
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Scheduling/SchedulerLogicTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Scheduling/SchedulerLogicTests.cs
@@ -5,6 +5,8 @@ using WalkingTec.Mvvm.Etl.Models;
 using WalkingTec.Mvvm.Etl.Pipeline;
 using WalkingTec.Mvvm.Etl.Pipeline.Loaders;
 using WalkingTec.Mvvm.Etl.Pipeline.Sources;
+using OracleSource = WalkingTec.Mvvm.Etl.Pipeline.Sources.OracleSource;
+using OracleBulkLoader = WalkingTec.Mvvm.Etl.Pipeline.Loaders.OracleBulkLoader;
 using WalkingTec.Mvvm.Etl.Scheduling;
 
 namespace WalkingTec.Mvvm.Etl.Test.Scheduling;
@@ -105,5 +107,19 @@ public class SchedulerLogicTests
     public void EtlSourceFactory_CreateLoader_unsupported_throws()
     {
         EtlSourceFactory.CreateLoader(Core.DBTypeEnum.SQLite);
+    }
+
+    [TestMethod]
+    public void EtlSourceFactory_CreateSource_Oracle_returns_OracleSource()
+    {
+        using var source = EtlSourceFactory.CreateSource(Core.DBTypeEnum.Oracle);
+        Assert.IsInstanceOfType(source, typeof(OracleSource));
+    }
+
+    [TestMethod]
+    public void EtlSourceFactory_CreateLoader_Oracle_returns_OracleBulkLoader()
+    {
+        var loader = EtlSourceFactory.CreateLoader(Core.DBTypeEnum.Oracle);
+        Assert.IsInstanceOfType(loader, typeof(OracleBulkLoader));
     }
 }

--- a/test/WalkingTec.Mvvm.Etl.Test/ViewModels/EtlJobListVmTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/ViewModels/EtlJobListVmTests.cs
@@ -1,0 +1,117 @@
+#nullable enable
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.ViewModels;
+using WalkingTec.Mvvm.Test.Mock;
+
+namespace WalkingTec.Mvvm.Etl.Test.ViewModels;
+
+[TestClass]
+public class EtlJobListVmTests
+{
+    private WTMContext _wtm = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var dc = new EtlTestDataContext(Guid.NewGuid().ToString(), DBTypeEnum.Memory);
+        _wtm = MockWtmContext.CreateWtmContext(dc);
+
+        // Seed data
+        dc.Set<EtlJobDefinition>().AddRange(
+            new EtlJobDefinition
+            {
+                Name = "OrderSync",
+                CronExpression = "0 0 * * *",
+                SourceCsKey = "upstream",
+                SourceDbType = DBTypeEnum.SqlServer,
+                WatermarkType = EtlWatermarkType.Timestamp,
+                Status = EtlJobStatus.Enabled,
+                CreateTime = DateTime.UtcNow.AddMinutes(-3)
+            },
+            new EtlJobDefinition
+            {
+                Name = "ProductSync",
+                CronExpression = "0 */6 * * *",
+                SourceCsKey = "upstream",
+                SourceDbType = DBTypeEnum.SqlServer,
+                WatermarkType = EtlWatermarkType.Identity,
+                Status = EtlJobStatus.Disabled,
+                CreateTime = DateTime.UtcNow.AddMinutes(-2)
+            },
+            new EtlJobDefinition
+            {
+                Name = "InventorySync",
+                CronExpression = "0 0 * * *",
+                SourceCsKey = "warehouse",
+                SourceDbType = DBTypeEnum.SqlServer,
+                WatermarkType = EtlWatermarkType.FullLoad,
+                Status = EtlJobStatus.Enabled,
+                CreateTime = DateTime.UtcNow.AddMinutes(-1)
+            }
+        );
+        dc.SaveChanges();
+    }
+
+    private EtlJobListVM CreateVm()
+    {
+        var vm = _wtm.CreateVM<EtlJobListVM>();
+        return vm;
+    }
+
+    [TestMethod]
+    public void Search_by_name_filters_correctly()
+    {
+        var vm = CreateVm();
+        vm.Searcher.Name = "Order";
+        vm.DoSearch();
+
+        Assert.AreEqual(1, vm.EntityList.Count);
+        Assert.AreEqual("OrderSync", vm.EntityList[0].Name);
+    }
+
+    [TestMethod]
+    public void Search_by_status_filters_correctly()
+    {
+        var vm = CreateVm();
+        vm.Searcher.Status = EtlJobStatus.Enabled;
+        vm.DoSearch();
+
+        Assert.AreEqual(2, vm.EntityList.Count);
+        Assert.IsTrue(vm.EntityList.All(x => x.Status == EtlJobStatus.Enabled));
+    }
+
+    [TestMethod]
+    public void List_orders_by_create_time_desc()
+    {
+        var vm = CreateVm();
+        vm.DoSearch();
+
+        Assert.AreEqual(3, vm.EntityList.Count);
+        Assert.AreEqual("InventorySync", vm.EntityList[0].Name);
+        Assert.AreEqual("ProductSync", vm.EntityList[1].Name);
+        Assert.AreEqual("OrderSync", vm.EntityList[2].Name);
+    }
+
+    [TestMethod]
+    public void Search_by_source_db_type_filters_correctly()
+    {
+        var vm = CreateVm();
+        vm.Searcher.SourceDbType = DBTypeEnum.Oracle;
+        vm.DoSearch();
+
+        Assert.AreEqual(0, vm.EntityList.Count);
+    }
+
+    [TestMethod]
+    public void Search_no_filter_returns_all()
+    {
+        var vm = CreateVm();
+        vm.DoSearch();
+
+        Assert.AreEqual(3, vm.EntityList.Count);
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/ViewModels/EtlRunLogListVmTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/ViewModels/EtlRunLogListVmTests.cs
@@ -1,0 +1,130 @@
+#nullable enable
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.ViewModels;
+using WalkingTec.Mvvm.Test.Mock;
+
+namespace WalkingTec.Mvvm.Etl.Test.ViewModels;
+
+[TestClass]
+public class EtlRunLogListVmTests
+{
+    private WTMContext _wtm = null!;
+    private Guid _jobId1;
+    private Guid _jobId2;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var dc = new EtlTestDataContext(Guid.NewGuid().ToString(), DBTypeEnum.Memory);
+        _wtm = MockWtmContext.CreateWtmContext(dc);
+
+        _jobId1 = Guid.NewGuid();
+        _jobId2 = Guid.NewGuid();
+
+        // Seed jobs
+        dc.Set<EtlJobDefinition>().AddRange(
+            new EtlJobDefinition
+            {
+                ID = _jobId1, Name = "Job1", CronExpression = "0 0 * * *",
+                SourceCsKey = "cs1", SourceDbType = DBTypeEnum.SqlServer,
+                WatermarkType = EtlWatermarkType.FullLoad, Status = EtlJobStatus.Enabled
+            },
+            new EtlJobDefinition
+            {
+                ID = _jobId2, Name = "Job2", CronExpression = "0 0 * * *",
+                SourceCsKey = "cs2", SourceDbType = DBTypeEnum.SqlServer,
+                WatermarkType = EtlWatermarkType.FullLoad, Status = EtlJobStatus.Enabled
+            }
+        );
+
+        // Seed run logs
+        dc.Set<EtlRunLog>().AddRange(
+            new EtlRunLog
+            {
+                JobId = _jobId1, Trigger = EtlRunTrigger.Scheduled,
+                Result = EtlRunResult.Success, ExtractedRows = 1000, LoadedRows = 1000,
+                StartedAt = new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc),
+                FinishedAt = new DateTime(2026, 3, 10, 0, 5, 0, DateTimeKind.Utc), ElapsedMs = 300000
+            },
+            new EtlRunLog
+            {
+                JobId = _jobId1, Trigger = EtlRunTrigger.Manual,
+                Result = EtlRunResult.Failed, ErrorMessage = "Connection timeout",
+                StartedAt = new DateTime(2026, 3, 11, 0, 0, 0, DateTimeKind.Utc),
+                FinishedAt = new DateTime(2026, 3, 11, 0, 1, 0, DateTimeKind.Utc), ElapsedMs = 60000
+            },
+            new EtlRunLog
+            {
+                JobId = _jobId2, Trigger = EtlRunTrigger.Scheduled,
+                Result = EtlRunResult.Success, ExtractedRows = 500, LoadedRows = 500,
+                StartedAt = new DateTime(2026, 3, 12, 0, 0, 0, DateTimeKind.Utc),
+                FinishedAt = new DateTime(2026, 3, 12, 0, 2, 0, DateTimeKind.Utc), ElapsedMs = 120000
+            }
+        );
+        dc.SaveChanges();
+    }
+
+    private EtlRunLogListVM CreateVm()
+    {
+        return _wtm.CreateVM<EtlRunLogListVM>();
+    }
+
+    [TestMethod]
+    public void Search_by_job_id_filters_correctly()
+    {
+        var vm = CreateVm();
+        vm.Searcher.JobId = _jobId1;
+        vm.DoSearch();
+
+        Assert.AreEqual(2, vm.EntityList.Count);
+        Assert.IsTrue(vm.EntityList.All(x => x.JobId == _jobId1));
+    }
+
+    [TestMethod]
+    public void Search_by_result_filters_correctly()
+    {
+        var vm = CreateVm();
+        vm.Searcher.Result = EtlRunResult.Failed;
+        vm.DoSearch();
+
+        Assert.AreEqual(1, vm.EntityList.Count);
+        Assert.AreEqual("Connection timeout", vm.EntityList[0].ErrorMessage);
+    }
+
+    [TestMethod]
+    public void Search_by_date_range_filters_correctly()
+    {
+        var vm = CreateVm();
+        vm.Searcher.StartedAtBegin = new DateTime(2026, 3, 11, 0, 0, 0, DateTimeKind.Utc);
+        vm.Searcher.StartedAtEnd = new DateTime(2026, 3, 12, 23, 59, 59, DateTimeKind.Utc);
+        vm.DoSearch();
+
+        Assert.AreEqual(2, vm.EntityList.Count);
+    }
+
+    [TestMethod]
+    public void List_orders_by_started_at_desc()
+    {
+        var vm = CreateVm();
+        vm.DoSearch();
+
+        Assert.AreEqual(3, vm.EntityList.Count);
+        Assert.IsTrue(vm.EntityList[0].StartedAt >= vm.EntityList[1].StartedAt);
+        Assert.IsTrue(vm.EntityList[1].StartedAt >= vm.EntityList[2].StartedAt);
+    }
+
+    [TestMethod]
+    public void Search_by_trigger_filters_correctly()
+    {
+        var vm = CreateVm();
+        vm.Searcher.Trigger = EtlRunTrigger.Manual;
+        vm.DoSearch();
+
+        Assert.AreEqual(1, vm.EntityList.Count);
+        Assert.AreEqual(EtlRunTrigger.Manual, vm.EntityList[0].Trigger);
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/ViewModels/EtlTestDataContext.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/ViewModels/EtlTestDataContext.cs
@@ -1,0 +1,15 @@
+#nullable enable
+using Microsoft.EntityFrameworkCore;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Models;
+
+namespace WalkingTec.Mvvm.Etl.Test.ViewModels;
+
+internal class EtlTestDataContext : EmptyContext
+{
+    public EtlTestDataContext(string cs, DBTypeEnum dbtype)
+        : base(cs, dbtype) { }
+
+    public DbSet<EtlJobDefinition> EtlJobDefinitions { get; set; } = null!;
+    public DbSet<EtlRunLog> EtlRunLogs { get; set; } = null!;
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/WalkingTec.Mvvm.Etl.Test.csproj
+++ b/test/WalkingTec.Mvvm.Etl.Test/WalkingTec.Mvvm.Etl.Test.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WalkingTec.Mvvm.Etl\WalkingTec.Mvvm.Etl.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/WalkingTec.Mvvm.Etl.Test/WalkingTec.Mvvm.Etl.Test.csproj
+++ b/test/WalkingTec.Mvvm.Etl.Test/WalkingTec.Mvvm.Etl.Test.csproj
@@ -15,5 +15,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\WalkingTec.Mvvm.Etl\WalkingTec.Mvvm.Etl.csproj" />
+    <ProjectReference Include="..\WalkingTec.Mvvm.Test.Mock\WalkingTec.Mvvm.Test.Mock.csproj" />
   </ItemGroup>
 </Project>

--- a/test/docker-compose.etl-test.yml
+++ b/test/docker-compose.etl-test.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "EtlTest@2026!"
+    ports:
+      - "1433:1433"
+    healthcheck:
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "EtlTest@2026!" -Q "SELECT 1" -C
+      interval: 10s
+      retries: 10
+      start_period: 30s
+
+  oracle:
+    image: gvenzl/oracle-xe:21-slim
+    environment:
+      ORACLE_PASSWORD: "EtlTest2026"
+    ports:
+      - "1521:1521"
+    healthcheck:
+      test: healthcheck.sh
+      interval: 20s
+      retries: 10
+      start_period: 60s


### PR DESCRIPTION
## Summary

Closes #169

- **Developer documentation** (`docs/etl-module.md`, 603 lines): Quick Start, API reference, watermark strategies, staging tables, scheduling, security model, troubleshooting
- **Docker Compose test environment** (`test/docker-compose.etl-test.yml`): MSSQL 2022 + Oracle XE 21
- **15 integration tests**: 6 MssqlBulkLoader, 6 OracleBulkLoader, 3 end-to-end pipeline (full load, incremental, failure resilience)
- **CHANGELOG** updated with 8.6.0 ETL module entry

## Impact

- No business logic changes — documentation and test-only delivery
- All 65 existing unit tests pass
- Integration tests require Docker (`--filter "TestCategory=Integration"`)

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test --filter "TestCategory!=Integration"` — 65/65 pass
- [ ] `docker compose -f test/docker-compose.etl-test.yml up -d` → `dotnet test --filter "TestCategory=Integration"` (manual, requires Docker)

## Follow-up

- #216 — integration test edge case coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)