### PR TITLE
fix(analysis): card chart stacks on repeated clicks

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -233,6 +233,8 @@
                 if (!resultDiv) return;
                 var oldChart = document.getElementById('analysis-chart-' + gridId);
                 if (oldChart && oldChart.parentNode) oldChart.parentNode.removeChild(oldChart);
+                var oldCards = resultDiv.querySelector('.analysis-cards');
+                if (oldCards && oldCards.parentNode) oldCards.parentNode.removeChild(oldCards);
                 renderChart(gridId, st.lastResult, st.lastReq, st.lastDimFields, resultDiv, ct);
             });
             chartToggleRow.appendChild(btn);


### PR DESCRIPTION
## Summary

- Fix: clicking "card" chart type repeatedly caused cards to accumulate
- Root cause: toggle cleanup only removed ECharts div (by id), missed `.analysis-cards` container
- Added `querySelector('.analysis-cards')` removal before re-rendering

Fixes #246

## Test plan

- [x] 196 JS tests pass
- [ ] Manual: click card button multiple times — only one card set should display

🤖 Generated with [Claude Code](https://claude.com/claude-code)