### PR TITLE
feat(analysis): ad-hoc filter UI for BA users

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -535,6 +535,41 @@
         btnRow.appendChild(pivotWrapper);
         selectorBody.appendChild(btnRow);
 
+        // ── FilterBar（Ad-hoc 篩選條件）──
+        var filterSection = document.createElement('div');
+        filterSection.className = 'analysis-filter-section';
+        filterSection.style.cssText = 'margin-top:8px;padding:8px 0 0 0;border-top:1px solid #e8e8e8;';
+
+        var filterBtnRow = document.createElement('div');
+        filterBtnRow.style.cssText = 'display:flex;align-items:center;gap:6px;margin-bottom:6px;';
+
+        var addFilterBtn = document.createElement('button');
+        addFilterBtn.type = 'button';
+        addFilterBtn.className = 'layui-btn layui-btn-xs layui-btn-warm analysis-add-filter-btn';
+        addFilterBtn.dataset.gridId = gridId;
+        addFilterBtn.textContent = '+ 新增篩選條件';
+        addFilterBtn.addEventListener('click', function () { addFilterRow(gridId); });
+        filterBtnRow.appendChild(addFilterBtn);
+
+        var clearFilterBtn = document.createElement('button');
+        clearFilterBtn.type = 'button';
+        clearFilterBtn.className = 'layui-btn layui-btn-xs layui-btn-primary analysis-clear-filter-btn';
+        clearFilterBtn.dataset.gridId = gridId;
+        clearFilterBtn.textContent = '清除篩選';
+        clearFilterBtn.addEventListener('click', function () {
+            var list = filterSection.querySelector('.analysis-filter-list');
+            if (list) clearChildren(list);
+        });
+        filterBtnRow.appendChild(clearFilterBtn);
+
+        filterSection.appendChild(filterBtnRow);
+
+        var filterList = document.createElement('div');
+        filterList.className = 'analysis-filter-list';
+        filterSection.appendChild(filterList);
+
+        selectorBody.appendChild(filterSection);
+
         selectorSection.appendChild(selectorBody);
 
         // Summary bar (visible when collapsed)
@@ -748,6 +783,127 @@
         return { dims: dims, msrs: msrs, dimensionHierarchies: dimensionHierarchies };
     }
 
+
+    // ─── Ad-hoc 篩選條件 ─────────────────────────────────────────────────────
+
+    var _FILTER_OPS = [
+        { value: 'Eq',       label: '等於' },
+        { value: 'Gt',       label: '大於' },
+        { value: 'Gte',      label: '大於等於' },
+        { value: 'Lt',       label: '小於' },
+        { value: 'Lte',      label: '小於等於' },
+        { value: 'Contains', label: '包含' }
+    ];
+
+    /**
+     * 從 filterBar 讀取所有有效篩選列，組裝成 [{field, op, value}]。
+     * 欄位或值任一為空的列被跳過。
+     */
+    function collectFilters(gridId) {
+        var panel = document.getElementById('analysis-panel-' + gridId);
+        if (!panel) return [];
+        var rows = panel.querySelectorAll('.analysis-filter-row');
+        var filters = [];
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var fieldSel = row.querySelector('.analysis-filter-field');
+            var opSel    = row.querySelector('.analysis-filter-op');
+            var valInput = row.querySelector('.analysis-filter-value');
+            var field = fieldSel ? fieldSel.value : '';
+            var op    = opSel    ? opSel.value    : '';
+            var value = valInput ? valInput.value  : '';
+            if (!field || !value) continue;
+            filters.push({ field: field, op: op || 'Eq', value: value });
+        }
+        return filters;
+    }
+
+    /**
+     * 在 filterBar 新增一行篩選列。
+     */
+    function addFilterRow(gridId, fields) {
+        var panel = document.getElementById('analysis-panel-' + gridId);
+        if (!panel) return;
+        var filterList = panel.querySelector('.analysis-filter-list');
+        if (!filterList) return;
+
+        var st = _state[gridId];
+        var metaFields = fields || (st && st.fields) || [];
+
+        var row = document.createElement('div');
+        row.className = 'analysis-filter-row layui-inline';
+        row.style.cssText = 'display:flex;align-items:center;gap:6px;margin-bottom:6px;';
+
+        var fieldSel = document.createElement('select');
+        fieldSel.className = 'analysis-filter-field';
+        fieldSel.style.cssText = 'min-width:120px;';
+        var emptyOpt = document.createElement('option');
+        emptyOpt.value = '';
+        emptyOpt.textContent = '選擇欄位\u2026';
+        fieldSel.appendChild(emptyOpt);
+        metaFields.forEach(function (f) {
+            var opt = document.createElement('option');
+            opt.value = f.fieldName;
+            opt.textContent = f.displayName;
+            fieldSel.appendChild(opt);
+        });
+        row.appendChild(fieldSel);
+
+        var opSel = document.createElement('select');
+        opSel.className = 'analysis-filter-op';
+        opSel.style.cssText = 'min-width:100px;';
+        _FILTER_OPS.forEach(function (o) {
+            var opt = document.createElement('option');
+            opt.value = o.value;
+            opt.textContent = o.label;
+            opSel.appendChild(opt);
+        });
+        row.appendChild(opSel);
+
+        var valInput = document.createElement('input');
+        valInput.type = 'text';
+        valInput.className = 'analysis-filter-value layui-input';
+        valInput.style.cssText = 'width:140px;display:inline-block;';
+        valInput.placeholder = '篩選值\u2026';
+        row.appendChild(valInput);
+
+        var removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'layui-btn layui-btn-xs layui-btn-danger';
+        removeBtn.textContent = '\u2715';
+        removeBtn.addEventListener('click', function () {
+            if (filterList.contains(row)) filterList.removeChild(row);
+        });
+        row.appendChild(removeBtn);
+
+        filterList.appendChild(row);
+    }
+
+    /**
+     * 在 meta 載入後更新已存在篩選列的欄位選單。
+     */
+    function updateFilterFieldOptions(gridId, fields) {
+        var panel = document.getElementById('analysis-panel-' + gridId);
+        if (!panel) return;
+        var selects = panel.querySelectorAll('.analysis-filter-field');
+        for (var i = 0; i < selects.length; i++) {
+            var fieldSel = selects[i];
+            var currentVal = fieldSel.value;
+            while (fieldSel.firstChild) fieldSel.removeChild(fieldSel.firstChild);
+            var emptyOpt = document.createElement('option');
+            emptyOpt.value = '';
+            emptyOpt.textContent = '選擇欄位\u2026';
+            fieldSel.appendChild(emptyOpt);
+            fields.forEach(function (f) {
+                var opt = document.createElement('option');
+                opt.value = f.fieldName;
+                opt.textContent = f.displayName;
+                if (f.fieldName === currentVal) opt.selected = true;
+                fieldSel.appendChild(opt);
+            });
+        }
+    }
+
     // ─── 查詢 ────────────────────────────────────────────────────────────────
 
     function query(gridId) {
@@ -786,7 +942,7 @@
             listVmType: st.listVmType,
             dimensions: dims,
             measures: msrs,
-            filters: [],
+            filters: collectFilters(gridId),
             dimensionHierarchies: Object.keys(sel.dimensionHierarchies).length > 0
                 ? sel.dimensionHierarchies : undefined,
             searcherFormData: searcherJson
@@ -1290,7 +1446,7 @@
         var searcherJson = collectSearcherFormData(gridId);
         var req = {
             listVmType: st.listVmType, dimensions: dims, measures: msrs,
-            filters: [], dimensionHierarchies: exportHierarchies, searcherFormData: searcherJson
+            filters: collectFilters(gridId), dimensionHierarchies: exportHierarchies, searcherFormData: searcherJson
         };
         if (isPivot) req.pivotDimension = pivotDim;
         var chartCb = document.querySelector('.analysis-export-chart-cb[data-grid-id="' + gridId + '"]');
@@ -1354,6 +1510,9 @@
         computeScale: computeScale,
         scaleSeriesData: scaleSeriesData,
         detectDualAxis: detectDualAxis,
+        addFilterRow: addFilterRow,
+        collectFilters: collectFilters,
+        updateFilterFieldOptions: updateFilterFieldOptions,
         _getState: function (gridId) { return _state[gridId]; }
     };
 

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -2671,3 +2671,162 @@ describe('#294 日期層級 hierarchy select → disabled + tooltip', () => {
         expect(th.textContent).toBe('X_Sum');
     });
 });
+
+// ─── #298: Ad-hoc 篩選條件 UI ────────────────────────────────────────────────
+describe('#298 Ad-hoc filter UI', () => {
+    const sampleFields = [
+        { kind: 'Dimension', fieldName: 'Region',      displayName: '地區',   isDate: false, allowedFuncs: 0 },
+        { kind: 'Measure',   fieldName: 'TotalAmount',  displayName: '總金額', isDate: false, allowedFuncs: 2 },
+    ];
+
+    function makePanelWithFilterBar(gridId) {
+        const panel = document.createElement('div');
+        panel.id = 'analysis-panel-' + gridId;
+        return panel;
+    }
+
+    async function renderPanelViaToggle(gridId, panel, fields) {
+        const fetchOrig = global.fetch;
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue(fields),
+        });
+        const idSpy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-panel-' + gridId ? panel : null
+        );
+        waReq.toggle(gridId, 'TestVm298');
+        await new Promise(r => setTimeout(r, 50));
+        idSpy.mockRestore();
+        global.fetch = fetchOrig;
+    }
+
+    test('addFilterRow() — 點擊新增後篩選列數量增加 1', async () => {
+        const gridId = 'filter298a';
+        const panel = makePanelWithFilterBar(gridId);
+        await renderPanelViaToggle(gridId, panel, sampleFields);
+
+        const idSpy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-panel-' + gridId ? panel : null
+        );
+
+        const before = panel.querySelectorAll('.analysis-filter-row').length;
+        waReq.addFilterRow(gridId);
+        const after = panel.querySelectorAll('.analysis-filter-row').length;
+
+        expect(after).toBe(before + 1);
+        idSpy.mockRestore();
+    });
+
+    test('removeFilterRow() — 點擊 ✕ 後對應篩選列被移除', async () => {
+        const gridId = 'filter298b';
+        const panel = makePanelWithFilterBar(gridId);
+        await renderPanelViaToggle(gridId, panel, sampleFields);
+
+        const idSpy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-panel-' + gridId ? panel : null
+        );
+
+        waReq.addFilterRow(gridId);
+        waReq.addFilterRow(gridId);
+        expect(panel.querySelectorAll('.analysis-filter-row').length).toBe(2);
+
+        const firstRow = panel.querySelector('.analysis-filter-row');
+        const removeBtn = firstRow.querySelector('.layui-btn-danger');
+        removeBtn.click();
+
+        expect(panel.querySelectorAll('.analysis-filter-row').length).toBe(1);
+        idSpy.mockRestore();
+    });
+
+    test('buildReqFilters_emptyRows — 空行不加入 filters', async () => {
+        const gridId = 'filter298c';
+        const panel = makePanelWithFilterBar(gridId);
+        await renderPanelViaToggle(gridId, panel, sampleFields);
+
+        const idSpy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-panel-' + gridId ? panel : null
+        );
+
+        waReq.addFilterRow(gridId);
+        const filters = waReq.collectFilters(gridId);
+        expect(filters).toEqual([]);
+        idSpy.mockRestore();
+    });
+
+    test('buildReqFilters_validRow — 完整行正確序列化 {field, op, value}', async () => {
+        const gridId = 'filter298d';
+        const panel = makePanelWithFilterBar(gridId);
+        await renderPanelViaToggle(gridId, panel, sampleFields);
+
+        const idSpy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-panel-' + gridId ? panel : null
+        );
+
+        waReq.addFilterRow(gridId);
+        const row = panel.querySelector('.analysis-filter-row');
+        row.querySelector('.analysis-filter-field').value = 'TotalAmount';
+        row.querySelector('.analysis-filter-op').value = 'Gt';
+        row.querySelector('.analysis-filter-value').value = '10000';
+
+        const filters = waReq.collectFilters(gridId);
+        expect(filters).toEqual([{ field: 'TotalAmount', op: 'Gt', value: '10000' }]);
+        idSpy.mockRestore();
+    });
+
+    test('buildReqFilters_partialRow — 欄位為空的行被跳過', async () => {
+        const gridId = 'filter298e';
+        const panel = makePanelWithFilterBar(gridId);
+        await renderPanelViaToggle(gridId, panel, sampleFields);
+
+        const idSpy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-panel-' + gridId ? panel : null
+        );
+
+        waReq.addFilterRow(gridId);
+        const row = panel.querySelector('.analysis-filter-row');
+        row.querySelector('.analysis-filter-field').value = '';
+        row.querySelector('.analysis-filter-value').value = 'North';
+
+        const filters = waReq.collectFilters(gridId);
+        expect(filters).toEqual([]);
+        idSpy.mockRestore();
+    });
+
+    test('resetClearsFilters — 清除篩選按鈕後篩選列清空', async () => {
+        const gridId = 'filter298f';
+        const panel = makePanelWithFilterBar(gridId);
+        await renderPanelViaToggle(gridId, panel, sampleFields);
+
+        const idSpy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-panel-' + gridId ? panel : null
+        );
+
+        waReq.addFilterRow(gridId);
+        waReq.addFilterRow(gridId);
+        expect(panel.querySelectorAll('.analysis-filter-row').length).toBe(2);
+
+        const clearBtn = panel.querySelector('.analysis-clear-filter-btn');
+        clearBtn.click();
+
+        expect(panel.querySelectorAll('.analysis-filter-row').length).toBe(0);
+        idSpy.mockRestore();
+    });
+
+    test('operatorOptions — operator 選單有 6 個選項', async () => {
+        const gridId = 'filter298g';
+        const panel = makePanelWithFilterBar(gridId);
+        await renderPanelViaToggle(gridId, panel, sampleFields);
+
+        const idSpy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-panel-' + gridId ? panel : null
+        );
+
+        waReq.addFilterRow(gridId);
+        const opSel = panel.querySelector('.analysis-filter-op');
+        expect(opSel.options.length).toBe(6);
+
+        const opValues = Array.from(opSel.options).map(o => o.value);
+        expect(opValues).toEqual(['Eq', 'Gt', 'Gte', 'Lt', 'Lte', 'Contains']);
+        idSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary

- 在分析面板的查詢按鈕區下方新增 **FilterBar** UI，讓 BA 使用者可動態加入篩選條件
- `_buildReq()` 中的 `filters` 欄位從固定 `[]` 改為讀取 FilterBar 的實際條件
- 匯出（Excel / CSV）也同步套用篩選條件

## 實作細節

### UI 結構（`framework_analysis.js`）
- `+ 新增篩選條件` 按鈕：呼叫 `addFilterRow(gridId)`，每次新增一列
- `清除篩選` 按鈕：清空所有篩選列
- 每列包含：欄位選單（動態從 `_lastMeta.fields` 填入）、operator 選單（固定 6 項）、文字輸入框、✕ 移除按鈕

### 新增函式
| 函式 | 說明 |
|------|------|
| `collectFilters(gridId)` | 讀取所有篩選列，空行自動跳過 |
| `addFilterRow(gridId, fields?)` | 新增一行篩選列，欄位選單來自 state.fields |
| `updateFilterFieldOptions(gridId, fields)` | meta 載入後更新既有篩選列的欄位選單 |

### 查詢序列化
```json
{"field": "TotalAmount", "op": "Gt", "value": "10000"}
```
支援：`Eq` / `Gt` / `Gte` / `Lt` / `Lte` / `Contains`

## Test plan

- [x] `addFilterRow()` — 點擊新增後篩選列數量增加 1
- [x] `removeFilterRow()` — 點擊 ✕ 後對應篩選列被移除
- [x] `buildReqFilters_emptyRows` — 空行不加入 filters
- [x] `buildReqFilters_validRow` — 完整行正確序列化 `{field, op, value}`
- [x] `buildReqFilters_partialRow` — 欄位為空的行被跳過
- [x] `resetClearsFilters` — 清除篩選按鈕後篩選列清空
- [x] `operatorOptions` — operator 選單有 6 個選項
- [x] 全部 186 Jest tests 通過（含既有 179 個）

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)