### PR TITLE
feat(analysis): add X-Analysis-Truncated response header on export

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -179,6 +179,9 @@ namespace WalkingTec.Mvvm.Mvc
             try { result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecuteDynamic(baseQuery, req, fields); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
 
+            if (result.Truncated)
+                Response.Headers["X-Analysis-Truncated"] = "true";
+
             if (format.Equals("csv", StringComparison.OrdinalIgnoreCase))
             {
                 var csv = BuildCsv(result);

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WalkingTec.Mvvm.Core;
@@ -539,6 +540,54 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         {
             var result = CreateController().Export(null) as BadRequestObjectResult;
             Assert.IsNotNull(result, "null request 應回傳 400");
+        }
+
+        // ─── Export truncated header (#291) ───────────────────────────────────
+
+        [TestMethod]
+        public void Export_xlsx_sets_truncated_header_when_over_10000_rows()
+        {
+            // Inject 10,001 rows with unique Region values so GROUP BY produces
+            // 10,001 distinct groups — exceeding MaxRows (10,000)
+            _testData = Enumerable.Range(1, 10_001)
+                .Select(i => new SaleRecord { Region = "R" + i, Amount = i })
+                .ToList();
+
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            var httpCtx = new DefaultHttpContext();
+            var controller = new _AnalysisController(_registry, null, null);
+            controller.Wtm = MockWtmContext.CreateWtmContext();
+            controller.ControllerContext = new ControllerContext { HttpContext = httpCtx };
+
+            var result = controller.Export(req, "xlsx") as FileContentResult;
+            Assert.IsNotNull(result, "應回傳 xlsx 檔案");
+            Assert.AreEqual("true", httpCtx.Response.Headers["X-Analysis-Truncated"].ToString(),
+                "截斷時應設置 X-Analysis-Truncated: true header");
+        }
+
+        [TestMethod]
+        public void Export_xlsx_no_truncated_header_when_under_limit()
+        {
+            _testData = Enumerable.Range(1, 5)
+                .Select(i => new SaleRecord { Region = "R" + i, Amount = i * 100 })
+                .ToList();
+
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            var httpCtx = new DefaultHttpContext();
+            var controller = new _AnalysisController(_registry, null, null);
+            controller.Wtm = MockWtmContext.CreateWtmContext();
+            controller.ControllerContext = new ControllerContext { HttpContext = httpCtx };
+
+            var result = controller.Export(req, "xlsx") as FileContentResult;
+            Assert.IsNotNull(result);
+            Assert.IsFalse(httpCtx.Response.Headers.ContainsKey("X-Analysis-Truncated"),
+                "未截斷時不應設置 X-Analysis-Truncated header");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Export 端點（xlsx + csv）超過 10,000 筆截斷時，response 加上 `X-Analysis-Truncated: true` header
- Client 端（前端、下載工具）可偵測截斷並顯示提示
- 行為符合 `docs/analysis-mode.md` Phase 1 Known Limitations 說明

## Changes

- `src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs` — Export endpoint 加 2 行（`if (result.Truncated) Response.Headers["X-Analysis-Truncated"] = "true"`）
- `test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs` — 新增 2 個 MSTest（31 total, all pass）

## Test plan

- [ ] `dotnet test --filter FullyQualifiedName~AnalysisControllerTests` — 31/31 pass
- [ ] Demo 環境：匯出超過 10k 筆時，response header 包含 `X-Analysis-Truncated: true`

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)