### PR TITLE
feat(analysis): pie chart, card fix, Excel chart export

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
@@ -1,7 +1,10 @@
 #nullable enable
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using NPOI.SS.UserModel;
+using NPOI.SS.UserModel.Charts;
+using NPOI.SS.Util;
 using NPOI.XSSF.UserModel;
 
 namespace WalkingTec.Mvvm.Core.Analysis
@@ -14,7 +17,9 @@ namespace WalkingTec.Mvvm.Core.Analysis
         /// <summary>
         /// 匯出分析結果為 Excel（xlsx），回傳位元組陣列。
         /// </summary>
-        public static byte[] Export(AnalysisQueryResponse result)
+        /// <param name="result">查詢結果</param>
+        /// <param name="includeChart">是否嵌入圖表（預設 false）</param>
+        public static byte[] Export(AnalysisQueryResponse result, bool includeChart = false)
         {
             using var workbook = new XSSFWorkbook();
             var sheet = workbook.CreateSheet("Analysis");
@@ -47,9 +52,62 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 }
             }
 
+            if (includeChart && result.Rows.Count > 0 && result.Columns.Count >= 2)
+            {
+                EmbedBarChart(sheet, result);
+            }
+
             using var ms = new MemoryStream();
             workbook.Write(ms, leaveOpen: true);
             return ms.ToArray();
+        }
+
+        /// <summary>
+        /// 在數據表下方嵌入 bar chart。
+        /// 假設第一個 column 為維度（category），其餘為度量（values）。
+        /// </summary>
+        private static void EmbedBarChart(ISheet sheet, AnalysisQueryResponse result)
+        {
+            var drawing = sheet.CreateDrawingPatriarch();
+            // 圖表放在數據列下方，留 2 行空白
+            int chartTopRow = result.Rows.Count + 3;
+            var anchor = drawing.CreateAnchor(0, 0, 0, 0,
+                0, chartTopRow, result.Columns.Count + 2, chartTopRow + 15);
+            var chart = drawing.CreateChart(anchor);
+
+            // 找出度量 columns（跳過第一個維度 column）
+            var measureIndices = new List<int>();
+            for (int c = 1; c < result.Columns.Count; c++)
+            {
+                // 如果 column 對應的值在第一行是 numeric，視為度量
+                if (result.Rows[0].TryGetValue(result.Columns[c], out var v)
+                    && (v is decimal or double or float or int or long))
+                {
+                    measureIndices.Add(c);
+                }
+            }
+
+            if (measureIndices.Count == 0) return;
+
+            var data = chart.ChartDataFactory.CreateBarChartData<string, double>();
+
+            // Category axis: first column, rows 1..N (0-based: row 1 = first data row)
+            var cats = DataSources.FromStringCellRange(sheet,
+                new CellRangeAddress(1, result.Rows.Count, 0, 0));
+
+            foreach (var colIdx in measureIndices)
+            {
+                var vals = DataSources.FromNumericCellRange(sheet,
+                    new CellRangeAddress(1, result.Rows.Count, colIdx, colIdx));
+                data.AddSeries(cats, vals).SetTitle(result.Columns[colIdx]);
+            }
+
+            var catAxis = chart.ChartAxisFactory.CreateCategoryAxis(AxisPosition.Bottom);
+            var valAxis = chart.ChartAxisFactory.CreateValueAxis(AxisPosition.Left);
+            valAxis.SetCrosses(AxisCrosses.AutoZero);
+
+            chart.Plot(data, catAxis, valAxis);
+            chart.GetOrCreateLegend().Position = LegendPosition.Bottom;
         }
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -138,7 +138,8 @@ namespace WalkingTec.Mvvm.Mvc
         /// </summary>
         [HttpPost("export")]
         public IActionResult Export([FromBody] AnalysisQueryRequest req,
-                                    [FromQuery] string format = "xlsx")
+                                    [FromQuery] string format = "xlsx",
+                                    [FromQuery] bool includeChart = false)
         {
             // 與 Query 端點一致的維度/度量上限驗證（I-5）
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
@@ -170,7 +171,7 @@ namespace WalkingTec.Mvvm.Mvc
                 return File(Encoding.UTF8.GetBytes(csv), "text/csv", "analysis.csv");
             }
 
-            var xlsx = AnalysisExcelExporter.Export(result);
+            var xlsx = AnalysisExcelExporter.Export(result, includeChart);
             return File(xlsx,
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                 "analysis.xlsx");
@@ -182,7 +183,8 @@ namespace WalkingTec.Mvvm.Mvc
         /// </summary>
         [HttpPost("pivot/export")]
         public IActionResult PivotExport([FromBody] AnalysisPivotRequest req,
-                                         [FromQuery] string format = "xlsx")
+                                         [FromQuery] string format = "xlsx",
+                                         [FromQuery] bool includeChart = false)
         {
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
             if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");
@@ -223,7 +225,7 @@ namespace WalkingTec.Mvvm.Mvc
                 return File(Encoding.UTF8.GetBytes(csv), "text/csv", "analysis_pivot.csv");
             }
 
-            var xlsx = AnalysisExcelExporter.Export(queryResult);
+            var xlsx = AnalysisExcelExporter.Export(queryResult, includeChart);
             return File(xlsx,
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                 "analysis_pivot.xlsx");

--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -12,12 +12,13 @@
      * 判斷應使用哪種圖表類型（純函式，無副作用）
      * @param {Array} dims - 選取的維度陣列（每項 {fieldName, isDate}）
      * @param {Array} msrs - 選取的度量陣列
-     * @returns {string} 'card'|'bar'|'bar-stacked'|'line'
+     * @returns {string} 'card'|'pie'|'bar'|'bar-stacked'|'line'
      */
     function detectChartType(dims, msrs) {
         if (dims.length === 0) return 'card';
         if (dims.some(function (d) { return d.isDate; })) return 'line';
         if (dims.length >= 2) return 'bar-stacked';
+        if (dims.length === 1 && msrs.length === 1) return 'pie';
         return 'bar';
     }
 
@@ -196,9 +197,22 @@
         pivotWrapper.appendChild(pivotToggle);
         pivotWrapper.appendChild(pivotText);
 
+        var chartExportWrapper = document.createElement('label');
+        chartExportWrapper.style.cssText = 'display:inline-flex;align-items:center;margin-left:10px;cursor:pointer;';
+        var chartExportCb = document.createElement('input');
+        chartExportCb.type = 'checkbox';
+        chartExportCb.className = 'analysis-export-chart-cb';
+        chartExportCb.dataset.gridId = gridId;
+        chartExportCb.style.marginRight = '4px';
+        var chartExportLabel = document.createElement('span');
+        chartExportLabel.textContent = '含圖表';
+        chartExportWrapper.appendChild(chartExportCb);
+        chartExportWrapper.appendChild(chartExportLabel);
+
         btnRow.appendChild(queryBtn);
         btnRow.appendChild(exportXlsxBtn);
         btnRow.appendChild(exportCsvBtn);
+        btnRow.appendChild(chartExportWrapper);
         btnRow.appendChild(pivotWrapper);
         body.appendChild(btnRow);
 
@@ -206,7 +220,7 @@
         chartToggleRow.id = 'analysis-chart-toggle-' + gridId;
         chartToggleRow.style.marginTop = '8px';
         chartToggleRow.style.display = 'none'; // shown after first query
-        ['bar', 'line', 'bar-stacked', 'card'].forEach(function (ct) {
+        ['bar', 'line', 'bar-stacked', 'pie', 'card'].forEach(function (ct) {
             var btn = document.createElement('button');
             btn.type = 'button';
             btn.className = 'layui-btn layui-btn-xs';
@@ -618,6 +632,41 @@
      * 渲染 ECharts 圖表（若 echarts 全域變數不存在則略過）
      */
     function renderChart(gridId, result, req, dimFields, container, forceChartType) {
+        var dimMeta = req.dimensions.map(function (d) {
+            var f = (dimFields || []).filter(function (fd) { return fd.fieldName === d; })[0];
+            return { fieldName: d, isDate: f ? f.isDate === true : false };
+        });
+
+        var chartType = forceChartType || detectChartType(dimMeta, req.measures);
+
+        // card: 渲染 HTML 數字卡片，不使用 ECharts
+        if (chartType === 'card') {
+            var cardContainer = document.createElement('div');
+            cardContainer.className = 'analysis-cards';
+            cardContainer.style.display = 'flex';
+            cardContainer.style.gap = '16px';
+            cardContainer.style.marginTop = '15px';
+            var row = result.rows && result.rows.length > 0 ? result.rows[0] : {};
+            req.measures.forEach(function (m) {
+                var key = m.field + '_' + m.func;
+                var val = row[key];
+                var card = document.createElement('div');
+                card.className = 'analysis-card-item';
+                card.style.cssText = 'flex:1;text-align:center;padding:20px;background:#f8f9fa;border-radius:8px;border:1px solid #e0e0e0;';
+                var label = document.createElement('div');
+                label.style.cssText = 'font-size:13px;color:#666;margin-bottom:8px;';
+                label.textContent = key;
+                var value = document.createElement('div');
+                value.style.cssText = 'font-size:28px;font-weight:bold;color:#333;';
+                value.textContent = val != null ? String(val) : '—';
+                card.appendChild(label);
+                card.appendChild(value);
+                cardContainer.appendChild(card);
+            });
+            container.appendChild(cardContainer);
+            return;
+        }
+
         if (typeof window.echarts === 'undefined') return;
 
         var chartDiv = document.createElement('div');
@@ -627,12 +676,6 @@
         chartDiv.style.marginTop = '15px';
         container.appendChild(chartDiv);
 
-        var dimMeta = req.dimensions.map(function (d) {
-            var f = (dimFields || []).filter(function (fd) { return fd.fieldName === d; })[0];
-            return { fieldName: d, isDate: f ? f.isDate === true : false };
-        });
-
-        var chartType = forceChartType || detectChartType(dimMeta, req.measures);
         var chart = window.echarts.init(chartDiv);
         var firstDim = req.dimensions[0];
         var firstDimIsDate = dimMeta.length > 0 && dimMeta[0].isDate;
@@ -640,23 +683,44 @@
             var v = r[firstDim];
             return firstDimIsDate ? formatDateKey(v) : String(v || '');
         });
-        var series = req.measures.map(function (m) {
-            var key = m.field + '_' + m.func;
-            return {
-                name: key,
-                type: chartType === 'line' ? 'line' : 'bar',
-                stack: chartType === 'bar-stacked' ? 'total' : undefined,
-                data: result.rows.map(function (r) { return r[key]; })
-            };
-        });
 
-        chart.setOption({
-            tooltip: { trigger: 'axis' },
-            legend: { data: req.measures.map(function (m) { return m.field + '_' + m.func; }) },
-            xAxis: { type: 'category', data: categories },
-            yAxis: { type: 'value' },
-            series: series
-        });
+        // pie: 圓餅圖
+        if (chartType === 'pie') {
+            var pieKey = req.measures[0].field + '_' + req.measures[0].func;
+            chart.setOption({
+                tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+                legend: { orient: 'vertical', left: 'left', data: categories },
+                series: [{
+                    name: pieKey,
+                    type: 'pie',
+                    radius: '55%',
+                    center: ['50%', '55%'],
+                    data: categories.map(function (cat, i) {
+                        return { name: cat, value: result.rows[i][pieKey] };
+                    }),
+                    emphasis: { itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: 'rgba(0,0,0,0.5)' } }
+                }]
+            });
+        } else {
+            // bar / bar-stacked / line
+            var series = req.measures.map(function (m) {
+                var key = m.field + '_' + m.func;
+                return {
+                    name: key,
+                    type: chartType === 'line' ? 'line' : 'bar',
+                    stack: chartType === 'bar-stacked' ? 'total' : undefined,
+                    data: result.rows.map(function (r) { return r[key]; })
+                };
+            });
+
+            chart.setOption({
+                tooltip: { trigger: 'axis' },
+                legend: { data: req.measures.map(function (m) { return m.field + '_' + m.func; }) },
+                xAxis: { type: 'category', data: categories },
+                yAxis: { type: 'value' },
+                series: series
+            });
+        }
 
         // drill-down click handler
         chart.on('click', function (params) {
@@ -888,8 +952,11 @@
             req.pivotDimension = pivotDim;
         }
 
+        var chartCb = document.querySelector('.analysis-export-chart-cb[data-grid-id="' + gridId + '"]');
+        var includeChart = chartCb && chartCb.checked ? 'true' : 'false';
+
         var endpoint = isPivot ? '/_analysis/pivot/export' : '/_analysis/export';
-        return fetch(endpoint + '?format=' + encodeURIComponent(format), {
+        return fetch(endpoint + '?format=' + encodeURIComponent(format) + '&includeChart=' + includeChart, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(req)

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
@@ -168,5 +168,69 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.AreEqual(0, sheet.LastRowNum); // 只有 row 0（header）
             Assert.IsNull(sheet.GetRow(1));       // 無資料列
         }
+
+        // ─── includeChart=false：不含圖表（預設行為）────────────────────────────
+
+        [TestMethod]
+        public void Export_without_chart_has_no_drawing()
+        {
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "華東", ["Amount_Sum"] = 300m }
+                });
+
+            var wb    = OpenWorkbook(AnalysisExcelExporter.Export(resp, includeChart: false));
+            var sheet = wb.GetSheetAt(0) as XSSFSheet;
+
+            Assert.IsNotNull(sheet);
+            // 無圖表時不應有 Drawing
+            var drawing = sheet.GetDrawingPatriarch();
+            Assert.IsTrue(drawing == null || drawing.GetCharts().Count == 0);
+        }
+
+        // ─── includeChart=true：嵌入 bar chart ──────────────────────────────────
+
+        [TestMethod]
+        public void Export_with_chart_has_drawing_with_chart()
+        {
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "華東", ["Amount_Sum"] = 100m },
+                    new() { ["Region"] = "華南", ["Amount_Sum"] = 300m },
+                });
+
+            var wb    = OpenWorkbook(AnalysisExcelExporter.Export(resp, includeChart: true));
+            var sheet = wb.GetSheetAt(0) as XSSFSheet;
+
+            Assert.IsNotNull(sheet);
+            var drawing = sheet.GetDrawingPatriarch() as XSSFDrawing;
+            Assert.IsNotNull(drawing, "includeChart=true 時應有 Drawing");
+            Assert.IsTrue(drawing.GetCharts().Count >= 1, "至少應有 1 個 chart");
+        }
+
+        // ─── includeChart 預設值為 false ─────────────────────────────────────────
+
+        [TestMethod]
+        public void Export_default_includeChart_is_false()
+        {
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "華東", ["Amount_Sum"] = 300m }
+                });
+
+            // 不帶 includeChart 參數 → 預設不含圖表（向後相容）
+            var wb    = OpenWorkbook(AnalysisExcelExporter.Export(resp));
+            var sheet = wb.GetSheetAt(0) as XSSFSheet;
+
+            Assert.IsNotNull(sheet);
+            var drawing = sheet.GetDrawingPatriarch();
+            Assert.IsTrue(drawing == null || drawing.GetCharts().Count == 0);
+        }
     }
 }

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -87,8 +87,12 @@ describe('wtmAnalysis.detectChartType', () => {
         expect(wa.detectChartType([{ fieldName: 'Date', isDate: true }], [{}])).toBe('line');
     });
 
-    test('單一非日期維度 → bar', () => {
-        expect(wa.detectChartType([{ fieldName: 'Region', isDate: false }], [{}])).toBe('bar');
+    test('單一非日期維度 + 單 measure → pie', () => {
+        expect(wa.detectChartType([{ fieldName: 'Region', isDate: false }], [{ field: 'Amount', func: 'Sum' }])).toBe('pie');
+    });
+
+    test('單一非日期維度 + 多 measure → bar', () => {
+        expect(wa.detectChartType([{ fieldName: 'Region', isDate: false }], [{ field: 'A' }, { field: 'B' }])).toBe('bar');
     });
 
     test('兩個維度 → bar-stacked', () => {
@@ -639,12 +643,42 @@ describe('renderChart — forceChartType parameter', () => {
         expect(capturedOptions[0].series[0].stack).toBe('total');
     });
 
+    test('forceChartType=pie renders pie series with name/value data', () => {
+        const { wa, capturedOptions } = makeChartEnv();
+        const container = makeContainer();
+        wa.renderChart('g1', sampleResult, sampleReq, sampleDimFields, container, 'pie');
+        expect(capturedOptions.length).toBe(1);
+        expect(capturedOptions[0].series[0].type).toBe('pie');
+        expect(capturedOptions[0].series[0].data[0]).toEqual({ name: 'North', value: 100 });
+        // pie should not have xAxis/yAxis
+        expect(capturedOptions[0].xAxis).toBeUndefined();
+        expect(capturedOptions[0].yAxis).toBeUndefined();
+    });
+
+    test('forceChartType=card renders HTML cards, not ECharts', () => {
+        const { wa, capturedOptions } = makeChartEnv();
+        const container = makeContainer();
+        const cardResult = {
+            columns: ['Amount_Sum', 'Qty_Count'],
+            rows: [{ Amount_Sum: 12345, Qty_Count: 99 }],
+        };
+        const cardReq = { dimensions: [], measures: [{ field: 'Amount', func: 'Sum' }, { field: 'Qty', func: 'Count' }] };
+        wa.renderChart('g1', cardResult, cardReq, [], container, 'card');
+        // card should NOT call echarts (no setOption)
+        expect(capturedOptions.length).toBe(0);
+        // should append a card container div
+        const appended = container.children;
+        expect(appended.length).toBeGreaterThanOrEqual(1);
+        const cardDiv = appended[appended.length - 1];
+        expect(cardDiv.className).toContain('analysis-cards');
+    });
+
     test('no forceChartType uses detectChartType result', () => {
         const { wa, capturedOptions } = makeChartEnv();
         const container = makeContainer();
-        // sampleDimFields has isDate:false, single dim → detectChartType returns 'bar'
+        // sampleDimFields has isDate:false, single dim, single measure → detectChartType returns 'pie'
         wa.renderChart('g1', sampleResult, sampleReq, sampleDimFields, container);
-        expect(capturedOptions[0].series[0].type).toBe('bar');
+        expect(capturedOptions[0].series[0].type).toBe('pie');
     });
 
     test('renderChart skips when echarts not available', () => {
@@ -698,8 +732,11 @@ describe('[cov] waReq pure functions — detectChartType / validateSelection / p
     test('detectChartType: date dim → line', () => {
         expect(waReq.detectChartType([{ isDate: true }], [{}])).toBe('line');
     });
-    test('detectChartType: single non-date dim → bar', () => {
-        expect(waReq.detectChartType([{ isDate: false }], [{}])).toBe('bar');
+    test('detectChartType: single non-date dim + single measure → pie', () => {
+        expect(waReq.detectChartType([{ isDate: false }], [{ field: 'A' }])).toBe('pie');
+    });
+    test('detectChartType: single non-date dim + multi measure → bar', () => {
+        expect(waReq.detectChartType([{ isDate: false }], [{ field: 'A' }, { field: 'B' }])).toBe('bar');
     });
     test('detectChartType: 2 dims → bar-stacked', () => {
         expect(waReq.detectChartType([{}, {}], [{}])).toBe('bar-stacked');
@@ -1213,21 +1250,33 @@ describe('[cov] waReq.renderChart — all branches', () => {
         expect(opts[0].series[0].stack).toBe('total');
     });
 
-    test('no dims (card) → type=bar, no stack', () => {
+    test('no dims (card) → renders HTML cards, no echarts', () => {
         const opts = [];
         global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), on: jest.fn(), dispose: jest.fn() }; }) };
         const noDimReq = { dimensions: [], measures: [{ field: 'Amount', func: 'Sum' }] };
-        waReq.renderChart('scovR7', { columns: ['Amount_Sum'], rows: [{ Amount_Sum: 42 }] }, noDimReq, [], makeContainer());
-        expect(opts[0].series[0].type).toBe('bar');
-        expect(opts[0].series[0].stack).toBeUndefined();
+        const container = makeContainer();
+        waReq.renderChart('scovR7', { columns: ['Amount_Sum'], rows: [{ Amount_Sum: 42 }] }, noDimReq, [], container);
+        // card should NOT call echarts
+        expect(opts.length).toBe(0);
+        // should have appended a card container
+        expect(container.querySelector('.analysis-cards')).not.toBeNull();
     });
 
-    test('dim not in dimFields → isDate defaults false → bar type', () => {
+    test('dim not in dimFields → isDate defaults false, single measure → pie type', () => {
         const opts = [];
         global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), on: jest.fn(), dispose: jest.fn() }; }) };
         const unknownReq = { dimensions: ['Unknown'], measures: [{ field: 'A', func: 'Sum' }] };
         waReq.renderChart('scovR8', { columns: ['Unknown', 'A_Sum'], rows: [{ Unknown: 'X', A_Sum: 1 }] }, unknownReq, [], makeContainer());
-        expect(opts[0].series[0].type).toBe('bar');
+        expect(opts[0].series[0].type).toBe('pie');
+    });
+
+    test('forceChartType=pie → pie series with name/value data', () => {
+        const opts = [];
+        global.echarts = { init: jest.fn(function() { return { setOption: jest.fn(function(o) { opts.push(o); }), on: jest.fn(), dispose: jest.fn() }; }) };
+        waReq.renderChart('scovR9', sampleResult, sampleReq, sampleDimFields, makeContainer(), 'pie');
+        expect(opts[0].series[0].type).toBe('pie');
+        expect(opts[0].series[0].data[0]).toEqual({ name: 'North', value: 100 });
+        expect(opts[0].xAxis).toBeUndefined();
     });
 });
 
@@ -1255,8 +1304,8 @@ describe('[cov] waReq.renderPanel — createFieldSection allowedFuncs branches',
         // Panel got renderPanel output appended — verify checkboxes and select
         const checkboxes = panel.querySelectorAll('input[type="checkbox"]');
         const selects = panel.querySelectorAll('select');
-        // 4 fields (1 dim + 3 measures) + 1 pivot mode toggle checkbox = 5 checkboxes
-        expect(checkboxes.length).toBe(5);
+        // 4 fields (1 dim + 3 measures) + 1 pivot mode toggle + 1 含圖表 export checkbox = 6 checkboxes
+        expect(checkboxes.length).toBe(6);
         expect(selects.length).toBe(1);
     });
 });


### PR DESCRIPTION
## Summary
- **Fix card chart type**: renders HTML KPI number cards instead of falling back to bar chart
- **Add pie chart**: single dimension + single measure auto-detects as pie; added to chart toggle buttons
- **Excel chart export**: new `含圖表` checkbox (default unchecked); when checked, NPOI bar chart embedded in xlsx
- **Controller**: Export/PivotExport endpoints accept `includeChart` query parameter

## Test plan
- [x] 137 JS tests passing (new: pie detectChartType, pie renderChart, card renderChart, checkbox count)
- [x] 477 C# tests passing (new: Export with/without chart, default includeChart=false)
- [ ] Manual: verify pie chart renders in browser for single dim + single measure
- [ ] Manual: verify card renders number cards when no dimensions selected
- [ ] Manual: verify xlsx export with 含圖表 checked contains chart in Excel

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)