### PR TITLE
fix(etl): handle Abort endpoint error gracefully

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
@@ -126,8 +126,15 @@ public class _EtlJobController : BaseController
     [HttpPost]
     public async Task<IActionResult> Abort(Guid id)
     {
-        await _scheduler.AbortAsync(id);
-        return Ok(new { success = true, message = "已中止" });
+        try
+        {
+            await _scheduler.AbortAsync(id);
+            return Ok(new { success = true, message = "已中止" });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 
     [ActionDescription("跳過下次")]

--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
@@ -85,6 +85,19 @@ public class EtlJobControllerTests
     }
 
     [TestMethod]
+    public async Task Abort_returns_400_when_job_not_running()
+    {
+        var id = Guid.NewGuid();
+        _mockScheduler.Setup(x => x.AbortAsync(id))
+            .ThrowsAsync(new InvalidOperationException($"Job {id} is not currently running."));
+
+        var result = await _controller.Abort(id) as BadRequestObjectResult;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(400, result!.StatusCode);
+    }
+
+    [TestMethod]
     public async Task SkipNext_calls_scheduler()
     {
         var id = Guid.NewGuid();


### PR DESCRIPTION
## Summary
- Wrap `AbortAsync` call in try-catch to return HTTP 400 with error message instead of 500 + stack trace leak
- Add test for non-running Job abort scenario

## Test plan
- [x] `Abort_calls_scheduler` — existing test, still passes
- [x] `Abort_returns_400_when_job_not_running` — new test, verifies 400 response

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)