### PR TITLE
feat(etl): add ETL management views for demo

### DIFF
--- a/demo/WalkingTec.Mvvm.Demo/Views/_EtlJob/Create.cshtml
+++ b/demo/WalkingTec.Mvvm.Demo/Views/_EtlJob/Create.cshtml
@@ -1,0 +1,23 @@
+@model WalkingTec.Mvvm.Etl.ViewModels.EtlJobDefinitionVM
+
+<wt:form vm="@Model">
+  <wt:row items-per-row="ItemsPerRowEnum.Two">
+    <wt:textbox field="Entity.Name" />
+    <wt:textbox field="Entity.Description" />
+    <wt:textbox field="Entity.CronExpression" />
+    <wt:textbox field="Entity.JobClassName" />
+    <wt:combobox field="Entity.Status" />
+    <wt:textbox field="Entity.SourceCsKey" />
+    <wt:combobox field="Entity.SourceDbType" />
+    <wt:combobox field="Entity.WatermarkType" />
+    <wt:textbox field="Entity.WatermarkColumn" />
+    <wt:textbox field="Entity.InitialWatermarkValue" />
+    <wt:textbox field="Entity.WatermarkTimeZone" />
+    <wt:textbox field="Entity.RetryCount" />
+    <wt:textbox field="Entity.TimeoutMinutes" />
+  </wt:row>
+  <wt:row align="AlignEnum.Right">
+    <wt:submitbutton />
+    <wt:closebutton />
+  </wt:row>
+</wt:form>

--- a/demo/WalkingTec.Mvvm.Demo/Views/_EtlJob/Delete.cshtml
+++ b/demo/WalkingTec.Mvvm.Demo/Views/_EtlJob/Delete.cshtml
@@ -1,0 +1,22 @@
+@model WalkingTec.Mvvm.Etl.ViewModels.EtlJobDefinitionVM
+@inject IStringLocalizer<Program> Localizer;
+
+<wt:form vm="@Model">
+  <wt:quote>@Localizer["Sys.DeleteConfirm"]</wt:quote>
+  <wt:row items-per-row="ItemsPerRowEnum.Two">
+    <wt:display field="Entity.Name" />
+    <wt:display field="Entity.Description" />
+    <wt:display field="Entity.CronExpression" />
+    <wt:display field="Entity.Status" />
+    <wt:display field="Entity.SourceCsKey" />
+    <wt:display field="Entity.SourceDbType" />
+    <wt:display field="Entity.WatermarkType" />
+    <wt:display field="Entity.LastRunAt" />
+    <wt:display field="Entity.LastError" />
+  </wt:row>
+  <wt:hidden field="Entity.ID" />
+  <wt:row align="AlignEnum.Right">
+    <wt:submitbutton theme="ButtonThemeEnum.Warm" text="@Localizer["Sys.Delete"]" />
+    <wt:closebutton />
+  </wt:row>
+</wt:form>

--- a/demo/WalkingTec.Mvvm.Demo/Views/_EtlJob/Edit.cshtml
+++ b/demo/WalkingTec.Mvvm.Demo/Views/_EtlJob/Edit.cshtml
@@ -1,0 +1,24 @@
+@model WalkingTec.Mvvm.Etl.ViewModels.EtlJobDefinitionVM
+
+<wt:form vm="@Model">
+  <wt:row items-per-row="ItemsPerRowEnum.Two">
+    <wt:textbox field="Entity.Name" />
+    <wt:textbox field="Entity.Description" />
+    <wt:textbox field="Entity.CronExpression" />
+    <wt:textbox field="Entity.JobClassName" />
+    <wt:combobox field="Entity.Status" />
+    <wt:textbox field="Entity.SourceCsKey" />
+    <wt:combobox field="Entity.SourceDbType" />
+    <wt:combobox field="Entity.WatermarkType" />
+    <wt:textbox field="Entity.WatermarkColumn" />
+    <wt:textbox field="Entity.InitialWatermarkValue" />
+    <wt:textbox field="Entity.WatermarkTimeZone" />
+    <wt:textbox field="Entity.RetryCount" />
+    <wt:textbox field="Entity.TimeoutMinutes" />
+  </wt:row>
+  <wt:hidden field="Entity.ID" />
+  <wt:row align="AlignEnum.Right">
+    <wt:submitbutton />
+    <wt:closebutton />
+  </wt:row>
+</wt:form>

--- a/demo/WalkingTec.Mvvm.Demo/Views/_EtlJob/Index.cshtml
+++ b/demo/WalkingTec.Mvvm.Demo/Views/_EtlJob/Index.cshtml
@@ -1,0 +1,11 @@
+@model WalkingTec.Mvvm.Etl.ViewModels.EtlJobListVM
+@inject IStringLocalizer<Program> Localizer;
+
+<wt:searchpanel vm="@Model" reset-btn="true">
+  <wt:row items-per-row="ItemsPerRowEnum.Three">
+    <wt:textbox field="Searcher.Name" />
+    <wt:combobox field="Searcher.Status" empty-text="@Localizer["Sys.All"]" />
+    <wt:combobox field="Searcher.SourceDbType" empty-text="@Localizer["Sys.All"]" />
+  </wt:row>
+</wt:searchpanel>
+<wt:grid vm="@Model" url="/_EtlJob/Search" />

--- a/demo/WalkingTec.Mvvm.Demo/Views/_EtlRunLog/Index.cshtml
+++ b/demo/WalkingTec.Mvvm.Demo/Views/_EtlRunLog/Index.cshtml
@@ -1,0 +1,12 @@
+@model WalkingTec.Mvvm.Etl.ViewModels.EtlRunLogListVM
+@inject IStringLocalizer<Program> Localizer;
+
+<wt:searchpanel vm="@Model" reset-btn="true">
+  <wt:row items-per-row="ItemsPerRowEnum.Three">
+    <wt:combobox field="Searcher.Result" empty-text="@Localizer["Sys.All"]" />
+    <wt:combobox field="Searcher.Trigger" empty-text="@Localizer["Sys.All"]" />
+    <wt:datetime field="Searcher.StartedAtBegin" />
+    <wt:datetime field="Searcher.StartedAtEnd" />
+  </wt:row>
+</wt:searchpanel>
+<wt:grid vm="@Model" url="/_EtlRunLog/Search" />


### PR DESCRIPTION
## Summary
- Add 5 LayUI .cshtml views for ETL Job CRUD and RunLog browsing
- Views follow existing WTM TagHelper patterns (searchpanel, grid, form, combobox, etc.)

## Files added
| View | Purpose |
|------|---------|
| `_EtlJob/Index.cshtml` | Search panel (Name, Status, SourceDbType) + grid |
| `_EtlJob/Create.cshtml` | Job creation form with all config fields |
| `_EtlJob/Edit.cshtml` | Job edit form + hidden ID |
| `_EtlJob/Delete.cshtml` | Confirmation with read-only display |
| `_EtlRunLog/Index.cshtml` | Log search (Result, Trigger, date range) + grid |

## Test plan
- [x] Build succeeds (`dotnet build -c Release`)
- [x] Index renders LayUI search panel + grid HTML
- [x] Create renders form with all required fields
- [x] Edit loads existing job data into form
- [x] Delete shows confirmation with job details
- [x] RunLog Index renders search + grid

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)