### PR TITLE
fix(etl): replace [FromBody] string with DTO in Reschedule

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
@@ -140,11 +140,15 @@ public class _EtlJobController : BaseController
 
     [ActionDescription("修改排程")]
     [HttpPost]
-    public async Task<IActionResult> Reschedule(Guid id, [FromBody] string newCron)
+    public async Task<IActionResult> Reschedule(Guid id, [FromBody] RescheduleRequest? request)
     {
-        if (!CronExpression.IsValidExpression(newCron))
+        if (string.IsNullOrWhiteSpace(request?.NewCron))
+            return BadRequest(new { error = "Cron 表達式不可為空" });
+        if (!CronExpression.IsValidExpression(request.NewCron))
             return BadRequest(new { error = "無效的 Cron 表達式" });
-        await _scheduler.RescheduleAsync(id, newCron);
+        await _scheduler.RescheduleAsync(id, request.NewCron);
         return Ok(new { success = true, message = "排程已更新" });
     }
 }
+
+public record RescheduleRequest(string NewCron);

--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
@@ -97,11 +97,34 @@ public class EtlJobControllerTests
     }
 
     [TestMethod]
+    public async Task Reschedule_rejects_null_request()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _controller.Reschedule(id, null) as BadRequestObjectResult;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(400, result!.StatusCode);
+        _mockScheduler.Verify(x => x.RescheduleAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Reschedule_rejects_empty_cron()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _controller.Reschedule(id, new RescheduleRequest("")) as BadRequestObjectResult;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(400, result!.StatusCode);
+    }
+
+    [TestMethod]
     public async Task Reschedule_rejects_invalid_cron()
     {
         var id = Guid.NewGuid();
 
-        var result = await _controller.Reschedule(id, "not-a-cron") as BadRequestObjectResult;
+        var result = await _controller.Reschedule(id, new RescheduleRequest("not-a-cron")) as BadRequestObjectResult;
 
         Assert.IsNotNull(result);
         Assert.AreEqual(400, result!.StatusCode);
@@ -115,7 +138,7 @@ public class EtlJobControllerTests
         var validCron = "0 0 0 * * ?";
         _mockScheduler.Setup(x => x.RescheduleAsync(id, validCron)).Returns(Task.CompletedTask);
 
-        var result = await _controller.Reschedule(id, validCron) as OkObjectResult;
+        var result = await _controller.Reschedule(id, new RescheduleRequest(validCron)) as OkObjectResult;
 
         Assert.IsNotNull(result);
         Assert.AreEqual(200, result!.StatusCode);


### PR DESCRIPTION
## Summary
- Replace `[FromBody] string newCron` with `RescheduleRequest` record DTO to fix null binding
- Add null/empty guard before `CronExpression.IsValidExpression` call
- Add 2 new test cases (null request, empty cron)

## Test plan
- [x] `Reschedule_rejects_null_request` — new, verifies null body → 400
- [x] `Reschedule_rejects_empty_cron` — new, verifies empty string → 400
- [x] `Reschedule_rejects_invalid_cron` — updated to use DTO
- [x] `Reschedule_accepts_valid_cron` — updated to use DTO

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)