### PR TITLE
fix(analysis): add null guard for Query/Export request body

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -74,8 +74,9 @@ namespace WalkingTec.Mvvm.Mvc
         /// 執行動態 GroupBy 聚合查詢，回傳聚合結果。
         /// </summary>
         [HttpPost("query")]
-        public IActionResult Query([FromBody] AnalysisQueryRequest req)
+        public IActionResult Query([FromBody] AnalysisQueryRequest? req)
         {
+            if (req is null) return BadRequest("Invalid request body.");
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
             if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");
 
@@ -145,10 +146,11 @@ namespace WalkingTec.Mvvm.Mvc
         /// 匯出分析結果為 Excel 或 CSV。
         /// </summary>
         [HttpPost("export")]
-        public IActionResult Export([FromBody] AnalysisQueryRequest req,
+        public IActionResult Export([FromBody] AnalysisQueryRequest? req,
                                     [FromQuery] string format = "xlsx",
                                     [FromQuery] bool includeChart = false)
         {
+            if (req is null) return BadRequest("Invalid request body.");
             // 與 Query 端點一致的維度/度量上限驗證（I-5）
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
             if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -524,5 +524,21 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             var result = CreateController().Query(req) as BadRequestObjectResult;
             Assert.IsNotNull(result, "無效日期格式應回傳 400");
         }
+
+        // ─── Null request guard (#268) ──────────────────────────────────────
+
+        [TestMethod]
+        public void Query_null_request_returns_400()
+        {
+            var result = CreateController().Query(null) as BadRequestObjectResult;
+            Assert.IsNotNull(result, "null request 應回傳 400");
+        }
+
+        [TestMethod]
+        public void Export_null_request_returns_400()
+        {
+            var result = CreateController().Export(null) as BadRequestObjectResult;
+            Assert.IsNotNull(result, "null request 應回傳 400");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `Query` 和 `Export` 端點加入 `req is null` 早期檢查，回傳 400 而非 500 NRE
- 當 JSON body 包含無效 enum 值時，ASP.NET Core model binding 會將整個 req 設為 null

## Changes
- `_AnalysisController.cs`: 參數改為 `AnalysisQueryRequest?`，加 null guard
- `AnalysisControllerTests.cs`: 新增 2 個測試驗證 null request 回傳 400

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)