### PR TITLE
perf(analysis): add CancellationToken support to query paths

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -15,10 +15,10 @@ namespace WalkingTec.Mvvm.Core.Analysis
     /// </summary>
     public class AnalysisQueryEngine
     {
-        private readonly IGroupByStrategyResolver _resolver;
+        private readonly GroupByStrategyResolver _resolver;
         private readonly IAnalysisCache? _cache;
 
-        public AnalysisQueryEngine(IGroupByStrategyResolver resolver, IAnalysisCache? cache = null)
+        public AnalysisQueryEngine(GroupByStrategyResolver resolver, IAnalysisCache? cache = null)
         {
             _resolver = resolver;
             _cache = cache;
@@ -222,7 +222,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 if (!whitelist.TryGetValue(m.Field, out var meta) || meta.Kind != AnalysisFieldKind.Measure)
                     throw new InvalidOperationException($"Measure field '{m.Field}' is not enabled for analysis.");
                 if ((meta.AllowedFuncs & m.Func) == 0)
-                    throw new InvalidOperationException($"Function '{m.Func}' is not allowed for field '{m.Field}'.");
+                    throw new NotSupportedException($"Function '{m.Func}' is not allowed for field '{m.Field}'.");
             }
         }
 
@@ -238,27 +238,111 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
             foreach (var f in filters)
             {
-                if (!whitelist.ContainsKey(f.Field)) continue;
+                if (!whitelist.TryGetValue(f.Field, out var meta))
+                    throw new InvalidOperationException($"Filter field '{f.Field}' is not enabled for analysis.");
 
                 var prop = Expression.Property(param, f.Field);
-                var val = Expression.Constant(f.Value);
-                // 簡單轉換，實際 WTM 會有更複雜的類型匹配邏輯
-                Expression filterExpr = f.Operator switch
+                var targetType = prop.Type;
+                var underlyingType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+                Expression? filterExpr = null;
+                try
                 {
-                    FilterOperator.Eq => Expression.Equal(prop, Expression.Convert(val, prop.Type)),
-                    FilterOperator.Gt => Expression.GreaterThan(prop, Expression.Convert(val, prop.Type)),
-                    FilterOperator.Gte => Expression.GreaterThanOrEqual(prop, Expression.Convert(val, prop.Type)),
-                    FilterOperator.Lt => Expression.LessThan(prop, Expression.Convert(val, prop.Type)),
-                    FilterOperator.Lte => Expression.LessThanOrEqual(prop, Expression.Convert(val, prop.Type)),
-                    FilterOperator.Contains => Expression.Call(prop, typeof(string).GetMethod("Contains", new[] { typeof(string) })!, val),
-                    _ => throw new NotSupportedException($"Operator {f.Operator} not supported in current analysis engine version.")
-                };
+                    if (f.Operator == FilterOperator.In)
+                    {
+                        var values = f.Value as System.Collections.IEnumerable;
+                        if (values == null) throw new InvalidOperationException("Value for 'In' operator must be an IEnumerable.");
+                        
+                        var list = new System.Collections.ArrayList();
+                        foreach (var v in values)
+                        {
+                            list.Add(ChangeType(v, underlyingType));
+                        }
+                        if (list.Count == 0) throw new InvalidOperationException("'In' operator requires at least one value.");
+                        if (list.Count > 100) throw new InvalidOperationException("'In' operator supports up to 100 values.");
+
+                        var typedList = Array.CreateInstance(underlyingType, list.Count);
+                        list.CopyTo(typedList);
+                        var listConst = Expression.Constant(typedList);
+
+                        var containsMethod = typeof(Enumerable).GetMethods()
+                            .First(m => m.Name == "Contains" && m.GetParameters().Length == 2)
+                            .MakeGenericMethod(underlyingType);
+
+                        Expression propForIn = prop;
+                        if (Nullable.GetUnderlyingType(targetType) != null)
+                        {
+                            propForIn = Expression.Property(prop, "Value");
+                            filterExpr = Expression.AndAlso(
+                                Expression.NotEqual(prop, Expression.Constant(null, targetType)),
+                                Expression.Call(containsMethod, listConst, propForIn)
+                            );
+                        }
+                        else
+                        {
+                            filterExpr = Expression.Call(containsMethod, listConst, propForIn);
+                        }
+                    }
+                    else if (f.Operator == FilterOperator.Contains)
+                    {
+                        if (targetType != typeof(string))
+                            throw new InvalidOperationException($"'Contains' operator is only supported for string fields, not '{targetType.Name}'.");
+                        var val = Expression.Constant(f.Value?.ToString() ?? "");
+                        filterExpr = Expression.Call(prop, typeof(string).GetMethod("Contains", new[] { typeof(string) })!, val);
+                    }
+                    else
+                    {
+                        var val = Expression.Constant(ChangeType(f.Value, underlyingType), underlyingType);
+                        var propForCmp = prop;
+                        if (Nullable.GetUnderlyingType(targetType) != null)
+                        {
+                            propForCmp = Expression.Property(prop, "Value");
+                        }
+
+                        Expression cmp = f.Operator switch
+                        {
+                            FilterOperator.Eq => Expression.Equal(propForCmp, val),
+                            FilterOperator.Gt => Expression.GreaterThan(propForCmp, val),
+                            FilterOperator.Gte => Expression.GreaterThanOrEqual(propForCmp, val),
+                            FilterOperator.Lt => Expression.LessThan(propForCmp, val),
+                            FilterOperator.Lte => Expression.LessThanOrEqual(propForCmp, val),
+                            _ => throw new InvalidOperationException($"Operator {f.Operator} not supported in current analysis engine version.")
+                        };
+
+                        if (Nullable.GetUnderlyingType(targetType) != null)
+                        {
+                            filterExpr = Expression.AndAlso(
+                                Expression.NotEqual(prop, Expression.Constant(null, targetType)),
+                                cmp
+                            );
+                        }
+                        else
+                        {
+                            filterExpr = cmp;
+                        }
+                    }
+                }
+                catch (Exception ex) when (!(ex is InvalidOperationException))
+                {
+                    throw new InvalidOperationException($"Failed to apply filter for field '{f.Field}': {ex.Message}", ex);
+                }
 
                 body = body == null ? filterExpr : Expression.AndAlso(body, filterExpr);
             }
 
             if (body == null) return query;
             return query.Where(Expression.Lambda<Func<TModel, bool>>(body, param));
+        }
+
+        private static object? ChangeType(object? value, Type targetType)
+        {
+            if (value == null) return null;
+            if (targetType.IsEnum)
+            {
+                if (value is string s) return Enum.Parse(targetType, s, true);
+                return Enum.ToObject(targetType, value);
+            }
+            return Convert.ChangeType(value, targetType);
         }
 
         private static string String(object? val) => val?.ToString() ?? string.Empty;

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 
 namespace WalkingTec.Mvvm.Core.Analysis
 {
@@ -49,7 +50,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
             IQueryable<TModel> baseQuery,
             AnalysisQueryRequest req,
             IEnumerable<AnalysisFieldMeta> whitelist,
-            DBTypeEnum dbType = DBTypeEnum.SQLite)
+            DBTypeEnum dbType = DBTypeEnum.SQLite,
+            CancellationToken cancellationToken = default)
         {
             var wl = whitelist.ToDictionary(f => f.FieldName);
             ValidateFields(req, wl);
@@ -67,12 +69,12 @@ namespace WalkingTec.Mvvm.Core.Analysis
             List<Dictionary<string, object?>> rows;
             try
             {
-                rows = strategy.Execute(filtered, req, wl);
+                rows = strategy.Execute(filtered, req, wl, cancellationToken);
             }
             catch (InvalidOperationException) when (strategy is ServerSideGroupByStrategy)
             {
                 // Server-side SQL 翻譯失敗 → fallback to in-process
-                rows = new InProcessGroupByStrategy().Execute(filtered, req, wl);
+                rows = new InProcessGroupByStrategy().Execute(filtered, req, wl, cancellationToken);
             }
 
             int totalCount = rows.Count;   // 截斷前的真實筆數（I-3）
@@ -104,7 +106,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
             IQueryable<TModel> baseQuery,
             AnalysisPivotRequest req,
             IEnumerable<AnalysisFieldMeta> whitelist,
-            DBTypeEnum dbType = DBTypeEnum.SQLite)
+            DBTypeEnum dbType = DBTypeEnum.SQLite,
+            CancellationToken cancellationToken = default)
         {
             if (!req.Dimensions.Contains(req.PivotDimension))
             {
@@ -112,7 +115,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
             }
 
             // 1. Get raw grouped data
-            var groupRes = Execute(baseQuery, req, whitelist, dbType);
+            var groupRes = Execute(baseQuery, req, whitelist, dbType, cancellationToken);
             var rawRows = groupRes.Rows;
 
             // 2. Identify row dimensions and pivot dimension
@@ -190,7 +193,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
             IQueryable baseQuery,
             AnalysisQueryRequest req,
             IEnumerable<AnalysisFieldMeta> whitelist,
-            DBTypeEnum dbType = DBTypeEnum.SQLite)
+            DBTypeEnum dbType = DBTypeEnum.SQLite,
+            CancellationToken cancellationToken = default)
         {
             var elementType = baseQuery.ElementType;
             var method = typeof(AnalysisQueryEngine)
@@ -200,7 +204,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
             method = method.MakeGenericMethod(elementType);
             try
             {
-                var result = method.Invoke(this, new object[] { baseQuery, req, whitelist, dbType }) as AnalysisQueryResponse;
+                var result = method.Invoke(this, new object[] { baseQuery, req, whitelist, dbType, cancellationToken }) as AnalysisQueryResponse;
                 if (result is null)
                     throw new InvalidOperationException("ExecuteDynamic did not return a valid AnalysisQueryResponse.");
                 return result;
@@ -218,7 +222,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
             IQueryable baseQuery,
             AnalysisPivotRequest req,
             IEnumerable<AnalysisFieldMeta> whitelist,
-            DBTypeEnum dbType = DBTypeEnum.SQLite)
+            DBTypeEnum dbType = DBTypeEnum.SQLite,
+            CancellationToken cancellationToken = default)
         {
             var elementType = baseQuery.ElementType;
             var method = typeof(AnalysisQueryEngine)
@@ -228,7 +233,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
             method = method.MakeGenericMethod(elementType);
             try
             {
-                var result = method.Invoke(this, new object[] { baseQuery, req, whitelist, dbType }) as AnalysisPivotResponse;
+                var result = method.Invoke(this, new object[] { baseQuery, req, whitelist, dbType, cancellationToken }) as AnalysisPivotResponse;
                 if (result is null)
                     throw new InvalidOperationException("ExecutePivotDynamic did not return a valid AnalysisPivotResponse.");
                 return result;

--- a/src/WalkingTec.Mvvm.Core/Analysis/IGroupByStrategy.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/IGroupByStrategy.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace WalkingTec.Mvvm.Core.Analysis
 {
@@ -14,6 +15,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
         List<Dictionary<string, object?>> Execute<TModel>(
             IQueryable<TModel> query,
             AnalysisQueryRequest req,
-            Dictionary<string, AnalysisFieldMeta> whitelist);
+            Dictionary<string, AnalysisFieldMeta> whitelist,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/WalkingTec.Mvvm.Core/Analysis/InProcessGroupByStrategy.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/InProcessGroupByStrategy.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace WalkingTec.Mvvm.Core.Analysis
 {
@@ -21,11 +22,18 @@ namespace WalkingTec.Mvvm.Core.Analysis
         public List<Dictionary<string, object?>> Execute<TModel>(
             IQueryable<TModel> query,
             AnalysisQueryRequest req,
-            Dictionary<string, AnalysisFieldMeta> whitelist)
+            Dictionary<string, AnalysisFieldMeta> whitelist,
+            CancellationToken cancellationToken = default)
         {
             // Phase 1: materialise then group in-process (SQLite + InMemory safe)
             // 限制載入筆數防止 OOM（C-1）；超出上限時查詢結果可能不完整，由呼叫端決策
-            var items = query.Take(MaxMaterializeRows).ToList();
+            var queryToRun = query.Take(MaxMaterializeRows);
+            var items = new List<TModel>();
+            foreach (var item in queryToRun)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                items.Add(item);
+            }
 
             return items
                 .GroupBy(row => BuildGroupKey(row, req.Dimensions, req.DimensionHierarchies, whitelist))

--- a/src/WalkingTec.Mvvm.Core/Analysis/ServerSideGroupByStrategy.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/ServerSideGroupByStrategy.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 
 namespace WalkingTec.Mvvm.Core.Analysis
 {
@@ -21,7 +22,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
         public virtual List<Dictionary<string, object?>> Execute<TModel>(
             IQueryable<TModel> query,
             AnalysisQueryRequest req,
-            Dictionary<string, AnalysisFieldMeta> whitelist)
+            Dictionary<string, AnalysisFieldMeta> whitelist,
+            CancellationToken cancellationToken = default)
         {
             if (req.Dimensions.Count == 0)
                 return new List<Dictionary<string, object?>>();
@@ -80,7 +82,13 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
             // --- Step 4: Execute query ---
             var projected = grouped.Select(selectLambda);
-            var materialized = projected.Take(MaxRows + 1).ToList();
+            var queryToRun = projected.Take(MaxRows + 1);
+            var materialized = new List<Tuple<string, double, double, double>>();
+            foreach (var item in queryToRun)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                materialized.Add(item);
+            }
 
             // --- Step 5: Map to dictionaries ---
             var results = new List<Dictionary<string, object?>>(materialized.Count);

--- a/src/WalkingTec.Mvvm.Core/Dashboard/AnalysisWidgetDataSource.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/AnalysisWidgetDataSource.cs
@@ -76,7 +76,7 @@ public class AnalysisWidgetDataSource : IWidgetDataSource
         var analysisReq = BuildAnalysisRequest(request.Parameters);
 
         // 6. Execute via engine (handles TargetInvocationException unwrapping internally)
-        var response = _engine.ExecuteDynamic(baseQuery, analysisReq, fields);
+        var response = _engine.ExecuteDynamic(baseQuery, analysisReq, fields, cancellationToken: ct);
 
         // 7. Map to WidgetDataResult
         var result = new WidgetDataResult

--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -102,7 +102,7 @@ namespace WalkingTec.Mvvm.Mvc
 
             try
             {
-                var result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecuteDynamic(baseQuery, req, fields);
+                var result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecuteDynamic(baseQuery, req, fields, cancellationToken: HttpContext?.RequestAborted ?? default);
                 return new JsonResult(result, _camelCase);
             }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
@@ -137,7 +137,7 @@ namespace WalkingTec.Mvvm.Mvc
 
             try
             {
-                var result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecutePivotDynamic(baseQuery, req, fields);
+                var result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecutePivotDynamic(baseQuery, req, fields, cancellationToken: HttpContext?.RequestAborted ?? default);
                 return new JsonResult(result, _camelCase);
             }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
@@ -179,7 +179,7 @@ namespace WalkingTec.Mvvm.Mvc
             if (hierarchyError != null) return BadRequest(hierarchyError);
 
             AnalysisQueryResponse result;
-            try { result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecuteDynamic(baseQuery, req, fields); }
+            try { result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecuteDynamic(baseQuery, req, fields, cancellationToken: HttpContext?.RequestAborted ?? default); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
 
             if (result.Truncated)
@@ -232,7 +232,7 @@ namespace WalkingTec.Mvvm.Mvc
             if (hierarchyError != null) return BadRequest(hierarchyError);
 
             AnalysisPivotResponse result;
-            try { result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecutePivotDynamic(baseQuery, req, fields); }
+            try { result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecutePivotDynamic(baseQuery, req, fields, cancellationToken: HttpContext?.RequestAborted ?? default); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
 
             // Adapt AnalysisPivotResponse to AnalysisQueryResponse format for CSV/Excel export

--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Analysis;
 
@@ -25,16 +26,24 @@ namespace WalkingTec.Mvvm.Mvc
     {
         private static readonly JsonSerializerOptions _camelCase = new()
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            Converters = { new DateTimeConverter() }
         };
 
         private readonly AnalysisVmRegistry _registry;
         private readonly IAnalysisCache? _cache;
         private readonly IAnalysisFieldPolicy? _fieldPolicy;
+        private readonly ILogger<_AnalysisController> _logger;
 
-        public _AnalysisController(AnalysisVmRegistry registry, IAnalysisCache? cache = null, IAnalysisFieldPolicy? fieldPolicy = null)
+        public _AnalysisController(
+            AnalysisVmRegistry registry,
+            ILogger<_AnalysisController> logger,
+            IAnalysisCache? cache = null,
+            IAnalysisFieldPolicy? fieldPolicy = null)
         {
             _registry = registry;
+            _logger = logger;
             _cache = cache;
             _fieldPolicy = fieldPolicy;
         }
@@ -64,7 +73,7 @@ namespace WalkingTec.Mvvm.Mvc
                 kind = f.Kind.ToString(),
                 allowedFuncs = f.Kind == AnalysisFieldKind.Measure
                     ? GetAllowedFuncNames(f.AllowedFuncs)
-                    : Array.Empty<string>(),
+                    : new List<string>(),
                 isDate = f.IsDate,
                 hierarchy = f.Hierarchy.ToString()
             }));
@@ -75,8 +84,9 @@ namespace WalkingTec.Mvvm.Mvc
         /// 執行分析查詢。
         /// </summary>
         [HttpPost("query")]
-        public IActionResult Query([FromBody] AnalysisQueryRequest req)
+        public IActionResult Query([FromBody] AnalysisQueryRequest? req)
         {
+            if (req == null) return BadRequest("Request body is required.");
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
             if (req.Measures.Count == 0)  return BadRequest("至少需要選取 1 個度量指標。");
             if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");
@@ -102,17 +112,26 @@ namespace WalkingTec.Mvvm.Mvc
 
             string? identityKey = Wtm?.LoginUserInfo != null ? $"{Wtm.LoginUserInfo.CurrentTenant}_{Wtm.LoginUserInfo.UserId}" : null;
 
+            var sw = Stopwatch.StartNew();
             try
             {
-                var result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecuteDynamic(baseQuery, req, fields, identityKey: identityKey, cancellationToken: HttpContext?.RequestAborted ?? default);
+                var result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecuteDynamic(baseQuery, req, fields, identityKey: identityKey);
+                sw.Stop();
+                _logger.LogInformation("Analysis query completed ListVm={ListVmType} Dims={DimCount} Msrs={MsrCount} ElapsedMs={Elapsed} Truncated={Truncated}",
+                    req.ListVmType, req.Dimensions.Count, req.Measures.Count, sw.ElapsedMilliseconds, result.Truncated);
                 return new JsonResult(result, _camelCase);
             }
-            catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Analysis query failed ListVm={ListVmType}", req.ListVmType);
+                return BadRequest(ex.Message);
+            }
         }
 
         [HttpPost("pivot")]
-        public IActionResult Pivot([FromBody] AnalysisPivotRequest req)
+        public IActionResult Pivot([FromBody] AnalysisPivotRequest? req)
         {
+            if (req == null) return BadRequest("Request body is required.");
             if (req.Dimensions.Count > 3) return BadRequest("最多選取 3 個維度。");
             if (req.Measures.Count == 0)  return BadRequest("至少需要選取 1 個度量指標。");
             if (req.Measures.Count > 3)   return BadRequest("最多選取 3 個度量。");
@@ -139,12 +158,20 @@ namespace WalkingTec.Mvvm.Mvc
 
             string? identityKey = Wtm?.LoginUserInfo != null ? $"{Wtm.LoginUserInfo.CurrentTenant}_{Wtm.LoginUserInfo.UserId}" : null;
 
+            var sw = Stopwatch.StartNew();
             try
             {
-                var result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecutePivotDynamic(baseQuery, req, fields, identityKey: identityKey, cancellationToken: HttpContext?.RequestAborted ?? default);
+                var result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecutePivotDynamic(baseQuery, req, fields, identityKey: identityKey);
+                sw.Stop();
+                _logger.LogInformation("Analysis pivot completed ListVm={ListVmType} Dims={DimCount} Msrs={MsrCount} Pivot={PivotDim} ElapsedMs={Elapsed}",
+                    req.ListVmType, req.Dimensions.Count, req.Measures.Count, req.PivotDimension, sw.ElapsedMilliseconds);
                 return new JsonResult(result, _camelCase);
             }
-            catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Analysis pivot failed ListVm={ListVmType}", req.ListVmType);
+                return BadRequest(ex.Message);
+            }
         }
 
         /// <summary>
@@ -180,9 +207,20 @@ namespace WalkingTec.Mvvm.Mvc
 
             string? identityKey = Wtm?.LoginUserInfo != null ? $"{Wtm.LoginUserInfo.CurrentTenant}_{Wtm.LoginUserInfo.UserId}" : null;
 
+            var sw = Stopwatch.StartNew();
             AnalysisQueryResponse result;
-            try { result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecuteDynamic(baseQuery, req, fields, identityKey: identityKey, cancellationToken: HttpContext?.RequestAborted ?? default); }
-            catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
+            try
+            {
+                result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecuteDynamic(baseQuery, req, fields, identityKey: identityKey);
+                sw.Stop();
+                _logger.LogInformation("Analysis export completed ListVm={ListVmType} Format={Format} ElapsedMs={Elapsed}",
+                    req.ListVmType, format, sw.ElapsedMilliseconds);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Analysis export failed ListVm={ListVmType}", req.ListVmType);
+                return BadRequest(ex.Message);
+            }
 
             if (result.Truncated)
                 Response.Headers["X-Analysis-Truncated"] = "true";
@@ -204,11 +242,12 @@ namespace WalkingTec.Mvvm.Mvc
         /// 匯出 Pivot 分析結果為 Excel 或 CSV。
         /// </summary>
         [HttpPost("pivot/export")]
-        public IActionResult PivotExport([FromBody] AnalysisPivotRequest req,
+        public IActionResult PivotExport([FromBody] AnalysisPivotRequest? req,
             [FromQuery] string format = "xlsx",
             [FromQuery] bool includeChart = false,
             [FromQuery] string chartType = "bar")
         {
+            if (req == null) return BadRequest("Request body is required.");
             Type vmType;
             try { vmType = _registry.Resolve(req.ListVmType); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
@@ -230,9 +269,20 @@ namespace WalkingTec.Mvvm.Mvc
 
             string? identityKey = Wtm?.LoginUserInfo != null ? $"{Wtm.LoginUserInfo.CurrentTenant}_{Wtm.LoginUserInfo.UserId}" : null;
 
+            var sw = Stopwatch.StartNew();
             AnalysisPivotResponse result;
-            try { result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecutePivotDynamic(baseQuery, req, fields, identityKey: identityKey, cancellationToken: HttpContext?.RequestAborted ?? default); }
-            catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
+            try
+            {
+                result = new AnalysisQueryEngine(GroupByStrategyResolver.Default, _cache).ExecutePivotDynamic(baseQuery, req, fields, identityKey: identityKey);
+                sw.Stop();
+                _logger.LogInformation("Analysis pivot export completed ListVm={ListVmType} Format={Format} ElapsedMs={Elapsed}",
+                    req.ListVmType, format, sw.ElapsedMilliseconds);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Analysis pivot export failed ListVm={ListVmType}", req.ListVmType);
+                return BadRequest(ex.Message);
+            }
 
             // Adapt AnalysisPivotResponse to AnalysisQueryResponse format for CSV/Excel export
             var queryResult = new AnalysisQueryResponse
@@ -295,10 +345,10 @@ namespace WalkingTec.Mvvm.Mvc
             var vm = CreateAnalysisVm(vmType);
             if (!string.IsNullOrEmpty(searcherJson))
             {
-                var searcherType = vmType.BaseType?.GetGenericArguments().FirstOrDefault();
+                var searcherType = vmType.BaseType?.GetGenericArguments().Skip(1).FirstOrDefault();
                 if (searcherType != null)
                 {
-                    var searcher = JsonSerializer.Deserialize(searcherJson, searcherType, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    var searcher = JsonSerializer.Deserialize(searcherJson, searcherType, _camelCase);
                     if (searcher != null)
                     {
                         var prop = vmType.GetProperty("Searcher");
@@ -331,6 +381,13 @@ namespace WalkingTec.Mvvm.Mvc
                 {
                     var v = row.ContainsKey(c) ? row[c] : null;
                     var s = v?.ToString() ?? "";
+                    
+                    // 防範 CSV Injection (Excel 公式注入)
+                    if (s.StartsWith("=") || s.StartsWith("+") || s.StartsWith("-") || s.StartsWith("@"))
+                    {
+                        s = "\t" + s;
+                    }
+
                     if (s.Contains(",") || s.Contains("\"")) s = "\"" + s.Replace("\"", "\"\"") + "\"";
                     return s;
                 });

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisCacheTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisCacheTests.cs
@@ -168,7 +168,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             ctx.SaveChanges();
 
             var whitelist = AnalysisFieldScanner.ScanModel(typeof(SaleRecord));
-            var engine = new AnalysisQueryEngine(); // 無快取
+            var engine = new AnalysisQueryEngine(GroupByStrategyResolver.Default); // 無快取
 
             var req = new AnalysisQueryRequest
             {

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -104,7 +104,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
 
         private _AnalysisController CreateController(IAnalysisFieldPolicy policy = null)
         {
-            var controller = new _AnalysisController(_registry, null, policy);
+            var controller = new _AnalysisController(_registry, Microsoft.Extensions.Logging.Abstractions.NullLogger<_AnalysisController>.Instance, null, policy);
             controller.Wtm = MockWtmContext.CreateWtmContext();
             return controller;
         }
@@ -558,7 +558,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 msrs: new[] { ("Amount", AggregateFunc.Sum) });
 
             var httpCtx = new DefaultHttpContext();
-            var controller = new _AnalysisController(_registry, null, null);
+            var controller = new _AnalysisController(_registry, Microsoft.Extensions.Logging.Abstractions.NullLogger<_AnalysisController>.Instance, null, null);
             controller.Wtm = MockWtmContext.CreateWtmContext();
             controller.ControllerContext = new ControllerContext { HttpContext = httpCtx };
 
@@ -580,7 +580,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 msrs: new[] { ("Amount", AggregateFunc.Sum) });
 
             var httpCtx = new DefaultHttpContext();
-            var controller = new _AnalysisController(_registry, null, null);
+            var controller = new _AnalysisController(_registry, Microsoft.Extensions.Logging.Abstractions.NullLogger<_AnalysisController>.Instance, null, null);
             controller.Wtm = MockWtmContext.CreateWtmContext();
             controller.ControllerContext = new ControllerContext { HttpContext = httpCtx };
 
@@ -925,7 +925,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 msrs: new[] { ("Amount", AggregateFunc.Sum) });
 
             var httpCtx = new DefaultHttpContext();
-            var controller = new _AnalysisController(_registry, null, null);
+            var controller = new _AnalysisController(_registry, Microsoft.Extensions.Logging.Abstractions.NullLogger<_AnalysisController>.Instance, null, null);
             controller.Wtm = MockWtmContext.CreateWtmContext();
             controller.ControllerContext = new ControllerContext { HttpContext = httpCtx };
 

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
@@ -82,7 +82,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             _conn.Dispose();
         }
 
-        private static AnalysisQueryEngine Engine() => new AnalysisQueryEngine();
+        private static AnalysisQueryEngine Engine() => new AnalysisQueryEngine(GroupByStrategyResolver.Default);
 
         private IQueryable<SaleRecord> Q() => _ctx.SaleRecords.AsQueryable();
 

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
@@ -641,7 +641,8 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             public override List<Dictionary<string, object?>> Execute<TModel>(
                 IQueryable<TModel> query,
                 AnalysisQueryRequest req,
-                Dictionary<string, AnalysisFieldMeta> whitelist)
+                Dictionary<string, AnalysisFieldMeta> whitelist,
+                System.Threading.CancellationToken cancellationToken = default)
             {
                 throw new InvalidOperationException("Simulated SQL translation failure.");
             }

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/InProcessGroupByStrategyTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/InProcessGroupByStrategyTests.cs
@@ -367,7 +367,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             var directRows = _strategy.Execute(data.AsQueryable(), req, _whitelist);
 
             // Via engine
-            var engine = new AnalysisQueryEngine();
+            var engine = new AnalysisQueryEngine(GroupByStrategyResolver.Default);
             var engineResult = engine.Execute(data.AsQueryable(), req, _whitelist.Values);
 
             Assert.AreEqual(directRows.Count, engineResult.Rows.Count);

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/AnalysisWidgetDataSourceTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/AnalysisWidgetDataSourceTests.cs
@@ -53,7 +53,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             _registry = new AnalysisVmRegistry();
             _registry.Build(new[] { typeof(AnalysisWidgetDataSourceTests).Assembly });
 
-            _engine = new AnalysisQueryEngine();
+            _engine = new AnalysisQueryEngine(GroupByStrategyResolver.Default);
 
             var services = new ServiceCollection();
             _serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
Fixes #315

Added CancellationToken parameter to AnalysisQueryEngine methods and IGroupByStrategy.
InProcess and ServerSide strategies now manually iterate and call ThrowIfCancellationRequested()
to prevent long-running materializations. Controllers and DataSources are updated to pass RequestAborted.