### PR TITLE
fix(analysis): escape null bytes in GroupBy dimension keys (#372)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/InProcessGroupByStrategy.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/InProcessGroupByStrategy.cs
@@ -37,7 +37,10 @@ namespace WalkingTec.Mvvm.Core.Analysis
                     var dict = new Dictionary<string, object?>();
                     var keyParts = g.Key.Split('\0');
                     for (int i = 0; i < req.Dimensions.Count; i++)
-                        dict[req.Dimensions[i]] = i < keyParts.Length ? keyParts[i] : string.Empty;
+                    {
+                        var raw = i < keyParts.Length ? keyParts[i] : string.Empty;
+                        dict[req.Dimensions[i]] = DecodeKeyPart(raw);
+                    }
 
                     foreach (var m in req.Measures)
                     {
@@ -97,7 +100,28 @@ namespace WalkingTec.Mvvm.Core.Analysis
                        return DateTruncator.FormatKey(key, h);
                    }
 
-                   return val.ToString() ?? string.Empty;
+                   return EncodeKeyPart(val.ToString() ?? string.Empty);
                }));
+
+        /// <summary>
+        /// Escapes <c>%</c> and <c>\0</c> in a dimension value so it can be safely
+        /// joined with the <c>\0</c> separator without ambiguity.
+        /// Encode order: % → %25 first, then \0 → %00.
+        /// </summary>
+        internal static string EncodeKeyPart(string s)
+        {
+            if (s.IndexOf('%') < 0 && s.IndexOf('\0') < 0) return s;
+            return s.Replace("%", "%25").Replace("\0", "%00");
+        }
+
+        /// <summary>
+        /// Reverses <see cref="EncodeKeyPart"/>.
+        /// Decode order: %00 → \0 first, then %25 → % (order is critical).
+        /// </summary>
+        internal static string DecodeKeyPart(string s)
+        {
+            if (s.IndexOf('%') < 0) return s;
+            return s.Replace("%00", "\0").Replace("%25", "%");
+        }
     }
 }

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/InProcessGroupByStrategyTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/InProcessGroupByStrategyTests.cs
@@ -498,5 +498,129 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                     Convert.ToDecimal(engineRow["Amount_Sum"]));
             }
         }
+
+        // ─── Null-byte separator regression tests (#372) ──────────────────────
+
+        [TestMethod]
+        public void EncodeKeyPart_plain_string_returns_same_instance()
+        {
+            var s = "NorthEast";
+            Assert.AreSame(s, InProcessGroupByStrategy.EncodeKeyPart(s),
+                "無特殊字元時應回傳原始字串實例（無額外分配）");
+        }
+
+        [TestMethod]
+        public void EncodeKeyPart_escapes_null_byte()
+        {
+            Assert.AreEqual("A%00B", InProcessGroupByStrategy.EncodeKeyPart("A\0B"));
+        }
+
+        [TestMethod]
+        public void EncodeKeyPart_escapes_percent_sign()
+        {
+            Assert.AreEqual("100%25", InProcessGroupByStrategy.EncodeKeyPart("100%"));
+        }
+
+        [TestMethod]
+        public void EncodeKeyPart_escapes_both_percent_and_null_byte()
+        {
+            // "A%\0B" → escape % first → "A%25\0B" → escape \0 → "A%25%00B"
+            Assert.AreEqual("A%25%00B", InProcessGroupByStrategy.EncodeKeyPart("A%\0B"));
+        }
+
+        [TestMethod]
+        public void DecodeKeyPart_plain_string_returns_same_instance()
+        {
+            var s = "NorthEast";
+            Assert.AreSame(s, InProcessGroupByStrategy.DecodeKeyPart(s));
+        }
+
+        [TestMethod]
+        public void DecodeKeyPart_restores_null_byte()
+        {
+            Assert.AreEqual("A\0B", InProcessGroupByStrategy.DecodeKeyPart("A%00B"));
+        }
+
+        [TestMethod]
+        public void DecodeKeyPart_restores_percent_sign()
+        {
+            Assert.AreEqual("100%", InProcessGroupByStrategy.DecodeKeyPart("100%25"));
+        }
+
+        [TestMethod]
+        public void EncodeDecodeKeyPart_roundtrip_with_literal_percent00_string()
+        {
+            // 原始值字面上含 "%00"（不是 null byte），不應被錯誤解讀
+            var original = "CODE%00XY";
+            var encoded = InProcessGroupByStrategy.EncodeKeyPart(original);
+            var decoded = InProcessGroupByStrategy.DecodeKeyPart(encoded);
+            Assert.AreEqual(original, decoded, "含 %00 字面字串應正確往返編解碼");
+        }
+
+        [TestMethod]
+        public void Multi_dimension_with_null_byte_in_first_dimension_does_not_corrupt()
+        {
+            // 金融情境：商品代碼含 ETL 載入殘留的 \0（Oracle CHAR 填充等）
+            var data = new List<SaleRecord>
+            {
+                new SaleRecord { Region = "A\0B", Category = "North", Amount = 100m },
+                new SaleRecord { Region = "CD",   Category = "South", Amount = 200m }
+            };
+
+            var req = Req(
+                dims: new[] { "Region", "Category" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            var rows = _strategy.Execute(data.AsQueryable(), req, _whitelist);
+
+            Assert.AreEqual(2, rows.Count, "應有 2 個分組");
+            var nullByteRow = rows.Single(r => r["Region"]?.ToString() == "A\0B");
+            Assert.AreEqual("North", nullByteRow["Category"]?.ToString(),
+                "含 \\0 的維度值不應導致 Category 欄位錯位");
+            Assert.AreEqual(100m, Convert.ToDecimal(nullByteRow["Amount_Sum"]));
+        }
+
+        [TestMethod]
+        public void Multi_dimension_with_null_byte_in_second_dimension_does_not_corrupt()
+        {
+            var data = new List<SaleRecord>
+            {
+                new SaleRecord { Region = "East", Category = "Cat\0A", Amount = 50m },
+                new SaleRecord { Region = "West", Category = "CatB",   Amount = 75m }
+            };
+
+            var req = Req(
+                dims: new[] { "Region", "Category" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            var rows = _strategy.Execute(data.AsQueryable(), req, _whitelist);
+
+            Assert.AreEqual(2, rows.Count);
+            var nullByteRow = rows.Single(r => r["Category"]?.ToString() == "Cat\0A");
+            Assert.AreEqual("East", nullByteRow["Region"]?.ToString(),
+                "第二維度含 \\0 不應導致 Region 欄位錯位");
+        }
+
+        [TestMethod]
+        public void Single_dimension_with_null_byte_groups_correctly()
+        {
+            var data = new List<SaleRecord>
+            {
+                new SaleRecord { Region = "A\0B", Amount = 100m },
+                new SaleRecord { Region = "A\0B", Amount = 200m },
+                new SaleRecord { Region = "CD",   Amount = 300m }
+            };
+
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            var rows = _strategy.Execute(data.AsQueryable(), req, _whitelist);
+
+            Assert.AreEqual(2, rows.Count, "A\\0B 應歸為同一分組");
+            var nullByteRow = rows.Single(r => r["Region"]?.ToString() == "A\0B");
+            Assert.AreEqual(300m, Convert.ToDecimal(nullByteRow["Amount_Sum"]),
+                "含 \\0 的單維度應正確聚合 100+200=300");
+        }
     }
 }

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardDefinitionTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardDefinitionTests.cs
@@ -21,7 +21,17 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
                 Sharing = new SharingDefinition { Mode = "public" },
                 Layout = new List<LayoutItem>
                 {
-                    new LayoutItem { Id = "widget1", X = 0, Y = 0, W = 2, H = 2, LG = 3, MD = 4, SM = 6, XS = 12 }
+                    new LayoutItem
+                    {
+                        Id = "widget1", X = 0, Y = 0, W = 2, H = 2,
+                        Breakpoints = new LayoutBreakpoints
+                        {
+                            Lg = new LayoutBreakpointItem { W = 3 },
+                            Md = new LayoutBreakpointItem { W = 4 },
+                            Sm = new LayoutBreakpointItem { W = 6 },
+                            Xs = new LayoutBreakpointItem { W = 12 }
+                        }
+                    }
                 },
                 Widgets = new Dictionary<string, WidgetDefinition>
                 {
@@ -48,10 +58,11 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             deserialized.Title.Should().Be("Test Dashboard");
             deserialized.Layout.Should().HaveCount(1);
             deserialized.Layout[0].Id.Should().Be("widget1");
-            deserialized.Layout[0].LG.Should().Be(3);
-            deserialized.Layout[0].MD.Should().Be(4);
-            deserialized.Layout[0].SM.Should().Be(6);
-            deserialized.Layout[0].XS.Should().Be(12);
+            deserialized.Layout[0].Breakpoints.Should().NotBeNull();
+            deserialized.Layout[0].Breakpoints!.Lg!.W.Should().Be(3);
+            deserialized.Layout[0].Breakpoints!.Md!.W.Should().Be(4);
+            deserialized.Layout[0].Breakpoints!.Sm!.W.Should().Be(6);
+            deserialized.Layout[0].Breakpoints!.Xs!.W.Should().Be(12);
             deserialized.Widgets.Should().ContainKey("widget1");
         }
 

--- a/test/WalkingTec.Mvvm.Core.Test/Integration/SupplyChainIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/SupplyChainIntegrationTests.cs
@@ -1015,14 +1015,8 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
             var whitelist = AnalysisFieldScanner.ScanModel(typeof(InventoryMovement));
 
             // 應正常回傳（Analysis 不計算周轉率，只聚合原始欄位）
-            AnalysisQueryResponse result = null!;
-            Assert.IsTrue(
-                (() =>
-                {
-                    result = _engine.Execute(zeroInventoryData.AsQueryable(), req, whitelist);
-                    return true;
-                })(),
-                "庫存量為 0 的 Analysis 查詢不應拋出例外");
+            var result = _engine.Execute(zeroInventoryData.AsQueryable(), req, whitelist);
+            Assert.IsNotNull(result, "庫存量為 0 的 Analysis 查詢不應拋出例外");
 
             Assert.AreEqual(1, result.Rows.Count, "應有 1 個分組");
             Assert.AreEqual(0m, Convert.ToDecimal(result.Rows[0]["InventoryValue_Avg"]),


### PR DESCRIPTION
## Summary

`InProcessGroupByStrategy` used `\0` as a separator to join multi-dimension values into a group key, then split on `\0` to recover them. If a dimension value itself contained `\0` (e.g., Oracle CHAR-padded product codes loaded via ETL), `Split('\0')` produced extra parts and dimension labels shifted silently — measure values remained correct while labels were wrong.

## Root Cause

```csharp
// Before: vulnerable to \0 in values
string.Join('\0', dimensions.Select(d => val.ToString()))
// ...
var keyParts = g.Key.Split('\0'); // ambiguous if values contain \0
```

## Fix

Add `EncodeKeyPart` / `DecodeKeyPart` helpers that percent-encode `%` and `\0` before joining:

| Step | Operation |
|---|---|
| Encode | `%` → `%25`, then `\0` → `%00` (order critical) |
| Decode | `%00` → `\0`, then `%25` → `%` (reverse order) |
| Fast path | Strings with no `%` or `\0` bypass encoding entirely |

## Tests (11 new)

- `EncodeKeyPart`: plain, null byte, percent sign, both characters
- `DecodeKeyPart`: plain, null byte, percent sign
- Round-trip: literal `%00` string survives encode→decode
- Integration: `\0` in first dimension, `\0` in second dimension, single dimension with `\0`

## Test plan

- [x] 27/27 `InProcessGroupByStrategyTests` pass

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)