### PR TITLE
test(etl): edge case tests — batch, transform, concurrency, Oracle E2E

### DIFF
--- a/test/WalkingTec.Mvvm.Etl.Test/Integration/OracleEndToEndPipelineTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Integration/OracleEndToEndPipelineTests.cs
@@ -1,0 +1,234 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Oracle.ManagedDataAccess.Client;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Pipeline.Loaders;
+using WalkingTec.Mvvm.Etl.Pipeline.Sources;
+
+namespace WalkingTec.Mvvm.Etl.Test.Integration;
+
+/// <summary>
+/// Oracle 端到端 Pipeline 整合測試 — 驗證 Oracle-to-Oracle 完整 ETL 流程。
+/// 需要 Docker: docker compose -f test/docker-compose.etl-test.yml up -d
+/// </summary>
+[TestClass]
+[TestCategory("Integration")]
+public class OracleEndToEndPipelineTests : IntegrationTestBase
+{
+    private const string SourceTable = "ETL_E2E_ORA_SOURCE";
+    private const string StagingTable = "ETL_E2E_ORA_STAGING";
+    private const string TargetTable = "ETL_E2E_ORA_TARGET";
+
+    private static readonly StagingTableSpec StagingSpec = new(
+        StagingTable,
+        new StagingColumn("ORDERNO", "VARCHAR2(50)"),
+        new StagingColumn("AMOUNT", "NUMBER(18,2)"),
+        new StagingColumn("UPDATEDAT", "TIMESTAMP")
+    );
+
+    [TestInitialize]
+    public async Task Setup()
+    {
+        await DropOracleTableSafeAsync(SourceTable);
+        await DropOracleTableSafeAsync(StagingTable);
+        await DropOracleTableSafeAsync(TargetTable);
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        await DropOracleTableSafeAsync(SourceTable);
+        await DropOracleTableSafeAsync(StagingTable);
+        await DropOracleTableSafeAsync(TargetTable);
+    }
+
+    [TestMethod]
+    public async Task Full_pipeline_oracle_to_oracle()
+    {
+        // Arrange — 來源 2000 筆
+        await CreateOracleSourceTableAsync(SourceTable, 2000);
+        await CreateOracleTargetTableAsync(TargetTable);
+
+        using var source = new OracleSource();
+        var loader = new OracleBulkLoader();
+        var executor = new EtlPipelineExecutor(source, loader);
+
+        var config = new EtlPipelineConfig
+        {
+            JobId = Guid.NewGuid(),
+            JobName = "Oracle-E2E-FullLoad",
+            SourceConnectionString = OracleConnectionString,
+            TargetConnectionString = OracleConnectionString,
+            QueryTemplate = $"SELECT ORDERNO, AMOUNT, UPDATEDAT FROM {SourceTable}",
+            TargetTableName = TargetTable,
+            MergeKeyColumn = "ORDERNO",
+            BatchSize = 500,
+            StagingTable = StagingSpec
+        };
+
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+
+        // Act
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        // Assert
+        Assert.IsTrue(result.Success, $"Pipeline failed: {result.ErrorMessage}");
+        Assert.AreEqual(2000, result.ExtractedRows);
+        Assert.AreEqual(2000, result.LoadedRows);
+
+        var targetCount = await CountOracleRowsAsync(TargetTable);
+        Assert.AreEqual(2000, targetCount);
+    }
+
+    [TestMethod]
+    public async Task Incremental_pipeline_oracle_only_loads_new_rows()
+    {
+        // Arrange — 來源先 500 筆
+        await CreateOracleSourceTableAsync(SourceTable, 500);
+        await CreateOracleTargetTableAsync(TargetTable);
+
+        // 第一跑
+        using var source1 = new OracleSource();
+        var loader = new OracleBulkLoader();
+        var executor1 = new EtlPipelineExecutor(source1, loader);
+
+        var config = new EtlPipelineConfig
+        {
+            JobId = Guid.NewGuid(),
+            JobName = "Oracle-E2E-Incremental",
+            SourceConnectionString = OracleConnectionString,
+            TargetConnectionString = OracleConnectionString,
+            QueryTemplate = $"SELECT ORDERNO, AMOUNT, UPDATEDAT FROM {SourceTable} WHERE UPDATEDAT > :watermark ORDER BY UPDATEDAT",
+            TargetTableName = TargetTable,
+            MergeKeyColumn = "ORDERNO",
+            BatchSize = 200,
+            StagingTable = StagingSpec
+        };
+
+        var watermark1 = new WatermarkStrategy(
+            EtlWatermarkType.Timestamp, "UPDATEDAT",
+            "\"2025-12-31T00:00:00Z\"");
+
+        var result1 = await executor1.ExecuteAsync(config, watermark1);
+        Assert.IsTrue(result1.Success, $"First run failed: {result1.ErrorMessage}");
+        Assert.AreEqual(500, result1.ExtractedRows);
+
+        // 新增 200 筆
+        await InsertOracleRowsAsync(SourceTable, 200, 500);
+
+        // 第二跑
+        using var source2 = new OracleSource();
+        var executor2 = new EtlPipelineExecutor(source2, loader);
+        var watermark2 = new WatermarkStrategy(
+            EtlWatermarkType.Timestamp, "UPDATEDAT",
+            result1.NewWatermarkValue);
+
+        var result2 = await executor2.ExecuteAsync(config, watermark2);
+
+        // Assert
+        Assert.IsTrue(result2.Success, $"Second run failed: {result2.ErrorMessage}");
+        Assert.AreEqual(200, result2.ExtractedRows);
+
+        var targetCount = await CountOracleRowsAsync(TargetTable);
+        Assert.AreEqual(700, targetCount);
+    }
+
+    #region Oracle Helpers
+
+    private static async Task CreateOracleSourceTableAsync(string tableName, int rowCount)
+    {
+        await DropOracleTableSafeAsync(tableName);
+        await using var conn = new OracleConnection(OracleConnectionString);
+        await conn.OpenAsync();
+
+        await using var createCmd = conn.CreateCommand();
+        createCmd.CommandText = $@"
+            CREATE TABLE {tableName} (
+                ORDERNO   VARCHAR2(50) NOT NULL,
+                AMOUNT    NUMBER(18,2) NOT NULL,
+                UPDATEDAT TIMESTAMP NOT NULL,
+                CONSTRAINT PK_{tableName} PRIMARY KEY (ORDERNO)
+            )";
+        await createCmd.ExecuteNonQueryAsync();
+
+        var baseDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (int i = 0; i < rowCount; i++)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $@"
+                INSERT INTO {tableName} (ORDERNO, AMOUNT, UPDATEDAT)
+                VALUES (:no, :amt, :dt)";
+            cmd.Parameters.Add(new OracleParameter("no", $"ORD-{i:D8}"));
+            cmd.Parameters.Add(new OracleParameter("amt", 100m + (i % 1000)));
+            cmd.Parameters.Add(new OracleParameter("dt", baseDate.AddSeconds(i)));
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static async Task CreateOracleTargetTableAsync(string tableName)
+    {
+        await DropOracleTableSafeAsync(tableName);
+        await using var conn = new OracleConnection(OracleConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
+            CREATE TABLE {tableName} (
+                ORDERNO   VARCHAR2(50) NOT NULL,
+                AMOUNT    NUMBER(18,2) NOT NULL,
+                UPDATEDAT TIMESTAMP NOT NULL,
+                CONSTRAINT PK_{tableName} PRIMARY KEY (ORDERNO)
+            )";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task InsertOracleRowsAsync(string tableName, int count, int startIndex)
+    {
+        await using var conn = new OracleConnection(OracleConnectionString);
+        await conn.OpenAsync();
+
+        var baseDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (int i = startIndex; i < startIndex + count; i++)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $@"
+                INSERT INTO {tableName} (ORDERNO, AMOUNT, UPDATEDAT)
+                VALUES (:no, :amt, :dt)";
+            cmd.Parameters.Add(new OracleParameter("no", $"ORD-{i:D8}"));
+            cmd.Parameters.Add(new OracleParameter("amt", 100m + (i % 1000)));
+            cmd.Parameters.Add(new OracleParameter("dt", baseDate.AddSeconds(i)));
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static async Task DropOracleTableSafeAsync(string tableName)
+    {
+        await using var conn = new OracleConnection(OracleConnectionString);
+        await conn.OpenAsync();
+
+        await using var checkCmd = conn.CreateCommand();
+        checkCmd.CommandText = "SELECT COUNT(*) FROM USER_TABLES WHERE TABLE_NAME = :t";
+        checkCmd.Parameters.Add(new OracleParameter("t", tableName.ToUpperInvariant()));
+        var exists = Convert.ToInt32(await checkCmd.ExecuteScalarAsync()) > 0;
+
+        if (exists)
+        {
+            await using var dropCmd = conn.CreateCommand();
+            dropCmd.CommandText = $"DROP TABLE {tableName} PURGE";
+            await dropCmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static async Task<int> CountOracleRowsAsync(string tableName)
+    {
+        await using var conn = new OracleConnection(OracleConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM {tableName}";
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+    }
+
+    #endregion
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EdgeCaseTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EdgeCaseTests.cs
@@ -1,0 +1,166 @@
+#nullable enable
+using System;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Pipeline;
+using WalkingTec.Mvvm.Etl.Testing;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+/// <summary>
+/// Pipeline 邊界場景測試 — 補充 #216
+/// </summary>
+[TestClass]
+public class EdgeCaseTests
+{
+    private MockEtlSource _source = null!;
+    private MockBulkLoader _loader = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _source = new MockEtlSource();
+        _loader = new MockBulkLoader();
+    }
+
+    // ─── Batch splitting ───
+
+    [TestMethod]
+    public async Task Batch_splitting_10K_by_3K_yields_4_batches()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(10_000));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 3_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue();
+        _loader.BatchCount.Should().Be(4); // 3K + 3K + 3K + 1K
+        _loader.TotalRows.Should().Be(10_000);
+    }
+
+    [TestMethod]
+    public async Task Batch_splitting_exact_multiple_yields_correct_count()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(9_000));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 3_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue();
+        _loader.BatchCount.Should().Be(3); // 3K + 3K + 3K exact
+        _loader.TotalRows.Should().Be(9_000);
+    }
+
+    [TestMethod]
+    public async Task Batch_size_larger_than_data_yields_single_batch()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100));
+        var config = TestHelpers.CreateTestConfig() with { BatchSize = 50_000 };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue();
+        _loader.BatchCount.Should().Be(1);
+        _loader.TotalRows.Should().Be(100);
+    }
+
+    // ─── Transform: filtering ───
+
+    [TestMethod]
+    public async Task Transform_filtering_reduces_loaded_rows()
+    {
+        // 1000 筆，Amount 在 100~1099 之間，過濾只留 Amount > 500
+        _source.SetData(TestHelpers.GenerateOrderData(1_000));
+        var config = TestHelpers.CreateTestConfig() with
+        {
+            BatchSize = 500,
+            TransformFunc = dt =>
+            {
+                var filtered = dt.Clone();
+                foreach (DataRow row in dt.Rows)
+                {
+                    if ((decimal)row["Amount"] > 500m)
+                        filtered.ImportRow(row);
+                }
+                return filtered;
+            }
+        };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue();
+        // Amount = 100 + (i % 1000), so values > 500 are i%1000 > 400 → 599 out of 1000
+        result.LoadedRows.Should().BeLessThan(1_000);
+        result.LoadedRows.Should().BeGreaterThan(0);
+        _loader.MergeCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Transform_filtering_all_rows_results_in_zero_loaded()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(100));
+        var config = TestHelpers.CreateTestConfig() with
+        {
+            TransformFunc = _ =>
+            {
+                // Return empty DataTable — all rows filtered out
+                var empty = new DataTable();
+                empty.Columns.Add("OrderNo", typeof(string));
+                empty.Columns.Add("Amount", typeof(decimal));
+                empty.Columns.Add("UpdatedAt", typeof(DateTime));
+                return empty;
+            }
+        };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue();
+        result.LoadedRows.Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task Transform_adds_computed_column()
+    {
+        _source.SetData(TestHelpers.GenerateOrderData(50));
+        DataTable? capturedBatch = null;
+        _loader.OnBatchLoaded += (_, _) =>
+        {
+            capturedBatch ??= _loader.LoadedBatches.First();
+        };
+
+        var config = TestHelpers.CreateTestConfig() with
+        {
+            TransformFunc = dt =>
+            {
+                if (!dt.Columns.Contains("DoubleAmount"))
+                    dt.Columns.Add("DoubleAmount", typeof(decimal));
+                foreach (DataRow row in dt.Rows)
+                    row["DoubleAmount"] = (decimal)row["Amount"] * 2;
+                return dt;
+            }
+        };
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        await executor.ExecuteAsync(config, watermark);
+
+        capturedBatch.Should().NotBeNull();
+        capturedBatch!.Columns.Contains("DoubleAmount").Should().BeTrue();
+        var firstRow = capturedBatch.Rows[0];
+        ((decimal)firstRow["DoubleAmount"]).Should().Be((decimal)firstRow["Amount"] * 2);
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Scheduling/ConcurrentExecutionTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Scheduling/ConcurrentExecutionTests.cs
@@ -1,0 +1,64 @@
+#nullable enable
+using System;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Quartz;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Scheduling;
+
+namespace WalkingTec.Mvvm.Etl.Test.Scheduling;
+
+/// <summary>
+/// 並行觸發保護測試 — 驗證 Quartz [DisallowConcurrentExecution] attribute
+/// 和 ShouldExecute 的 Running 狀態檢查雙重保護機制。
+/// </summary>
+[TestClass]
+public class ConcurrentExecutionTests
+{
+    [TestMethod]
+    public void EtlQuartzJob_has_DisallowConcurrentExecution_attribute()
+    {
+        var attr = typeof(EtlQuartzJob)
+            .GetCustomAttribute<DisallowConcurrentExecutionAttribute>();
+
+        Assert.IsNotNull(attr,
+            "EtlQuartzJob must have [DisallowConcurrentExecution] to prevent parallel runs of the same job");
+    }
+
+    [TestMethod]
+    public void ShouldExecute_rejects_Running_status()
+    {
+        var job = new EtlJobDefinition
+        {
+            Name = "concurrent-test",
+            CronExpression = "0 0 * * *",
+            SourceCsKey = "test",
+            SourceDbType = Core.DBTypeEnum.SqlServer,
+            WatermarkType = EtlWatermarkType.FullLoad,
+            Status = EtlJobStatus.Running,
+            SkipCount = 0
+        };
+
+        Assert.IsFalse(EtlSchedulerService.ShouldExecute(job),
+            "Running jobs must not be re-executed (application-level protection)");
+    }
+
+    [TestMethod]
+    public void ShouldExecute_accepts_Enabled_after_previous_run_completes()
+    {
+        var job = new EtlJobDefinition
+        {
+            Name = "concurrent-test",
+            CronExpression = "0 0 * * *",
+            SourceCsKey = "test",
+            SourceDbType = Core.DBTypeEnum.SqlServer,
+            WatermarkType = EtlWatermarkType.FullLoad,
+            Status = EtlJobStatus.Enabled,
+            SkipCount = 0,
+            LastRunAt = DateTime.UtcNow.AddMinutes(-5)
+        };
+
+        Assert.IsTrue(EtlSchedulerService.ShouldExecute(job),
+            "Enabled jobs with completed previous runs should execute");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #216

Adds 11 new tests (9 unit + 2 integration) covering edge case scenarios for the ETL module.

### Unit tests (9, run in CI)
- **Batch splitting**: 10K/3K→4 batches, exact multiple (9K/3K→3), oversized batch (100/50K→1)
- **Transform**: row filtering with reduced count, filter-all→zero rows, computed column addition
- **Concurrency**: `[DisallowConcurrentExecution]` attribute verification via reflection, `ShouldExecute` Running/Enabled state checks

### Integration tests (2, require Docker)
- Full pipeline Oracle-to-Oracle (2000 rows, BatchSize=500)
- Incremental pipeline with Timestamp watermark (500 + 200 rows)

## Impact

- No business logic changes — test-only
- Unit test count: 65 → 74 (+9)

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test --filter "TestCategory!=Integration"` — 74/74 pass
- [ ] Oracle E2E (manual, requires Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)