### PR TITLE
fix(analysis): apply DimensionHierarchies in InProcessGroupByStrategy

### DIFF
--- a/demo/WalkingTec.Mvvm.Demo/ViewModels/StudentVMs/StudentListVM.cs
+++ b/demo/WalkingTec.Mvvm.Demo/ViewModels/StudentVMs/StudentListVM.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -79,7 +79,8 @@ namespace WalkingTec.Mvvm.Demo.ViewModels.StudentVMs
                     PhotoId = x.PhotoId,
                     IsValid = x.IsValid,
                     EnRollDate = x.EnRollDate,
-                    MajorName_view = x.StudentMajor.Select(y=>y.Major.MajorName).ToSepratedString(null,","), 
+                    RecordCount = 1,
+                    MajorName_view = x.StudentMajor.Select(y=>y.Major.MajorName).ToSepratedString(null,","),
                 })
                 .OrderBy(x => x.ID);
             return query;
@@ -91,5 +92,8 @@ namespace WalkingTec.Mvvm.Demo.ViewModels.StudentVMs
         [Display(Name = "专业名称")]
         public String MajorName_view { get; set; }
 
+        [Display(Name = "學生數")]
+        [Measure(DisplayName = "學生數", AllowedFuncs = AggregateFunc.Count | AggregateFunc.Sum)]
+        public int RecordCount { get; set; }
     }
 }

--- a/src/WalkingTec.Mvvm.Core/Analysis/InProcessGroupByStrategy.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/InProcessGroupByStrategy.cs
@@ -28,7 +28,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
             var items = query.Take(MaxMaterializeRows).ToList();
 
             return items
-                .GroupBy(row => BuildGroupKey(row, req.Dimensions))
+                .GroupBy(row => BuildGroupKey(row, req.Dimensions, req.DimensionHierarchies, whitelist))
                 .Take(MaxRows + 1)
                 .Select(g =>
                 {
@@ -65,13 +65,37 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 .ToList();
         }
 
-        private static string BuildGroupKey<TModel>(TModel row, List<string> dimensions)
+        private static string BuildGroupKey<TModel>(
+            TModel row,
+            List<string> dimensions,
+            Dictionary<string, DateHierarchy>? hierarchies,
+            Dictionary<string, AnalysisFieldMeta> whitelist)
             => string.Join('\0', dimensions.Select(d =>
                {
                    var propInfo = typeof(TModel).GetProperty(d);
                    if (propInfo is null)
                        throw new InvalidOperationException($"Property '{d}' not found on {typeof(TModel).Name}.");
-                   return propInfo.GetValue(row)?.ToString() ?? string.Empty;
+                   var val = propInfo.GetValue(row);
+                   if (val == null) return string.Empty;
+
+                   // 日期維度按 hierarchy 截斷
+                   if (hierarchies != null
+                       && hierarchies.TryGetValue(d, out var h)
+                       && h != DateHierarchy.None
+                       && val is DateTime dt)
+                   {
+                       int key = h switch
+                       {
+                           DateHierarchy.Year => dt.Year,
+                           DateHierarchy.Quarter => dt.Year * 10 + ((dt.Month - 1) / 3 + 1),
+                           DateHierarchy.Month => dt.Year * 100 + dt.Month,
+                           DateHierarchy.Day => dt.Year * 10000 + dt.Month * 100 + dt.Day,
+                           _ => throw new ArgumentException($"Unsupported hierarchy: {h}")
+                       };
+                       return DateTruncator.FormatKey(key, h);
+                   }
+
+                   return val.ToString() ?? string.Empty;
                }));
     }
 }

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/InProcessGroupByStrategyTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/InProcessGroupByStrategyTests.cs
@@ -38,10 +38,31 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             public decimal Discount { get; set; }
         }
 
+        /// <summary>
+        /// 帶有 DateTime 維度的測試模型，用於驗證日期階層截斷。
+        /// </summary>
+        private class DateSaleRecord
+        {
+            [Dimension(DisplayName = "訂單日期", Hierarchy = DateHierarchy.Month)]
+            public DateTime OrderDate { get; set; }
+
+            [Dimension(DisplayName = "地區")]
+            public string Region { get; set; } = string.Empty;
+
+            [Dimension(DisplayName = "出貨日期")]
+            public DateTime? ShipDate { get; set; }
+
+            [Measure(AllowedFuncs =
+                AggregateFunc.Sum | AggregateFunc.Count,
+                DisplayName = "金額")]
+            public decimal Amount { get; set; }
+        }
+
         // ─── 基礎設施 ──────────────────────────────────────────────────────────
 
         private InProcessGroupByStrategy _strategy = null!;
         private Dictionary<string, AnalysisFieldMeta> _whitelist = null!;
+        private Dictionary<string, AnalysisFieldMeta> _dateWhitelist = null!;
 
         [TestInitialize]
         public void Setup()
@@ -49,21 +70,28 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             _strategy = new InProcessGroupByStrategy();
             _whitelist = AnalysisFieldScanner.ScanModel(typeof(SaleRecord))
                 .ToDictionary(f => f.FieldName);
+            _dateWhitelist = AnalysisFieldScanner.ScanModel(typeof(DateSaleRecord))
+                .ToDictionary(f => f.FieldName);
         }
 
         private static IQueryable<SaleRecord> MakeQuery(params SaleRecord[] records)
             => records.AsQueryable();
 
+        private static IQueryable<DateSaleRecord> MakeDateQuery(params DateSaleRecord[] records)
+            => records.AsQueryable();
+
         private static AnalysisQueryRequest Req(
             string[]? dims = null,
-            (string field, AggregateFunc func)[]? msrs = null)
+            (string field, AggregateFunc func)[]? msrs = null,
+            Dictionary<string, DateHierarchy>? hierarchies = null)
         {
             return new AnalysisQueryRequest
             {
                 Dimensions = dims?.ToList() ?? new List<string>(),
                 Measures = msrs?.Select(m => new MeasureRequest { Field = m.field, Func = m.func }).ToList()
                            ?? new List<MeasureRequest>(),
-                Filters = new List<FilterCondition>()
+                Filters = new List<FilterCondition>(),
+                DimensionHierarchies = hierarchies
             };
         }
 
@@ -163,6 +191,161 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             // Verify the constant is accessible and correct
             Assert.AreEqual(50_000, InProcessGroupByStrategy.MaxMaterializeRows);
         }
+
+        // ─── 日期階層截斷測試（PR #228 修復驗證）─────────────────────────────
+
+        [TestMethod]
+        public void Date_dimension_with_Month_hierarchy_groups_by_month()
+        {
+            // 3 筆不同日期但同月 → 應只產生 1 個群組
+            var data = MakeDateQuery(
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 1), Amount = 100m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 15), Amount = 200m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 31), Amount = 300m }
+            );
+            var req = Req(
+                dims: new[] { "OrderDate" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                hierarchies: new Dictionary<string, DateHierarchy> { ["OrderDate"] = DateHierarchy.Month });
+
+            var rows = _strategy.Execute(data, req, _dateWhitelist);
+
+            Assert.AreEqual(1, rows.Count, "同月份的 3 筆應合併為 1 組");
+            Assert.AreEqual(600m, Convert.ToDecimal(rows[0]["Amount_Sum"]));
+            Assert.AreEqual("2026-03", rows[0]["OrderDate"]?.ToString());
+        }
+
+        [TestMethod]
+        public void Date_dimension_with_Year_hierarchy_groups_by_year()
+        {
+            var data = MakeDateQuery(
+                new DateSaleRecord { OrderDate = new DateTime(2025, 1, 10), Amount = 100m },
+                new DateSaleRecord { OrderDate = new DateTime(2025, 6, 20), Amount = 200m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 5), Amount = 300m }
+            );
+            var req = Req(
+                dims: new[] { "OrderDate" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                hierarchies: new Dictionary<string, DateHierarchy> { ["OrderDate"] = DateHierarchy.Year });
+
+            var rows = _strategy.Execute(data, req, _dateWhitelist);
+
+            Assert.AreEqual(2, rows.Count, "2025 和 2026 應分為 2 組");
+            var y2025 = rows.Single(r => r["OrderDate"]?.ToString() == "2025");
+            Assert.AreEqual(300m, Convert.ToDecimal(y2025["Amount_Sum"]));
+            var y2026 = rows.Single(r => r["OrderDate"]?.ToString() == "2026");
+            Assert.AreEqual(300m, Convert.ToDecimal(y2026["Amount_Sum"]));
+        }
+
+        [TestMethod]
+        public void Date_dimension_with_Quarter_hierarchy_groups_by_quarter()
+        {
+            var data = MakeDateQuery(
+                new DateSaleRecord { OrderDate = new DateTime(2026, 1, 15), Amount = 100m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 2, 20), Amount = 200m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 10), Amount = 300m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 4, 5), Amount = 400m }
+            );
+            var req = Req(
+                dims: new[] { "OrderDate" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                hierarchies: new Dictionary<string, DateHierarchy> { ["OrderDate"] = DateHierarchy.Quarter });
+
+            var rows = _strategy.Execute(data, req, _dateWhitelist);
+
+            Assert.AreEqual(2, rows.Count, "Q1 和 Q2 應分為 2 組");
+            var q1 = rows.Single(r => r["OrderDate"]?.ToString() == "2026 Q1");
+            Assert.AreEqual(600m, Convert.ToDecimal(q1["Amount_Sum"]));
+            var q2 = rows.Single(r => r["OrderDate"]?.ToString() == "2026 Q2");
+            Assert.AreEqual(400m, Convert.ToDecimal(q2["Amount_Sum"]));
+        }
+
+        [TestMethod]
+        public void Date_dimension_with_Day_hierarchy_groups_by_day()
+        {
+            var data = MakeDateQuery(
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 9, 8, 0, 0), Amount = 100m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 9, 16, 30, 0), Amount = 200m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 10, 9, 0, 0), Amount = 300m }
+            );
+            var req = Req(
+                dims: new[] { "OrderDate" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                hierarchies: new Dictionary<string, DateHierarchy> { ["OrderDate"] = DateHierarchy.Day });
+
+            var rows = _strategy.Execute(data, req, _dateWhitelist);
+
+            Assert.AreEqual(2, rows.Count, "同天不同時間應合併，不同天分開");
+            var day9 = rows.Single(r => r["OrderDate"]?.ToString() == "2026-03-09");
+            Assert.AreEqual(300m, Convert.ToDecimal(day9["Amount_Sum"]));
+            var day10 = rows.Single(r => r["OrderDate"]?.ToString() == "2026-03-10");
+            Assert.AreEqual(300m, Convert.ToDecimal(day10["Amount_Sum"]));
+        }
+
+        [TestMethod]
+        public void Date_dimension_without_hierarchy_preserves_exact_values()
+        {
+            // 不傳 DimensionHierarchies → 每個不同的 DateTime 值各自一組
+            var data = MakeDateQuery(
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 1), Amount = 100m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 15), Amount = 200m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 3, 31), Amount = 300m }
+            );
+            var req = Req(
+                dims: new[] { "OrderDate" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                hierarchies: null);
+
+            var rows = _strategy.Execute(data, req, _dateWhitelist);
+
+            Assert.AreEqual(3, rows.Count, "無階層時每個不同日期各自一組");
+        }
+
+        [TestMethod]
+        public void Nullable_DateTime_null_values_grouped_as_empty()
+        {
+            // ShipDate 是 DateTime?，null 值應歸為空字串群組
+            var data = MakeDateQuery(
+                new DateSaleRecord { OrderDate = new DateTime(2026, 1, 1), ShipDate = new DateTime(2026, 1, 5), Amount = 100m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 1, 2), ShipDate = null, Amount = 200m },
+                new DateSaleRecord { OrderDate = new DateTime(2026, 1, 3), ShipDate = null, Amount = 300m }
+            );
+            var req = Req(
+                dims: new[] { "ShipDate" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                hierarchies: new Dictionary<string, DateHierarchy> { ["ShipDate"] = DateHierarchy.Month });
+
+            var rows = _strategy.Execute(data, req, _dateWhitelist);
+
+            Assert.AreEqual(2, rows.Count, "有值和 null 應分為 2 組");
+            var nullGroup = rows.Single(r => string.IsNullOrEmpty(r["ShipDate"]?.ToString()));
+            Assert.AreEqual(500m, Convert.ToDecimal(nullGroup["Amount_Sum"]));
+        }
+
+        [TestMethod]
+        public void Date_hierarchy_combined_with_string_dimension()
+        {
+            // 混合 string 維度 + date 階層：Region × Month
+            var data = MakeDateQuery(
+                new DateSaleRecord { Region = "華東", OrderDate = new DateTime(2026, 1, 10), Amount = 100m },
+                new DateSaleRecord { Region = "華東", OrderDate = new DateTime(2026, 1, 20), Amount = 200m },
+                new DateSaleRecord { Region = "華東", OrderDate = new DateTime(2026, 2, 5), Amount = 300m },
+                new DateSaleRecord { Region = "華南", OrderDate = new DateTime(2026, 1, 15), Amount = 400m }
+            );
+            var req = Req(
+                dims: new[] { "Region", "OrderDate" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                hierarchies: new Dictionary<string, DateHierarchy> { ["OrderDate"] = DateHierarchy.Month });
+
+            var rows = _strategy.Execute(data, req, _dateWhitelist);
+
+            Assert.AreEqual(3, rows.Count, "華東×2026-01, 華東×2026-02, 華南×2026-01");
+            var hdJan = rows.Single(r =>
+                r["Region"]?.ToString() == "華東" && r["OrderDate"]?.ToString() == "2026-01");
+            Assert.AreEqual(300m, Convert.ToDecimal(hdJan["Amount_Sum"]));
+        }
+
+        // ─── 原有測試 ─────────────────────────────────────────────────────────
 
         [TestMethod]
         public void Produces_same_results_as_old_engine_inline()


### PR DESCRIPTION
## Summary

- **Fix**: `InProcessGroupByStrategy.BuildGroupKey()` now applies `DimensionHierarchies` to truncate date dimensions by year/quarter/month/day. Previously, `DateTruncator` existed but was never called, causing date dimensions to group by exact `DateTime` (428 groups for 500 rows instead of 33 monthly groups).
- **Demo**: Added `[Measure(Count|Sum)] RecordCount` property to `Student_View` so Analysis Mode has a usable measure for demo testing.

## Test plan

- [x] 470 existing tests pass (0 failures)
- [x] API verified: `POST /_analysis/query` with `dimensionHierarchies: {"EnRollDate": "Month"}` returns 33 monthly groups (`2025-06`, `2026-03`, etc.)
- [x] Frontend verified: Analysis Mode panel renders dimensions + measures, query returns correct table + bar chart
- [x] CSV/XLSX export verified

Fixes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)