### PR TITLE
feat(analysis): dual Y-axis + currency scaling (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 更新日志
 
+## [Unreleased]
+
+### Added
+- **Analysis Mode — 雙 Y 軸（Dual Y-Axis）**：當 2 個度量最大值差距 ≥ 10 倍時自動啟用，ECharts 左右 Y 軸分離，NPOI Excel 產生 secondary value axis（#281）
+- **Analysis Mode — 金額縮放（Currency Scaling）**：依最大值自動選擇元/萬元/百萬元/億元顯示單位，Y 軸標題與 Excel header 附加單位，tooltip 仍顯示原始精確值（#281）
+
 ## [8.6.0] - 2026-03-12
 
 ### Added

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -25,10 +26,36 @@ namespace WalkingTec.Mvvm.Core.Analysis
             using var workbook = new XSSFWorkbook();
             var sheet = workbook.CreateSheet("Analysis");
 
-            // Header row
+            // Header row — append unit label for large-value measure columns
             var header = sheet.CreateRow(0);
             for (int i = 0; i < result.Columns.Count; i++)
-                header.CreateCell(i).SetCellValue(result.Columns[i]);
+            {
+                var colName = result.Columns[i];
+                var headerText = colName;
+
+                // Check if this column has numeric data and compute scale
+                if (result.Rows.Count > 0 && i >= 1)
+                {
+                    double maxAbs = 0;
+                    bool isNumeric = false;
+                    foreach (var row in result.Rows)
+                    {
+                        if (row.TryGetValue(colName, out var val) && val is decimal or double or float or int or long)
+                        {
+                            isNumeric = true;
+                            var abs = Math.Abs(Convert.ToDouble(val));
+                            if (abs > maxAbs) maxAbs = abs;
+                        }
+                    }
+                    if (isNumeric)
+                    {
+                        var (_, unit) = ComputeScale(maxAbs);
+                        if (!string.IsNullOrEmpty(unit))
+                            headerText = $"{colName}（{unit}）";
+                    }
+                }
+                header.CreateCell(i).SetCellValue(headerText);
+            }
 
             // Data rows
             for (int r = 0; r < result.Rows.Count; r++)
@@ -75,6 +102,42 @@ namespace WalkingTec.Mvvm.Core.Analysis
             return ms.ToArray();
         }
 
+        internal static (double Divisor, string Unit) ComputeScale(double maxAbsValue)
+        {
+            var abs = Math.Abs(maxAbsValue);
+            if (abs >= 100_000_000) return (100_000_000, "億");
+            if (abs >= 1_000_000) return (1_000_000, "百萬");
+            if (abs >= 10_000) return (10_000, "萬");
+            return (1, "");
+        }
+
+        internal static bool DetectDualAxis(AnalysisQueryResponse result, List<int> measureIndices)
+        {
+            if (measureIndices.Count != 2 || result.Rows.Count == 0) return false;
+
+            double max0 = 0, max1 = 0;
+            var col0 = result.Columns[measureIndices[0]];
+            var col1 = result.Columns[measureIndices[1]];
+
+            foreach (var row in result.Rows)
+            {
+                if (row.TryGetValue(col0, out var v0))
+                {
+                    var a0 = Math.Abs(Convert.ToDouble(v0));
+                    if (a0 > max0) max0 = a0;
+                }
+                if (row.TryGetValue(col1, out var v1))
+                {
+                    var a1 = Math.Abs(Convert.ToDouble(v1));
+                    if (a1 > max1) max1 = a1;
+                }
+            }
+
+            if (max0 == 0 || max1 == 0) return false;
+            var ratio = max0 > max1 ? max0 / max1 : max1 / max0;
+            return ratio >= 10;
+        }
+
         private static (IChart chart, List<int> measureIndices) CreateChartBase(ISheet sheet, AnalysisQueryResponse result)
         {
             var drawing = sheet.CreateDrawingPatriarch();
@@ -116,7 +179,17 @@ namespace WalkingTec.Mvvm.Core.Analysis
             var valAxis = chart.ChartAxisFactory.CreateValueAxis(AxisPosition.Left);
             valAxis.Crosses = AxisCrosses.AutoZero;
 
-            chart.Plot(data, catAxis, valAxis);
+            if (DetectDualAxis(result, measureIndices))
+            {
+                var valAxisRight = chart.ChartAxisFactory.CreateValueAxis(AxisPosition.Right);
+                valAxisRight.Crosses = AxisCrosses.AutoZero;
+                chart.Plot(data, catAxis, valAxis, valAxisRight);
+            }
+            else
+            {
+                chart.Plot(data, catAxis, valAxis);
+            }
+
             chart.GetOrCreateLegend().Position = LegendPosition.Bottom;
         }
 
@@ -140,7 +213,17 @@ namespace WalkingTec.Mvvm.Core.Analysis
             var valAxis = chart.ChartAxisFactory.CreateValueAxis(AxisPosition.Left);
             valAxis.Crosses = AxisCrosses.AutoZero;
 
-            chart.Plot(data, catAxis, valAxis);
+            if (DetectDualAxis(result, measureIndices))
+            {
+                var valAxisRight = chart.ChartAxisFactory.CreateValueAxis(AxisPosition.Right);
+                valAxisRight.Crosses = AxisCrosses.AutoZero;
+                chart.Plot(data, catAxis, valAxis, valAxisRight);
+            }
+            else
+            {
+                chart.Plot(data, catAxis, valAxis);
+            }
+
             chart.GetOrCreateLegend().Position = LegendPosition.Bottom;
         }
 

--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -44,6 +44,38 @@
         return s;
     }
 
+    function computeScale(maxVal) {
+        var abs = Math.abs(maxVal) || 0;
+        if (abs >= 100000000) return { divisor: 100000000, unit: '億' };
+        if (abs >= 1000000)   return { divisor: 1000000, unit: '百萬' };
+        if (abs >= 10000)     return { divisor: 10000, unit: '萬' };
+        return { divisor: 1, unit: '' };
+    }
+
+    function scaleSeriesData(data, divisor) {
+        if (!divisor || divisor === 1) return data;
+        return data.map(function (v) {
+            return v == null ? null : v / divisor;
+        });
+    }
+
+    function detectDualAxis(rows, measures) {
+        if (!measures || measures.length !== 2) return false;
+        if (!rows || rows.length === 0) return false;
+        var key0 = measures[0].field + '_' + measures[0].func;
+        var key1 = measures[1].field + '_' + measures[1].func;
+        var max0 = 0, max1 = 0;
+        for (var i = 0; i < rows.length; i++) {
+            var v0 = Math.abs(rows[i][key0] || 0);
+            var v1 = Math.abs(rows[i][key1] || 0);
+            if (v0 > max0) max0 = v0;
+            if (v1 > max1) max1 = v1;
+        }
+        if (max0 === 0 || max1 === 0) return false;
+        var ratio = max0 > max1 ? max0 / max1 : max1 / max0;
+        return ratio >= 10;
+    }
+
     function clearChildren(el) {
         while (el.firstChild) el.removeChild(el.firstChild);
     }
@@ -959,20 +991,63 @@
                 }]
             });
         } else {
-            var series = req.measures.map(function (m) {
+            var isDual = chartType !== 'bar-stacked' && detectDualAxis(result.rows, req.measures);
+            var scales = [];
+            if (isDual) {
+                req.measures.forEach(function (m) {
+                    var key = m.field + '_' + m.func;
+                    var maxVal = 0;
+                    result.rows.forEach(function (r) {
+                        var v = Math.abs(r[key] || 0);
+                        if (v > maxVal) maxVal = v;
+                    });
+                    scales.push(computeScale(maxVal));
+                });
+            }
+            var series = req.measures.map(function (m, idx) {
                 var key = m.field + '_' + m.func;
-                return {
+                var rawData = result.rows.map(function (r) { return r[key]; });
+                var s = {
                     name: key,
                     type: chartType === 'line' ? 'line' : 'bar',
                     stack: chartType === 'bar-stacked' ? 'total' : undefined,
-                    data: result.rows.map(function (r) { return r[key]; })
+                    data: isDual ? scaleSeriesData(rawData, scales[idx].divisor) : rawData
                 };
+                if (isDual) {
+                    s.yAxisIndex = idx;
+                    s.originalData = rawData;
+                }
+                return s;
             });
+
+            var yAxisOption;
+            if (isDual) {
+                yAxisOption = [
+                    { type: 'value', name: req.measures[0].field + (scales[0].unit ? '（' + scales[0].unit + '）' : ''), position: 'left' },
+                    { type: 'value', name: req.measures[1].field + (scales[1].unit ? '（' + scales[1].unit + '）' : ''), position: 'right' }
+                ];
+            } else {
+                yAxisOption = { type: 'value' };
+            }
+
+            var tooltipOption = { trigger: 'axis' };
+            if (isDual) {
+                tooltipOption.formatter = function (params) {
+                    var lines = [params[0].axisValueLabel];
+                    params.forEach(function (p) {
+                        var s = series[p.seriesIndex];
+                        var original = s.originalData ? s.originalData[p.dataIndex] : p.value;
+                        lines.push(p.marker + ' ' + p.seriesName + ': ' + (original == null ? '-' : original));
+                    });
+                    return lines.join('<br/>');
+                };
+            }
+
             chart.setOption({
-                tooltip: { trigger: 'axis' },
+                tooltip: tooltipOption,
                 legend: { data: req.measures.map(function (m) { return m.field + '_' + m.func; }) },
                 xAxis: { type: 'category', data: categories },
-                yAxis: { type: 'value' },
+                yAxis: yAxisOption,
                 series: series
             });
         }
@@ -1201,6 +1276,9 @@
         drillBack: drillBack,
         drillReset: drillReset,
         collectSearcherFormData: collectSearcherFormData,
+        computeScale: computeScale,
+        scaleSeriesData: scaleSeriesData,
+        detectDualAxis: detectDualAxis,
         _getState: function (gridId) { return _state[gridId]; }
     };
 

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
@@ -289,5 +289,112 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.IsNotNull(drawing);
             Assert.IsTrue(drawing.GetCharts().Count >= 1);
         }
+
+        // ─── #281: ComputeScale ─────────────────────────────────────────────
+
+        [TestMethod]
+        public void ComputeScale_small_value_no_unit()
+        {
+            var (divisor, unit) = AnalysisExcelExporter.ComputeScale(9999);
+            Assert.AreEqual(1, divisor);
+            Assert.AreEqual("", unit);
+        }
+
+        [TestMethod]
+        public void ComputeScale_wan_threshold()
+        {
+            var (divisor, unit) = AnalysisExcelExporter.ComputeScale(50000);
+            Assert.AreEqual(10_000, divisor);
+            Assert.AreEqual("萬", unit);
+        }
+
+        [TestMethod]
+        public void ComputeScale_yi_threshold()
+        {
+            var (divisor, unit) = AnalysisExcelExporter.ComputeScale(200_000_000);
+            Assert.AreEqual(100_000_000, divisor);
+            Assert.AreEqual("億", unit);
+        }
+
+        // ─── #281: Column header scaling ────────────────────────────────────
+
+        [TestMethod]
+        public void Export_header_appends_unit_for_large_values()
+        {
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = 5_000_000m },
+                });
+
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
+            var header = wb.GetSheetAt(0).GetRow(0);
+            Assert.AreEqual("Amount_Sum（百萬）", header.GetCell(1).StringCellValue);
+        }
+
+        [TestMethod]
+        public void Export_header_no_unit_for_small_values()
+        {
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = 500m },
+                });
+
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
+            var header = wb.GetSheetAt(0).GetRow(0);
+            Assert.AreEqual("Amount_Sum", header.GetCell(1).StringCellValue);
+        }
+
+        // ─── #281: Dual axis charts ─────────────────────────────────────────
+
+        private static AnalysisQueryResponse MakeDualMeasureResponse()
+        {
+            return MakeResponse(
+                new List<string> { "Region", "Amount_Sum", "Qty_Count" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = 1_000_000m, ["Qty_Count"] = 5m },
+                    new() { ["Region"] = "South", ["Amount_Sum"] = 2_000_000m, ["Qty_Count"] = 8m },
+                });
+        }
+
+        [TestMethod]
+        public void Export_dual_axis_bar_chart_does_not_throw()
+        {
+            var resp = MakeDualMeasureResponse();
+            var bytes = AnalysisExcelExporter.Export(resp, includeChart: true, chartType: "bar");
+            var wb = OpenWorkbook(bytes);
+            var sheet = wb.GetSheetAt(0) as XSSFSheet;
+            Assert.IsNotNull(sheet);
+            var drawing = sheet.GetDrawingPatriarch() as XSSFDrawing;
+            Assert.IsNotNull(drawing);
+            Assert.IsTrue(drawing.GetCharts().Count >= 1);
+        }
+
+        [TestMethod]
+        public void Export_dual_axis_line_chart_does_not_throw()
+        {
+            var resp = MakeDualMeasureResponse();
+            var bytes = AnalysisExcelExporter.Export(resp, includeChart: true, chartType: "line");
+            var wb = OpenWorkbook(bytes);
+            var sheet = wb.GetSheetAt(0) as XSSFSheet;
+            Assert.IsNotNull(sheet);
+            var drawing = sheet.GetDrawingPatriarch() as XSSFDrawing;
+            Assert.IsNotNull(drawing);
+            Assert.IsTrue(drawing.GetCharts().Count >= 1);
+        }
+
+        [TestMethod]
+        public void Export_single_measure_backward_compat()
+        {
+            // Single measure should still work exactly as before
+            var resp = MakeTwoRowResponse();
+            var bytes = AnalysisExcelExporter.Export(resp, includeChart: true, chartType: "bar");
+            Assert.IsNotNull(bytes);
+            Assert.IsTrue(bytes.Length > 0);
+        }
     }
 }

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -2121,3 +2121,186 @@ describe('Pivot mode in query()', () => {
         expect(mockAlert).toHaveBeenCalledWith('請選擇一個樞紐(Pivot)維度');
     });
 });
+
+// ─── #281: computeScale ──────────────────────────────────────────────────────
+describe('computeScale', () => {
+    test('0 → divisor 1, no unit', () => {
+        expect(waReq.computeScale(0)).toEqual({ divisor: 1, unit: '' });
+    });
+
+    test('9999 → divisor 1, no unit', () => {
+        expect(waReq.computeScale(9999)).toEqual({ divisor: 1, unit: '' });
+    });
+
+    test('10000 → divisor 10000, unit 萬', () => {
+        expect(waReq.computeScale(10000)).toEqual({ divisor: 10000, unit: '萬' });
+    });
+
+    test('999999 → divisor 10000, unit 萬', () => {
+        expect(waReq.computeScale(999999)).toEqual({ divisor: 10000, unit: '萬' });
+    });
+
+    test('1000000 → divisor 1000000, unit 百萬', () => {
+        expect(waReq.computeScale(1000000)).toEqual({ divisor: 1000000, unit: '百萬' });
+    });
+
+    test('100000000 → divisor 100000000, unit 億', () => {
+        expect(waReq.computeScale(100000000)).toEqual({ divisor: 100000000, unit: '億' });
+    });
+
+    test('negative value uses absolute value', () => {
+        expect(waReq.computeScale(-5000000)).toEqual({ divisor: 1000000, unit: '百萬' });
+    });
+});
+
+// ─── #281: scaleSeriesData ───────────────────────────────────────────────────
+describe('scaleSeriesData', () => {
+    test('divisor=1 returns data unchanged', () => {
+        var data = [100, 200, 300];
+        expect(waReq.scaleSeriesData(data, 1)).toEqual([100, 200, 300]);
+    });
+
+    test('divisor=10000 scales values', () => {
+        expect(waReq.scaleSeriesData([10000, 50000], 10000)).toEqual([1, 5]);
+    });
+
+    test('null values preserved as null', () => {
+        expect(waReq.scaleSeriesData([10000, null, 30000], 10000)).toEqual([1, null, 3]);
+    });
+
+    test('empty array returns empty', () => {
+        expect(waReq.scaleSeriesData([], 10000)).toEqual([]);
+    });
+});
+
+// ─── #281: detectDualAxis ────────────────────────────────────────────────────
+describe('detectDualAxis', () => {
+    const m2 = [{ field: 'Amount', func: 'Sum' }, { field: 'Qty', func: 'Count' }];
+
+    test('non-2 measures → false', () => {
+        expect(waReq.detectDualAxis(
+            [{ Amount_Sum: 1000000, Qty_Count: 10 }],
+            [{ field: 'Amount', func: 'Sum' }]
+        )).toBe(false);
+    });
+
+    test('empty rows → false', () => {
+        expect(waReq.detectDualAxis([], m2)).toBe(false);
+    });
+
+    test('ratio < 10x → false', () => {
+        expect(waReq.detectDualAxis(
+            [{ Amount_Sum: 100, Qty_Count: 20 }], m2
+        )).toBe(false);
+    });
+
+    test('ratio exactly 10x → true', () => {
+        expect(waReq.detectDualAxis(
+            [{ Amount_Sum: 100, Qty_Count: 10 }], m2
+        )).toBe(true);
+    });
+
+    test('ratio > 10x → true', () => {
+        expect(waReq.detectDualAxis(
+            [{ Amount_Sum: 1000000, Qty_Count: 5 }], m2
+        )).toBe(true);
+    });
+
+    test('reversed ratio > 10x → true', () => {
+        expect(waReq.detectDualAxis(
+            [{ Amount_Sum: 5, Qty_Count: 1000000 }], m2
+        )).toBe(true);
+    });
+
+    test('one max is 0 → false', () => {
+        expect(waReq.detectDualAxis(
+            [{ Amount_Sum: 0, Qty_Count: 100 }], m2
+        )).toBe(false);
+    });
+
+    test('multiple rows uses max across all', () => {
+        expect(waReq.detectDualAxis([
+            { Amount_Sum: 100, Qty_Count: 5 },
+            { Amount_Sum: 500000, Qty_Count: 8 },
+        ], m2)).toBe(true);
+    });
+});
+
+// ─── #281: renderChart dual axis ─────────────────────────────────────────────
+describe('renderChart — dual Y-axis (#281)', () => {
+    function makeChartEnv() {
+        const capturedOptions = [];
+        const { wa } = makeEnv({
+            echarts: {
+                init: jest.fn(() => ({
+                    setOption: jest.fn((opt) => { capturedOptions.push(opt); }),
+                    on: jest.fn(),
+                    dispose: jest.fn(),
+                })),
+            },
+        });
+        return { wa, capturedOptions };
+    }
+
+    function makeContainer() {
+        return {
+            appendChild: jest.fn(),
+            children: [],
+            style: {},
+            id: '',
+        };
+    }
+
+    test('dual axis produces yAxis array with 2 entries', () => {
+        const { wa, capturedOptions } = makeChartEnv();
+        const result = {
+            columns: ['Region', 'Amount_Sum', 'Qty_Count'],
+            rows: [
+                { Region: 'North', Amount_Sum: 1000000, Qty_Count: 5 },
+                { Region: 'South', Amount_Sum: 2000000, Qty_Count: 8 },
+            ],
+        };
+        const req = {
+            dimensions: ['Region'],
+            measures: [{ field: 'Amount', func: 'Sum' }, { field: 'Qty', func: 'Count' }],
+        };
+        const dims = [{ fieldName: 'Region', isDate: false }];
+        wa.renderChart('g1', result, req, dims, makeContainer());
+        expect(capturedOptions.length).toBe(1);
+        expect(Array.isArray(capturedOptions[0].yAxis)).toBe(true);
+        expect(capturedOptions[0].yAxis.length).toBe(2);
+        expect(capturedOptions[0].yAxis[0].position).toBe('left');
+        expect(capturedOptions[0].yAxis[1].position).toBe('right');
+    });
+
+    test('dual axis series have yAxisIndex 0 and 1', () => {
+        const { wa, capturedOptions } = makeChartEnv();
+        const result = {
+            columns: ['Region', 'Amount_Sum', 'Qty_Count'],
+            rows: [{ Region: 'North', Amount_Sum: 1000000, Qty_Count: 5 }],
+        };
+        const req = {
+            dimensions: ['Region'],
+            measures: [{ field: 'Amount', func: 'Sum' }, { field: 'Qty', func: 'Count' }],
+        };
+        wa.renderChart('g1', result, req, [{ fieldName: 'Region', isDate: false }], makeContainer());
+        expect(capturedOptions[0].series[0].yAxisIndex).toBe(0);
+        expect(capturedOptions[0].series[1].yAxisIndex).toBe(1);
+    });
+
+    test('single measure backward compat — yAxis is object not array', () => {
+        const { wa, capturedOptions } = makeChartEnv();
+        const result = {
+            columns: ['Region', 'Amount_Sum'],
+            rows: [{ Region: 'North', Amount_Sum: 100 }, { Region: 'South', Amount_Sum: 200 }],
+        };
+        const req = {
+            dimensions: ['Region'],
+            measures: [{ field: 'Amount', func: 'Sum' }],
+        };
+        // Force 'bar' to ensure it enters the else branch (1 dim + 1 measure defaults to 'pie')
+        wa.renderChart('g1', result, req, [{ fieldName: 'Region', isDate: false }], makeContainer(), 'bar');
+        expect(Array.isArray(capturedOptions[0].yAxis)).toBe(false);
+        expect(capturedOptions[0].yAxis).toEqual({ type: 'value' });
+    });
+});


### PR DESCRIPTION
## Summary
- **JS (ECharts)**: Auto dual Y-axis when 2 measures differ ≥10x; `computeScale` / `scaleSeriesData` / `detectDualAxis` pure functions; tooltip shows original values; `bar-stacked` excluded
- **C# (NPOI Excel)**: `ComputeScale` / `DetectDualAxis` helpers; column headers append unit label (萬/百萬/億) for large values; `EmbedBarChart` / `EmbedLineChart` create second `ValueAxis` when dual
- **Tests**: 22 Jest tests + 8 MSTest tests; all existing tests pass (218 JS, full C# suite)

## Test plan
- [ ] `cd test/WalkingTec.Mvvm.Js.Tests && npm test` — 218 tests pass
- [ ] `dotnet test test/WalkingTec.Mvvm.Core.Test -c Release --filter "FullyQualifiedName~AnalysisExcelExporter"` — all pass
- [ ] `dotnet build WalkingTec.Mvvm.sln -c Release` — 0 errors
- [ ] Manual: open Analysis panel with 2 measures (Amount vs Qty), verify dual Y-axis renders
- [ ] Manual: export to Excel, verify column header shows unit label for large values

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)