### PR TITLE
fix(analysis): match Excel export chart type with frontend display

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
@@ -19,7 +19,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
         /// </summary>
         /// <param name="result">查詢結果</param>
         /// <param name="includeChart">是否嵌入圖表（預設 false）</param>
-        public static byte[] Export(AnalysisQueryResponse result, bool includeChart = false)
+        /// <param name="chartType">圖表類型：bar, pie, line, bar-stacked（預設 bar）</param>
+        public static byte[] Export(AnalysisQueryResponse result, bool includeChart = false, string? chartType = null)
         {
             using var workbook = new XSSFWorkbook();
             var sheet = workbook.CreateSheet("Analysis");
@@ -54,7 +55,19 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
             if (includeChart && result.Rows.Count > 0 && result.Columns.Count >= 2)
             {
-                EmbedBarChart(sheet, result);
+                var type = (chartType ?? "bar").ToLowerInvariant();
+                switch (type)
+                {
+                    case "pie":
+                        EmbedPieChart(sheet, result);
+                        break;
+                    case "line":
+                        EmbedLineChart(sheet, result);
+                        break;
+                    default: // bar, bar-stacked, and any unknown type
+                        EmbedBarChart(sheet, result);
+                        break;
+                }
             }
 
             using var ms = new MemoryStream();
@@ -62,24 +75,17 @@ namespace WalkingTec.Mvvm.Core.Analysis
             return ms.ToArray();
         }
 
-        /// <summary>
-        /// 在數據表下方嵌入 bar chart。
-        /// 假設第一個 column 為維度（category），其餘為度量（values）。
-        /// </summary>
-        private static void EmbedBarChart(ISheet sheet, AnalysisQueryResponse result)
+        private static (IChart chart, List<int> measureIndices) CreateChartBase(ISheet sheet, AnalysisQueryResponse result)
         {
             var drawing = sheet.CreateDrawingPatriarch();
-            // 圖表放在數據列下方，留 2 行空白
             int chartTopRow = result.Rows.Count + 3;
             var anchor = drawing.CreateAnchor(0, 0, 0, 0,
                 0, chartTopRow, result.Columns.Count + 2, chartTopRow + 15);
             var chart = drawing.CreateChart(anchor);
 
-            // 找出度量 columns（跳過第一個維度 column）
             var measureIndices = new List<int>();
             for (int c = 1; c < result.Columns.Count; c++)
             {
-                // 如果 column 對應的值在第一行是 numeric，視為度量
                 if (result.Rows[0].TryGetValue(result.Columns[c], out var v)
                     && (v is decimal or double or float or int or long))
                 {
@@ -87,11 +93,15 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 }
             }
 
+            return (chart, measureIndices);
+        }
+
+        private static void EmbedBarChart(ISheet sheet, AnalysisQueryResponse result)
+        {
+            var (chart, measureIndices) = CreateChartBase(sheet, result);
             if (measureIndices.Count == 0) return;
 
             var data = chart.ChartDataFactory.CreateBarChartData<string, double>();
-
-            // Category axis: first column, rows 1..N (0-based: row 1 = first data row)
             var cats = DataSources.FromStringCellRange(sheet,
                 new CellRangeAddress(1, result.Rows.Count, 0, 0));
 
@@ -107,6 +117,48 @@ namespace WalkingTec.Mvvm.Core.Analysis
             valAxis.Crosses = AxisCrosses.AutoZero;
 
             chart.Plot(data, catAxis, valAxis);
+            chart.GetOrCreateLegend().Position = LegendPosition.Bottom;
+        }
+
+        private static void EmbedLineChart(ISheet sheet, AnalysisQueryResponse result)
+        {
+            var (chart, measureIndices) = CreateChartBase(sheet, result);
+            if (measureIndices.Count == 0) return;
+
+            var data = chart.ChartDataFactory.CreateLineChartData<string, double>();
+            var cats = DataSources.FromStringCellRange(sheet,
+                new CellRangeAddress(1, result.Rows.Count, 0, 0));
+
+            foreach (var colIdx in measureIndices)
+            {
+                var vals = DataSources.FromNumericCellRange(sheet,
+                    new CellRangeAddress(1, result.Rows.Count, colIdx, colIdx));
+                data.AddSeries(cats, vals).SetTitle(result.Columns[colIdx]);
+            }
+
+            var catAxis = chart.ChartAxisFactory.CreateCategoryAxis(AxisPosition.Bottom);
+            var valAxis = chart.ChartAxisFactory.CreateValueAxis(AxisPosition.Left);
+            valAxis.Crosses = AxisCrosses.AutoZero;
+
+            chart.Plot(data, catAxis, valAxis);
+            chart.GetOrCreateLegend().Position = LegendPosition.Bottom;
+        }
+
+        private static void EmbedPieChart(ISheet sheet, AnalysisQueryResponse result)
+        {
+            var (chart, measureIndices) = CreateChartBase(sheet, result);
+            if (measureIndices.Count == 0) return;
+
+            // Pie chart uses only the first measure
+            var firstMeasureIdx = measureIndices[0];
+            var data = chart.ChartDataFactory.CreatePieChartData<string, double>();
+            var cats = DataSources.FromStringCellRange(sheet,
+                new CellRangeAddress(1, result.Rows.Count, 0, 0));
+            var vals = DataSources.FromNumericCellRange(sheet,
+                new CellRangeAddress(1, result.Rows.Count, firstMeasureIdx, firstMeasureIdx));
+            data.AddSeries(cats, vals).SetTitle(result.Columns[firstMeasureIdx]);
+
+            chart.Plot(data);
             chart.GetOrCreateLegend().Position = LegendPosition.Bottom;
         }
     }

--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -148,7 +148,8 @@ namespace WalkingTec.Mvvm.Mvc
         [HttpPost("export")]
         public IActionResult Export([FromBody] AnalysisQueryRequest? req,
                                     [FromQuery] string format = "xlsx",
-                                    [FromQuery] bool includeChart = false)
+                                    [FromQuery] bool includeChart = false,
+                                    [FromQuery] string? chartType = null)
         {
             if (req is null) return BadRequest("Invalid request body.");
             // 與 Query 端點一致的維度/度量上限驗證（I-5）
@@ -184,7 +185,7 @@ namespace WalkingTec.Mvvm.Mvc
                 return File(Encoding.UTF8.GetBytes(csv), "text/csv", "analysis.csv");
             }
 
-            var xlsx = AnalysisExcelExporter.Export(result, includeChart);
+            var xlsx = AnalysisExcelExporter.Export(result, includeChart, chartType);
             return File(xlsx,
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                 "analysis.xlsx");
@@ -197,7 +198,8 @@ namespace WalkingTec.Mvvm.Mvc
         [HttpPost("pivot/export")]
         public IActionResult PivotExport([FromBody] AnalysisPivotRequest req,
                                          [FromQuery] string format = "xlsx",
-                                         [FromQuery] bool includeChart = false)
+                                         [FromQuery] bool includeChart = false,
+                                         [FromQuery] string? chartType = null)
         {
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
             if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");
@@ -241,7 +243,7 @@ namespace WalkingTec.Mvvm.Mvc
                 return File(Encoding.UTF8.GetBytes(csv), "text/csv", "analysis_pivot.csv");
             }
 
-            var xlsx = AnalysisExcelExporter.Export(queryResult, includeChart);
+            var xlsx = AnalysisExcelExporter.Export(queryResult, includeChart, chartType);
             return File(xlsx,
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                 "analysis_pivot.xlsx");

--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -1146,7 +1146,7 @@
         var chartCb = document.querySelector('.analysis-export-chart-cb[data-grid-id="' + gridId + '"]');
         var includeChart = chartCb && chartCb.checked ? 'true' : 'false';
         var dimMeta = dims.map(function (d) {
-            return st.fields.find(function (f) { return f.fieldName === d; }) || { isDate: false };
+            return (st.fields || []).find(function (f) { return f.fieldName === d; }) || { isDate: false };
         });
         var currentChartType = detectChartType(dimMeta, msrs);
         var endpoint = isPivot ? '/_analysis/pivot/export' : '/_analysis/export';

--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -1145,8 +1145,12 @@
         if (isPivot) req.pivotDimension = pivotDim;
         var chartCb = document.querySelector('.analysis-export-chart-cb[data-grid-id="' + gridId + '"]');
         var includeChart = chartCb && chartCb.checked ? 'true' : 'false';
+        var dimMeta = dims.map(function (d) {
+            return st.fields.find(function (f) { return f.fieldName === d; }) || { isDate: false };
+        });
+        var currentChartType = detectChartType(dimMeta, msrs);
         var endpoint = isPivot ? '/_analysis/pivot/export' : '/_analysis/export';
-        return fetch(endpoint + '?format=' + encodeURIComponent(format) + '&includeChart=' + includeChart, {
+        return fetch(endpoint + '?format=' + encodeURIComponent(format) + '&includeChart=' + includeChart + '&chartType=' + encodeURIComponent(currentChartType), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(req)

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
@@ -232,5 +232,62 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             var drawing = sheet.GetDrawingPatriarch();
             Assert.IsTrue(drawing == null || drawing.GetCharts().Count == 0);
         }
+
+        // ─── chartType 參數測試 (#275) ──────────────────────────────────────
+
+        private static AnalysisQueryResponse MakeTwoRowResponse()
+        {
+            return MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = 100m },
+                    new() { ["Region"] = "South", ["Amount_Sum"] = 200m },
+                });
+        }
+
+        [TestMethod]
+        public void Export_chartType_pie_produces_chart()
+        {
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(MakeTwoRowResponse(), includeChart: true, chartType: "pie"));
+            var sheet = wb.GetSheetAt(0) as XSSFSheet;
+            Assert.IsNotNull(sheet);
+            var drawing = sheet.GetDrawingPatriarch() as XSSFDrawing;
+            Assert.IsNotNull(drawing, "pie chart 應有 Drawing");
+            Assert.IsTrue(drawing.GetCharts().Count >= 1);
+        }
+
+        [TestMethod]
+        public void Export_chartType_line_produces_chart()
+        {
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(MakeTwoRowResponse(), includeChart: true, chartType: "line"));
+            var sheet = wb.GetSheetAt(0) as XSSFSheet;
+            Assert.IsNotNull(sheet);
+            var drawing = sheet.GetDrawingPatriarch() as XSSFDrawing;
+            Assert.IsNotNull(drawing, "line chart 應有 Drawing");
+            Assert.IsTrue(drawing.GetCharts().Count >= 1);
+        }
+
+        [TestMethod]
+        public void Export_chartType_bar_stacked_produces_chart()
+        {
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(MakeTwoRowResponse(), includeChart: true, chartType: "bar-stacked"));
+            var sheet = wb.GetSheetAt(0) as XSSFSheet;
+            Assert.IsNotNull(sheet);
+            var drawing = sheet.GetDrawingPatriarch() as XSSFDrawing;
+            Assert.IsNotNull(drawing, "bar-stacked chart 應有 Drawing");
+            Assert.IsTrue(drawing.GetCharts().Count >= 1);
+        }
+
+        [TestMethod]
+        public void Export_chartType_null_defaults_to_bar()
+        {
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(MakeTwoRowResponse(), includeChart: true, chartType: null));
+            var sheet = wb.GetSheetAt(0) as XSSFSheet;
+            Assert.IsNotNull(sheet);
+            var drawing = sheet.GetDrawingPatriarch() as XSSFDrawing;
+            Assert.IsNotNull(drawing);
+            Assert.IsTrue(drawing.GetCharts().Count >= 1);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Export API 新增 `chartType` query parameter（`bar` / `pie` / `line` / `bar-stacked`）
- `AnalysisExcelExporter` 根據 chartType 產出對應的 NPOI 圖表
- 前端 JS 匯出時自動帶上 `detectChartType` 結果
- 新增 4 個 MSTest 驗證各圖表類型匯出

## 修改範圍
| 檔案 | 變更 |
|------|------|
| `AnalysisExcelExporter.cs` | 支援 pie/line/bar，提取 `CreateChartBase` 共用邏輯 |
| `_AnalysisController.cs` | Export/PivotExport 加 `chartType` 參數 |
| `framework_analysis.js` | `exportData` 帶上 `chartType` |
| `AnalysisExcelExporterTests.cs` | 4 個 chartType 測試 |

## 向後相容
- `chartType` 為 optional，預設 `null` 時 fallback 為 bar（與原行為一致）

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)