### PR TITLE
fix(dashboard): serialize numeric fields as numbers (#280)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Dashboard/DashboardDefinition.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/DashboardDefinition.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace WalkingTec.Mvvm.Core.Dashboard;
 
+[JsonNumberHandling(JsonNumberHandling.Strict)]
 public class DashboardDefinition
 {
     public int SchemaVersion { get; set; } = 1;
@@ -28,6 +30,7 @@ public class SharingDefinition
     public List<string>? Roles { get; set; }
 }
 
+[JsonNumberHandling(JsonNumberHandling.Strict)]
 public class LayoutItem
 {
     public string Id { get; set; } = "";

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardDefinitionTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardDefinitionTests.cs
@@ -68,6 +68,39 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         }
 
         [TestMethod]
+        public void Serialize_RefreshInterval_as_number_even_with_WriteAsString()
+        {
+            // Simulate WTM's global JSON config (WriteAsString)
+            var globalOptions = new JsonSerializerOptions
+            {
+                NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString
+                               | System.Text.Json.Serialization.JsonNumberHandling.WriteAsString
+            };
+
+            var def = new DashboardDefinition
+            {
+                Id = "test",
+                RefreshInterval = 30,
+                SchemaVersion = 2,
+                Layout = new List<LayoutItem>
+                {
+                    new LayoutItem { Id = "w1", X = 1, Y = 2, W = 4, H = 3 }
+                }
+            };
+
+            var json = JsonSerializer.Serialize(def, globalOptions);
+
+            // RefreshInterval and SchemaVersion should be numbers, not strings
+            json.Should().Contain("\"RefreshInterval\":30", "RefreshInterval should serialize as number");
+            json.Should().Contain("\"SchemaVersion\":2", "SchemaVersion should serialize as number");
+            // LayoutItem numeric fields should also be numbers
+            json.Should().Contain("\"X\":1");
+            json.Should().Contain("\"Y\":2");
+            json.Should().Contain("\"W\":4");
+            json.Should().Contain("\"H\":3");
+        }
+
+        [TestMethod]
         public void DashboardSummary_maps_from_definition()
         {
             var def = new DashboardDefinition


### PR DESCRIPTION
## Summary
- `DashboardDefinition` 和 `LayoutItem` 加上 `[JsonNumberHandling(Strict)]`，覆蓋全域 `WriteAsString` 設定
- `RefreshInterval`、`SchemaVersion`、`X/Y/W/H` 在 API JSON 回應中正確序列化為數字（非字串）
- 新增測試驗證在 `WriteAsString` 全域設定下仍輸出數字

## Root Cause
WTM 全域 JSON 設定 `JsonNumberHandling.WriteAsString`（for LayUI form compatibility）導致所有數值欄位被序列化為字串

## Test plan
- [x] `Serialize_RefreshInterval_as_number_even_with_WriteAsString` 測試通過
- [x] 既有 Dashboard 序列化/反序列化 round-trip 測試通過

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)