### PR TITLE
fix(test): repair compile errors blocking Core.Test build (#354 #355)

### DIFF
--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardDefinitionTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardDefinitionTests.cs
@@ -21,7 +21,17 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
                 Sharing = new SharingDefinition { Mode = "public" },
                 Layout = new List<LayoutItem>
                 {
-                    new LayoutItem { Id = "widget1", X = 0, Y = 0, W = 2, H = 2, LG = 3, MD = 4, SM = 6, XS = 12 }
+                    new LayoutItem
+                    {
+                        Id = "widget1", X = 0, Y = 0, W = 2, H = 2,
+                        Breakpoints = new LayoutBreakpoints
+                        {
+                            Lg = new LayoutBreakpointItem { W = 3 },
+                            Md = new LayoutBreakpointItem { W = 4 },
+                            Sm = new LayoutBreakpointItem { W = 6 },
+                            Xs = new LayoutBreakpointItem { W = 12 }
+                        }
+                    }
                 },
                 Widgets = new Dictionary<string, WidgetDefinition>
                 {
@@ -48,10 +58,11 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             deserialized.Title.Should().Be("Test Dashboard");
             deserialized.Layout.Should().HaveCount(1);
             deserialized.Layout[0].Id.Should().Be("widget1");
-            deserialized.Layout[0].LG.Should().Be(3);
-            deserialized.Layout[0].MD.Should().Be(4);
-            deserialized.Layout[0].SM.Should().Be(6);
-            deserialized.Layout[0].XS.Should().Be(12);
+            deserialized.Layout[0].Breakpoints.Should().NotBeNull();
+            deserialized.Layout[0].Breakpoints!.Lg!.W.Should().Be(3);
+            deserialized.Layout[0].Breakpoints!.Md!.W.Should().Be(4);
+            deserialized.Layout[0].Breakpoints!.Sm!.W.Should().Be(6);
+            deserialized.Layout[0].Breakpoints!.Xs!.W.Should().Be(12);
             deserialized.Widgets.Should().ContainKey("widget1");
         }
 

--- a/test/WalkingTec.Mvvm.Core.Test/Integration/SupplyChainIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/SupplyChainIntegrationTests.cs
@@ -1015,14 +1015,8 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
             var whitelist = AnalysisFieldScanner.ScanModel(typeof(InventoryMovement));
 
             // 應正常回傳（Analysis 不計算周轉率，只聚合原始欄位）
-            AnalysisQueryResponse result = null!;
-            Assert.IsTrue(
-                (() =>
-                {
-                    result = _engine.Execute(zeroInventoryData.AsQueryable(), req, whitelist);
-                    return true;
-                })(),
-                "庫存量為 0 的 Analysis 查詢不應拋出例外");
+            var result = _engine.Execute(zeroInventoryData.AsQueryable(), req, whitelist);
+            Assert.IsNotNull(result, "庫存量為 0 的 Analysis 查詢不應拋出例外");
 
             Assert.AreEqual(1, result.Rows.Count, "應有 1 個分組");
             Assert.AreEqual(0m, Convert.ToDecimal(result.Rows[0]["InventoryValue_Avg"]),


### PR DESCRIPTION
## Summary

- **#354** `DashboardDefinitionTests`: PR #344 changed `LayoutItem` to use a nested `Breakpoints` object, but the test file still used the old flat `LG/MD/SM/XS` properties. Updated construction and assertions to `Breakpoints.Lg/Md/Sm/Xs.W`.
- **#355** `SupplyChainIntegrationTests`: Invalid C# IIFE lambda syntax `(() => { return true; })()` replaced with a direct `Execute()` call + `IsNotNull` assertion (semantically equivalent).

## Test plan

- [x] `dotnet build test/WalkingTec.Mvvm.Core.Test` → 0 errors (was 2 compile errors)
- [x] `dotnet test test/WalkingTec.Mvvm.Core.Test` → 769/779 pass (10 failures are pre-existing, unrelated to these edits)

Closes #354
Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)