### PR TITLE
test(auth): add JWT claims, signature, and expiration validation tests

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc.Tests/Security/JwtClaimsValidationTests.cs
+++ b/src/WalkingTec.Mvvm.Mvc.Tests/Security/JwtClaimsValidationTests.cs
@@ -1,0 +1,275 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.IdentityModel.Tokens;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Mvc.Tests.Fixtures;
+using Xunit;
+
+namespace WalkingTec.Mvvm.Mvc.Tests.Security
+{
+    /// <summary>
+    /// Tests that issued JWT access tokens contain correct claims, are properly
+    /// signed, and respect configured expiration boundaries.
+    ///
+    /// Covers issue #232 requirements:
+    /// - Validate signature errors (tampered tokens fail validation)
+    /// - Validate permission claims boundaries (itcode, tenant, jti present)
+    /// - Validate expired tokens (expiration matches config)
+    /// </summary>
+    public class JwtClaimsValidationTests : IDisposable
+    {
+        private readonly TokenTestFixture _fixture = new();
+        private const string TestSecurityKey = "WTM_Test_Key_AtLeast_32_Characters!!";
+        private const string TestIssuer = "WTM_Test";
+        private const string TestAudience = "WTM_Test";
+
+        // ─── Claims Content ─────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task IssuedToken_ContainsItCodeClaim()
+        {
+            var user = CreateUser("alice");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            var jwt = ParseJwt(token.AccessToken!);
+            jwt.Claims.Should().Contain(c => c.Type == "itcode" && c.Value == "alice");
+        }
+
+        [Fact]
+        public async Task IssuedToken_ContainsJtiClaim()
+        {
+            var user = CreateUser("bob");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            var jwt = ParseJwt(token.AccessToken!);
+            jwt.Claims.Should().Contain(c => c.Type == JwtRegisteredClaimNames.Jti);
+            var jti = jwt.Claims.First(c => c.Type == JwtRegisteredClaimNames.Jti).Value;
+            jti.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task IssuedToken_JtiIsUniquePerIssuance()
+        {
+            var user = CreateUser("charlie");
+            var token1 = await _fixture.TokenService.IssueTokenAsync(user);
+            var token2 = await _fixture.TokenService.IssueTokenAsync(user);
+
+            var jti1 = ParseJwt(token1.AccessToken!).Claims.First(c => c.Type == JwtRegisteredClaimNames.Jti).Value;
+            var jti2 = ParseJwt(token2.AccessToken!).Claims.First(c => c.Type == JwtRegisteredClaimNames.Jti).Value;
+            jti1.Should().NotBe(jti2, "each issuance must have a unique JTI to prevent replay");
+        }
+
+        [Fact]
+        public async Task IssuedToken_WithTenant_ContainsTenantClaim()
+        {
+            var user = CreateUser("dave", tenantCode: "tenant_a");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            var jwt = ParseJwt(token.AccessToken!);
+            jwt.Claims.Should().Contain(c => c.Type == "tenant" && c.Value == "tenant_a");
+        }
+
+        [Fact]
+        public async Task IssuedToken_WithoutTenant_OmitsTenantClaim()
+        {
+            var user = CreateUser("eve");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            var jwt = ParseJwt(token.AccessToken!);
+            jwt.Claims.Should().NotContain(c => c.Type == "tenant");
+        }
+
+        // ─── Expiration Boundaries ──────────────────────────────────────────────
+
+        [Fact]
+        public async Task IssuedToken_ExpirationMatchesConfiguredLifetime()
+        {
+            var before = DateTime.UtcNow;
+            var user = CreateUser("frank");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+            var after = DateTime.UtcNow;
+
+            var jwt = ParseJwt(token.AccessToken!);
+            jwt.ValidTo.Should().BeAfter(before.AddSeconds(3599));
+            jwt.ValidTo.Should().BeBefore(after.AddSeconds(3601));
+        }
+
+        [Fact]
+        public async Task IssuedToken_ExpiresInMatchesConfiguredSeconds()
+        {
+            var user = CreateUser("grace");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            token.ExpiresIn.Should().Be(3600);
+            token.TokenType.Should().Be("Bearer");
+        }
+
+        // ─── Signature Validation ───────────────────────────────────────────────
+
+        [Fact]
+        public async Task IssuedToken_ValidatesWithCorrectKey()
+        {
+            var user = CreateUser("heidi");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            var validationParams = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidIssuer = TestIssuer,
+                ValidateAudience = true,
+                ValidAudience = TestAudience,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestSecurityKey)),
+                ValidateLifetime = true
+            };
+
+            var handler = new JwtSecurityTokenHandler();
+            var principal = handler.ValidateToken(token.AccessToken, validationParams, out var validatedToken);
+
+            principal.Should().NotBeNull();
+            validatedToken.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task IssuedToken_FailsValidationWithWrongKey()
+        {
+            var user = CreateUser("ivan");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            var validationParams = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidIssuer = TestIssuer,
+                ValidateAudience = true,
+                ValidAudience = TestAudience,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(
+                    Encoding.UTF8.GetBytes("WRONG_KEY_THAT_IS_32_CHARS_LONG!!")),
+                ValidateLifetime = true
+            };
+
+            var handler = new JwtSecurityTokenHandler();
+            var act = () => handler.ValidateToken(token.AccessToken, validationParams, out _);
+            act.Should().Throw<SecurityTokenSignatureKeyNotFoundException>();
+        }
+
+        [Fact]
+        public async Task IssuedToken_FailsValidationWithWrongIssuer()
+        {
+            var user = CreateUser("judy");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            var validationParams = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidIssuer = "Wrong_Issuer",
+                ValidateAudience = false,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestSecurityKey)),
+                ValidateLifetime = false
+            };
+
+            var handler = new JwtSecurityTokenHandler();
+            var act = () => handler.ValidateToken(token.AccessToken, validationParams, out _);
+            act.Should().Throw<SecurityTokenInvalidIssuerException>();
+        }
+
+        [Fact]
+        public async Task IssuedToken_FailsValidationWithWrongAudience()
+        {
+            var user = CreateUser("karl");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            var validationParams = new TokenValidationParameters
+            {
+                ValidateIssuer = false,
+                ValidateAudience = true,
+                ValidAudience = "Wrong_Audience",
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestSecurityKey)),
+                ValidateLifetime = false
+            };
+
+            var handler = new JwtSecurityTokenHandler();
+            var act = () => handler.ValidateToken(token.AccessToken, validationParams, out _);
+            act.Should().Throw<SecurityTokenInvalidAudienceException>();
+        }
+
+        [Fact]
+        public async Task TamperedToken_FailsSignatureValidation()
+        {
+            var user = CreateUser("lisa");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            // Tamper with the payload by flipping a character
+            var parts = token.AccessToken!.Split('.');
+            var tamperedPayload = parts[1][..^1] + (parts[1][^1] == 'A' ? 'B' : 'A');
+            var tamperedToken = $"{parts[0]}.{tamperedPayload}.{parts[2]}";
+
+            var validationParams = new TokenValidationParameters
+            {
+                ValidateIssuer = false,
+                ValidateAudience = false,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestSecurityKey)),
+                ValidateLifetime = false
+            };
+
+            var handler = new JwtSecurityTokenHandler();
+            var act = () => handler.ValidateToken(tamperedToken, validationParams, out _);
+            // Tampered payload may cause Base64 decode failure (ArgumentException)
+            // or signature mismatch (SecurityTokenException) — either indicates rejection.
+            act.Should().Throw<Exception>()
+                .Which.Should().Match<Exception>(e =>
+                    e is SecurityTokenException || e is ArgumentException);
+        }
+
+        // ─── Token Structure ────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task IssuedToken_HasBearerTypeAndRefreshToken()
+        {
+            var user = CreateUser("mike");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            token.AccessToken.Should().NotBeNullOrEmpty();
+            token.RefreshToken.Should().NotBeNullOrEmpty();
+            token.TokenType.Should().Be("Bearer");
+            token.ExpiresIn.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public async Task IssuedToken_AccessTokenIsThreePartJwt()
+        {
+            var user = CreateUser("nina");
+            var token = await _fixture.TokenService.IssueTokenAsync(user);
+
+            var parts = token.AccessToken!.Split('.');
+            parts.Should().HaveCount(3, "JWT should have header.payload.signature");
+        }
+
+        // ─── Helpers ────────────────────────────────────────────────────────────
+
+        private static LoginUserInfo CreateUser(string itCode, string? tenantCode = null)
+        {
+            return new LoginUserInfo
+            {
+                ITCode = itCode,
+                TenantCode = tenantCode,
+                Name = $"Test_{itCode}"
+            };
+        }
+
+        private static JwtSecurityToken ParseJwt(string token)
+        {
+            var handler = new JwtSecurityTokenHandler();
+            return handler.ReadJwtToken(token);
+        }
+
+        public void Dispose() => _fixture.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

- Add 14 new xUnit tests for JWT access token validation in `JwtClaimsValidationTests`
- Covers the three requirements from issue #232:
  - **Expired tokens**: expiration matches configured lifetime (3600s)
  - **Signature errors**: wrong key, wrong issuer/audience, tampered payload all rejected
  - **Permission claims boundaries**: itcode, jti (unique per issuance), tenant claim presence/absence

## New tests

| Category | Count | Tests |
|----------|-------|-------|
| Claims content | 5 | itcode, jti, jti uniqueness, tenant present, tenant absent |
| Signature validation | 5 | correct key, wrong key, wrong issuer, wrong audience, tampered payload |
| Expiration boundaries | 2 | matches config, ExpiresIn value |
| Token structure | 2 | Bearer type, three-part JWT format |

## Test plan

- [x] Mvc.Tests: 38 passed (24 existing + 14 new)
- [x] Full solution build: 0 errors

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)