### PR TITLE
fix(analysis): harden dual Y-axis against non-numeric values and fix header/label bugs (#284–#288)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
@@ -26,35 +26,11 @@ namespace WalkingTec.Mvvm.Core.Analysis
             using var workbook = new XSSFWorkbook();
             var sheet = workbook.CreateSheet("Analysis");
 
-            // Header row — append unit label for large-value measure columns
+            // Header row — write original column names without unit decoration
             var header = sheet.CreateRow(0);
             for (int i = 0; i < result.Columns.Count; i++)
             {
-                var colName = result.Columns[i];
-                var headerText = colName;
-
-                // Check if this column has numeric data and compute scale
-                if (result.Rows.Count > 0 && i >= 1)
-                {
-                    double maxAbs = 0;
-                    bool isNumeric = false;
-                    foreach (var row in result.Rows)
-                    {
-                        if (row.TryGetValue(colName, out var val) && val is decimal or double or float or int or long)
-                        {
-                            isNumeric = true;
-                            var abs = Math.Abs(Convert.ToDouble(val));
-                            if (abs > maxAbs) maxAbs = abs;
-                        }
-                    }
-                    if (isNumeric)
-                    {
-                        var (_, unit) = ComputeScale(maxAbs);
-                        if (!string.IsNullOrEmpty(unit))
-                            headerText = $"{colName}（{unit}）";
-                    }
-                }
-                header.CreateCell(i).SetCellValue(headerText);
+                header.CreateCell(i).SetCellValue(result.Columns[i]);
             }
 
             // Data rows
@@ -121,12 +97,12 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
             foreach (var row in result.Rows)
             {
-                if (row.TryGetValue(col0, out var v0))
+                if (row.TryGetValue(col0, out var v0) && v0 is decimal or double or float or int or long)
                 {
                     var a0 = Math.Abs(Convert.ToDouble(v0));
                     if (a0 > max0) max0 = a0;
                 }
-                if (row.TryGetValue(col1, out var v1))
+                if (row.TryGetValue(col1, out var v1) && v1 is decimal or double or float or int or long)
                 {
                     var a1 = Math.Abs(Convert.ToDouble(v1));
                     if (a1 > max1) max1 = a1;

--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -53,7 +53,7 @@
     }
 
     function scaleSeriesData(data, divisor) {
-        if (!divisor || divisor === 1) return data;
+        if (divisor == null || !isFinite(divisor) || divisor <= 1) return data;
         return data.map(function (v) {
             return v == null ? null : v / divisor;
         });
@@ -66,8 +66,10 @@
         var key1 = measures[1].field + '_' + measures[1].func;
         var max0 = 0, max1 = 0;
         for (var i = 0; i < rows.length; i++) {
-            var v0 = Math.abs(rows[i][key0] || 0);
-            var v1 = Math.abs(rows[i][key1] || 0);
+            var raw0 = rows[i][key0];
+            var raw1 = rows[i][key1];
+            var v0 = (typeof raw0 === 'number' && isFinite(raw0)) ? Math.abs(raw0) : 0;
+            var v1 = (typeof raw1 === 'number' && isFinite(raw1)) ? Math.abs(raw1) : 0;
             if (v0 > max0) max0 = v0;
             if (v1 > max1) max1 = v1;
         }
@@ -1022,9 +1024,11 @@
 
             var yAxisOption;
             if (isDual) {
+                var name0 = req.measures[0].field + '_' + req.measures[0].func;
+                var name1 = req.measures[1].field + '_' + req.measures[1].func;
                 yAxisOption = [
-                    { type: 'value', name: req.measures[0].field + (scales[0].unit ? '（' + scales[0].unit + '）' : ''), position: 'left' },
-                    { type: 'value', name: req.measures[1].field + (scales[1].unit ? '（' + scales[1].unit + '）' : ''), position: 'right' }
+                    { type: 'value', name: name0 + (scales[0].unit ? '（' + scales[0].unit + '）' : ''), position: 'left' },
+                    { type: 'value', name: name1 + (scales[1].unit ? '（' + scales[1].unit + '）' : ''), position: 'right' }
                 ];
             } else {
                 yAxisOption = { type: 'value' };

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
@@ -316,11 +316,12 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.AreEqual("億", unit);
         }
 
-        // ─── #281: Column header scaling ────────────────────────────────────
+        // ─── #288: Column header — always raw column name (no unit decoration) ──
 
         [TestMethod]
         public void Export_header_appends_unit_for_large_values()
         {
+            // #288: header must be the original column name regardless of value magnitude
             var resp = MakeResponse(
                 new List<string> { "Region", "Amount_Sum" },
                 new List<Dictionary<string, object?>>
@@ -330,22 +331,42 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
 
             var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
             var header = wb.GetSheetAt(0).GetRow(0);
-            Assert.AreEqual("Amount_Sum（百萬）", header.GetCell(1).StringCellValue);
+            Assert.AreEqual("Amount_Sum", header.GetCell(1).StringCellValue);
+        }
+
+        // ─── #284: DetectDualAxis with non-numeric values ────────────────────
+
+        [TestMethod]
+        public void DetectDualAxis_non_numeric_string_does_not_throw()
+        {
+            // Rows containing non-numeric string values must not cause FormatException
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum", "Qty_Count" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = "N/A", ["Qty_Count"] = 5m },
+                    new() { ["Region"] = "South", ["Amount_Sum"] = 2_000_000m, ["Qty_Count"] = 8m },
+                });
+
+            // Should not throw; non-numeric value is treated as 0 (skipped)
+            var result = AnalysisExcelExporter.DetectDualAxis(resp, new List<int> { 1, 2 });
+            // max0 = 2_000_000, max1 = 8 → ratio = 250_000 → true
+            Assert.IsTrue(result);
         }
 
         [TestMethod]
-        public void Export_header_no_unit_for_small_values()
+        public void DetectDualAxis_all_non_numeric_returns_false()
         {
+            // If all values in a column are non-numeric, max stays 0 → returns false
             var resp = MakeResponse(
-                new List<string> { "Region", "Amount_Sum" },
+                new List<string> { "Region", "Amount_Sum", "Qty_Count" },
                 new List<Dictionary<string, object?>>
                 {
-                    new() { ["Region"] = "North", ["Amount_Sum"] = 500m },
+                    new() { ["Region"] = "North", ["Amount_Sum"] = "N/A", ["Qty_Count"] = "N/A" },
                 });
 
-            var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
-            var header = wb.GetSheetAt(0).GetRow(0);
-            Assert.AreEqual("Amount_Sum", header.GetCell(1).StringCellValue);
+            var result = AnalysisExcelExporter.DetectDualAxis(resp, new List<int> { 1, 2 });
+            Assert.IsFalse(result);
         }
 
         // ─── #281: Dual axis charts ─────────────────────────────────────────

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -2171,6 +2171,17 @@ describe('scaleSeriesData', () => {
     test('empty array returns empty', () => {
         expect(waReq.scaleSeriesData([], 10000)).toEqual([]);
     });
+
+    // #285: NaN / Infinity divisor must return data unchanged
+    test('divisor=NaN → returns data unchanged', () => {
+        var data = [100, 200, 300];
+        expect(waReq.scaleSeriesData(data, NaN)).toEqual([100, 200, 300]);
+    });
+
+    test('divisor=Infinity → returns data unchanged', () => {
+        var data = [100, 200, 300];
+        expect(waReq.scaleSeriesData(data, Infinity)).toEqual([100, 200, 300]);
+    });
 });
 
 // ─── #281: detectDualAxis ────────────────────────────────────────────────────
@@ -2224,6 +2235,23 @@ describe('detectDualAxis', () => {
             { Amount_Sum: 500000, Qty_Count: 8 },
         ], m2)).toBe(true);
     });
+
+    // #286: non-numeric strings must be treated as 0, not cause NaN
+    test('non-numeric string in rows → treated as 0, does not throw', () => {
+        // Amount_Sum has one non-numeric row; numeric row gives max0=2000000, max1=8 → ratio >= 10
+        expect(waReq.detectDualAxis([
+            { Amount_Sum: 'N/A', Qty_Count: 5 },
+            { Amount_Sum: 2000000, Qty_Count: 8 },
+        ], m2)).toBe(true);
+    });
+
+    test('mixed numeric and non-numeric rows → uses numeric max', () => {
+        // Only numeric values contribute to max; ratio = 1000000/8 >= 10 → true
+        expect(waReq.detectDualAxis([
+            { Amount_Sum: 'abc', Qty_Count: 8 },
+            { Amount_Sum: 1000000, Qty_Count: 'N/A' },
+        ], m2)).toBe(true);
+    });
 });
 
 // ─── #281: renderChart dual axis ─────────────────────────────────────────────
@@ -2271,6 +2299,9 @@ describe('renderChart — dual Y-axis (#281)', () => {
         expect(capturedOptions[0].yAxis.length).toBe(2);
         expect(capturedOptions[0].yAxis[0].position).toBe('left');
         expect(capturedOptions[0].yAxis[1].position).toBe('right');
+        // #287: name must use full key (field_func) to distinguish same-field different-func measures
+        expect(capturedOptions[0].yAxis[0].name).toMatch(/^Amount_Sum/);
+        expect(capturedOptions[0].yAxis[1].name).toMatch(/^Qty_Count/);
     });
 
     test('dual axis series have yAxisIndex 0 and 1', () => {


### PR DESCRIPTION
## 修復摘要

此 PR 修復 5 個 Analysis 模組雙 Y 軸功能的 P1 回歸問題。

### #284 — C# DetectDualAxis FormatException
- `DetectDualAxis` 改用型別檢查 `v0 is decimal or double or float or int or long`，跳過非數字字串，與 `CreateChartBase` 保持一致，避免 `Convert.ToDouble("N/A")` 拋出 `FormatException`

### #285 — JS scaleSeriesData NaN divisor 靜默錯誤
- `scaleSeriesData` 的防護條件從 `!divisor || divisor === 1` 改為 `divisor == null || !isFinite(divisor) || divisor <= 1`，確保 NaN/Infinity divisor 也會直接回傳原始資料

### #286 — JS detectDualAxis 非數字字串產生 NaN
- `detectDualAxis` 改用明確型別檢查 `typeof raw === 'number' && isFinite(raw)`，非數字字串一律視為 0，不再產生 NaN max 導致比例被低估

### #287 — Y 軸標籤缺少聚合函式名稱
- Y 軸名稱從 `m.field` 改為 `m.field + '_' + m.func`，與 legend/series name 一致，避免同欄位不同函式（如 Amount_Sum vs Amount_Avg）顯示為重複標籤

### #288 — Excel header 有單位但 data 未縮放（語意矛盾）
- 採方案 A：移除 header 單位標記邏輯，header 直接寫原始 column name，消除「header 顯示百萬但 cell 值是 5000000」的語意矛盾

## 測試

- JS：163 tests passed（新增 4 個測試，修改 1 個）
- C#：23 tests passed（新增 2 個測試，修改 1 個）
- Full build：0 errors

Closes #284, Closes #285, Closes #286, Closes #287, Closes #288