### PR TITLE
fix: path traversal, tenant isolation, GetMaxValue crash

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
@@ -85,11 +85,27 @@ public class JsonFileDashboardService : IDashboardService
 
     private string GetFilePath(string id, string? tenantId = null)
     {
+        ValidatePathSegment(id, nameof(id));
+        if (!string.IsNullOrEmpty(tenantId))
+            ValidatePathSegment(tenantId, nameof(tenantId));
+
         var dir = string.IsNullOrEmpty(tenantId)
             ? Path.Combine(_baseDir, "_default")
             : Path.Combine(_baseDir, tenantId);
         if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
-        return Path.Combine(dir, $"{id}.json");
+
+        var fullPath = Path.GetFullPath(Path.Combine(dir, $"{id}.json"));
+        var baseFullPath = Path.GetFullPath(_baseDir);
+        if (!fullPath.StartsWith(baseFullPath, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException($"Path traversal detected in dashboard ID or tenant ID.");
+
+        return fullPath;
+    }
+
+    private static void ValidatePathSegment(string value, string paramName)
+    {
+        if (value.Contains("..") || value.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            throw new ArgumentException($"Invalid characters in {paramName}: '{value}'");
     }
 
     public async Task<DashboardDefinition?> GetAsync(string dashboardId, string? tenantId = null)

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
@@ -163,9 +163,11 @@ public class EtlPipelineExecutor
         if (!batch.Columns.Contains(columnName) || batch.Rows.Count == 0)
             return null;
 
-        return batch.AsEnumerable()
+        var values = batch.AsEnumerable()
             .Select(r => r[columnName])
             .Where(v => v != null && v != DBNull.Value)
-            .Max();
+            .ToList();
+
+        return values.Count == 0 ? null : values.Max();
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc/_DashboardController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_DashboardController.cs
@@ -88,7 +88,8 @@ namespace WalkingTec.Mvvm.Mvc
         {
             if (dashboard == null || dashboard.Id != id) return BadRequest();
 
-            var existing = await _dashboardService.GetAsync(id);
+            var tenantId = GetTenantId();
+            var existing = await _dashboardService.GetAsync(id, tenantId);
             if (existing == null) return NotFound();
 
             var (userId, roles) = GetUserInfo();
@@ -98,7 +99,8 @@ namespace WalkingTec.Mvvm.Mvc
             }
 
             dashboard.Owner = existing.Owner; // preserve owner
-            
+            dashboard.TenantId = tenantId;    // server-side tenant, prevent spoofing
+
             await _dashboardService.UpdateAsync(dashboard);
             return Ok();
         }
@@ -106,7 +108,8 @@ namespace WalkingTec.Mvvm.Mvc
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete(string id)
         {
-            var existing = await _dashboardService.GetAsync(id);
+            var tenantId = GetTenantId();
+            var existing = await _dashboardService.GetAsync(id, tenantId);
             if (existing == null) return NotFound();
 
             var (userId, roles) = GetUserInfo();
@@ -122,7 +125,8 @@ namespace WalkingTec.Mvvm.Mvc
         [HttpGet("{id}/widget/{wid}/data")]
         public async Task<IActionResult> GetWidgetData(string id, string wid, CancellationToken ct)
         {
-            var dashboard = await _dashboardService.GetAsync(id);
+            var tenantId = GetTenantId();
+            var dashboard = await _dashboardService.GetAsync(id, tenantId);
             if (dashboard == null) return NotFound();
 
             var (userId, roles) = GetUserInfo();
@@ -152,7 +156,8 @@ namespace WalkingTec.Mvvm.Mvc
         [HttpPost("{id}/widget/{wid}/data")]
         public async Task<IActionResult> PostWidgetData(string id, string wid, [FromBody] Dictionary<string, string> filters, CancellationToken ct)
         {
-            var dashboard = await _dashboardService.GetAsync(id);
+            var tenantId = GetTenantId();
+            var dashboard = await _dashboardService.GetAsync(id, tenantId);
             if (dashboard == null) return NotFound();
 
             var (userId, roles) = GetUserInfo();

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/JsonFileDashboardServiceTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/JsonFileDashboardServiceTests.cs
@@ -174,5 +174,20 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             list.Should().HaveCount(1);
             list[0].Title.Should().Be("Default");
         }
+
+        [TestMethod]
+        public void Path_traversal_in_id_throws()
+        {
+            Func<Task> act = async () => await _service.CreateAsync(
+                new DashboardDefinition { Id = "../../../etc/evil", Title = "hack" });
+            act.Should().ThrowAsync<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void Path_traversal_in_tenantId_throws()
+        {
+            Func<Task> act = async () => await _service.GetAsync("valid-id", "../other_tenant");
+            act.Should().ThrowAsync<ArgumentException>();
+        }
     }
 }

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EdgeCaseTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EdgeCaseTests.cs
@@ -132,6 +132,37 @@ public class EdgeCaseTests
         result.LoadedRows.Should().Be(0);
     }
 
+    // ─── Watermark edge case ───
+
+    [TestMethod]
+    public async Task All_null_watermark_column_does_not_crash()
+    {
+        // All UpdatedAt values are DBNull — GetMaxValue should return null, not throw
+        var dt = new DataTable();
+        dt.Columns.Add("OrderNo", typeof(string));
+        dt.Columns.Add("Amount", typeof(decimal));
+        dt.Columns.Add("UpdatedAt", typeof(DateTime));
+        for (int i = 0; i < 10; i++)
+        {
+            var row = dt.NewRow();
+            row["OrderNo"] = $"ORD-{i:D4}";
+            row["Amount"] = 100m + i;
+            row["UpdatedAt"] = DBNull.Value;
+            dt.Rows.Add(row);
+        }
+        _source.SetData(dt);
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.Timestamp, "UpdatedAt", null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue();
+        result.ExtractedRows.Should().Be(10);
+    }
+
+    // ─── Transform: computed column ───
+
     [TestMethod]
     public async Task Transform_adds_computed_column()
     {


### PR DESCRIPTION
## Summary
- **P1 Path traversal** — `JsonFileDashboardService.GetFilePath()` now validates `id`/`tenantId` against `..` and invalid path chars, plus defense-in-depth `GetFullPath` check
- **P1 Tenant isolation bypass** — `_DashboardController` Update/Delete/GetWidgetData/PostWidgetData now pass `tenantId` to `GetAsync()`; Update sets server-side `TenantId`
- **P2 GetMaxValue crash** — `EtlPipelineExecutor` guards against empty sequence when all watermark column values are null

## Test plan
- [x] 75 .NET tests pass (including 2 new path traversal regression tests + 1 null watermark test)
- [x] 191 JS tests pass
- [x] `dotnet build -c Release` clean (0 errors)

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)