### PR TITLE
fix(analysis): return 400 when zero measures submitted (#296)

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -78,6 +78,7 @@ namespace WalkingTec.Mvvm.Mvc
         {
             if (req is null) return BadRequest("Invalid request body.");
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
+            if (req.Measures.Count == 0)  return BadRequest("至少需要選取 1 個度量指標。");
             if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");
 
             Type vmType;
@@ -111,6 +112,7 @@ namespace WalkingTec.Mvvm.Mvc
         public IActionResult Pivot([FromBody] AnalysisPivotRequest req)
         {
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
+            if (req.Measures.Count == 0)  return BadRequest("至少需要選取 1 個度量指標。");
             if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");
             if (string.IsNullOrEmpty(req.PivotDimension)) return BadRequest("必須指定 PivotDimension。");
 
@@ -154,6 +156,7 @@ namespace WalkingTec.Mvvm.Mvc
             if (req is null) return BadRequest("Invalid request body.");
             // 與 Query 端點一致的維度/度量上限驗證（I-5）
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
+            if (req.Measures.Count == 0)  return BadRequest("至少需要選取 1 個度量指標。");
             if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");
 
             Type vmType;
@@ -205,6 +208,7 @@ namespace WalkingTec.Mvvm.Mvc
                                          [FromQuery] string? chartType = null)
         {
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
+            if (req.Measures.Count == 0)  return BadRequest("至少需要選取 1 個度量指標。");
             if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");
             if (string.IsNullOrEmpty(req.PivotDimension)) return BadRequest("必須指定 PivotDimension。");
 

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -589,5 +589,44 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.IsFalse(httpCtx.Response.Headers.ContainsKey("X-Analysis-Truncated"),
                 "未截斷時不應設置 X-Analysis-Truncated header");
         }
+
+        // ─── 零個 measures 驗證（#296） ─────────────────────────────────────
+
+        [TestMethod]
+        public void Query_with_zero_measures_returns_400()
+        {
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華東", Amount = 100m }
+            };
+
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(SaleRecordListVM).FullName,
+                Dimensions = new List<string> { "Region" },
+                Measures   = new List<MeasureRequest>()   // 空陣列
+            };
+
+            var result = CreateController().Query(req) as BadRequestObjectResult;
+            Assert.IsNotNull(result, "空 measures 陣列應回傳 400");
+            Assert.IsTrue(result.Value?.ToString()?.Contains("度量指標") == true,
+                "錯誤訊息應包含「度量指標」");
+        }
+
+        [TestMethod]
+        public void Export_with_zero_measures_returns_400()
+        {
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(SaleRecordListVM).FullName,
+                Dimensions = new List<string> { "Region" },
+                Measures   = new List<MeasureRequest>()
+            };
+
+            var result = CreateController().Export(req) as BadRequestObjectResult;
+            Assert.IsNotNull(result, "Export 空 measures 陣列應回傳 400");
+            Assert.IsTrue(result.Value?.ToString()?.Contains("度量指標") == true,
+                "錯誤訊息應包含「度量指標」");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- All 4 analysis endpoints now validate that at least 1 measure is selected
- Returns `400 BadRequest("至少需要選取 1 個度量指標。")` when `Measures.Count == 0`
- Endpoints affected: Query, Pivot, Export, PivotExport

## Tests

- `Query_with_zero_measures_returns_400`
- `Export_with_zero_measures_returns_400`

Closes #296

> Replaces #299 which had merge conflicts with dotnet8.