### PR TITLE
fix(test): resolve SQLite duplicate MajorId column in DoLoginAsyncTests

### DIFF
--- a/test/WalkingTec.Mvvm.Core.Test/Integration/DoLoginAsyncTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/DoLoginAsyncTests.cs
@@ -27,7 +27,6 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
     /// the shared in-memory database alive across multiple context instances.
     /// </summary>
     [TestClass]
-    [Ignore("Pre-existing: FrameworkContext.EnsureCreated() fails with 'duplicate column name: MajorId' in SQLite — requires schema fix in test infrastructure")]
     public class DoLoginAsyncTests
     {
         private string _seed = null!;
@@ -36,8 +35,11 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
         [TestInitialize]
         public void Initialize()
         {
-            // NOTE: This class is [Ignore]'d due to a pre-existing FrameworkContext schema issue.
-            // MSTest still runs [TestInitialize] for ignored classes, so we guard here.
+            _seed = Guid.NewGuid().ToString();
+            _keepAlive = new SqliteConnection($"DataSource={_seed}?mode=memory&cache=shared");
+            _keepAlive.Open();
+            using var db = CreateDb();
+            ((DbContext)db).Database.EnsureCreated();
         }
 
         [TestCleanup]
@@ -200,11 +202,26 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
     /// Overrides OnConfiguring to prevent the base SqlServer/InMemory config from running
     /// (the connection is configured by the DoLoginAsyncTests ctor via EnsureCreated).
     /// </summary>
+    /// <summary>
+    /// Minimal DataContext for DoLoginAsync tests.
+    /// Inherits FrameworkContext to get the framework entity DbSets.
+    /// Overrides OnModelCreating to SKIP the global Utils.GetAllModels() scan,
+    /// which would discover conflicting entities (StudentMajor/StudentMajorTop)
+    /// from the test project's DataContext and cause SQLite schema errors.
+    /// </summary>
     internal class LoginTestDataContext : FrameworkContext
     {
         public LoginTestDataContext(string seed)
             : base($"DataSource={seed}?mode=memory&cache=shared", DBTypeEnum.SQLite) { }
 
         public DbSet<TestLoginUser> TestLoginUsers { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Intentionally do NOT call base.OnModelCreating() to avoid
+            // Utils.GetAllModels() scanning the entire test assembly.
+            // The framework entities are discovered via DbSet properties
+            // on FrameworkContext, which is sufficient for EnsureCreated().
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Override `OnModelCreating` in `LoginTestDataContext` to skip `FrameworkContext`'s `Utils.GetAllModels()` assembly scan, which discovers conflicting `StudentMajor`/`StudentMajorTop` entities from the test project
- Remove `[Ignore]` attribute and restore proper `[TestInitialize]` with SQLite shared in-memory setup
- 8 previously-ignored `DoLoginAsyncTests` now pass (488 total, 0 failures, 0 skipped)

## Root cause

`FrameworkContext.OnModelCreating()` → `Utils.GetAllModels()` scans all loaded assemblies → finds both `StudentMajor` (BasePoco) and `StudentMajorTop` (TopBasePoco) with identical `MajorId` column → SQLite Error 1: "duplicate column name: MajorId" on `EnsureCreated()`.

## Test plan

- [x] `DoLoginAsyncTests` — all 8 tests pass (PBKDF2 auth, MD5 migration, tenant mismatch, disabled user)
- [x] Full `Core.Test` suite — 488 passed, 0 failed, 0 skipped
- [x] `Admin.Test` — 34 passed

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)