### PR TITLE
test(analysis): add Pivot/PivotExport null and whitelist validation tests (#368)

### DIFF
--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -1346,5 +1346,88 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                     $"重複 Category 維度不應超過 2 個分組，實際：{resp.Rows.Count}");
             }
         }
+
+        // ─── Pivot / PivotExport 守衛測試 ──────────────────────────────────────────
+        //
+        // Query 和 Export 已有 null → 400 及欄位白名單測試，但 Pivot/PivotExport 缺失同等覆蓋。
+
+        private static AnalysisPivotRequest PivotReq(
+            string[] dims,
+            string pivotDim,
+            (string field, AggregateFunc func)[] msrs = null)
+            => new AnalysisPivotRequest
+            {
+                ListVmType     = typeof(SaleRecordListVM).FullName,
+                Dimensions     = dims?.ToList() ?? new List<string>(),
+                PivotDimension = pivotDim,
+                Measures       = msrs?.Select(m => new MeasureRequest { Field = m.field, Func = m.func }).ToList()
+                                 ?? new List<MeasureRequest>()
+            };
+
+        [TestMethod]
+        public void Pivot_null_request_returns_400()
+        {
+            var result = CreateController().Pivot(null);
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult),
+                "Pivot null body 應回傳 400");
+        }
+
+        [TestMethod]
+        public void PivotExport_null_request_returns_400()
+        {
+            var result = CreateController().PivotExport(null);
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult),
+                "PivotExport null body 應回傳 400");
+        }
+
+        [TestMethod]
+        public void Pivot_returns_400_when_PivotDimension_not_in_dimensions_list()
+        {
+            // Region 在白名單，但 PivotDimension = "Category" 不在所選 Dimensions 中
+            var req = PivotReq(
+                dims:     new[] { "Region" },
+                pivotDim: "Category",
+                msrs:     new[] { ("Amount", AggregateFunc.Sum) });
+            var result = CreateController().Pivot(req);
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult),
+                "PivotDimension 不在 Dimensions 清單中應回傳 400");
+        }
+
+        [TestMethod]
+        public void Pivot_returns_400_for_invalid_pivot_dimension_field()
+        {
+            // "InvalidField" 不在模型白名單
+            var req = PivotReq(
+                dims:     new[] { "InvalidField" },
+                pivotDim: "InvalidField",
+                msrs:     new[] { ("Amount", AggregateFunc.Sum) });
+            var result = CreateController().Pivot(req);
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult),
+                "不在白名單中的維度欄位應回傳 400");
+        }
+
+        [TestMethod]
+        public void PivotExport_returns_400_when_PivotDimension_not_in_dimensions_list()
+        {
+            var req = PivotReq(
+                dims:     new[] { "Region" },
+                pivotDim: "Category",
+                msrs:     new[] { ("Amount", AggregateFunc.Sum) });
+            var result = CreateController().PivotExport(req);
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult),
+                "PivotExport：PivotDimension 不在 Dimensions 清單中應回傳 400");
+        }
+
+        [TestMethod]
+        public void PivotExport_returns_400_for_invalid_dimension_field()
+        {
+            var req = PivotReq(
+                dims:     new[] { "InvalidField" },
+                pivotDim: "InvalidField",
+                msrs:     new[] { ("Amount", AggregateFunc.Sum) });
+            var result = CreateController().PivotExport(req);
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult),
+                "PivotExport：不在白名單中的維度欄位應回傳 400");
+        }
     }
 }

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardDefinitionTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/DashboardDefinitionTests.cs
@@ -21,7 +21,17 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
                 Sharing = new SharingDefinition { Mode = "public" },
                 Layout = new List<LayoutItem>
                 {
-                    new LayoutItem { Id = "widget1", X = 0, Y = 0, W = 2, H = 2, LG = 3, MD = 4, SM = 6, XS = 12 }
+                    new LayoutItem
+                    {
+                        Id = "widget1", X = 0, Y = 0, W = 2, H = 2,
+                        Breakpoints = new LayoutBreakpoints
+                        {
+                            Lg = new LayoutBreakpointItem { W = 3 },
+                            Md = new LayoutBreakpointItem { W = 4 },
+                            Sm = new LayoutBreakpointItem { W = 6 },
+                            Xs = new LayoutBreakpointItem { W = 12 }
+                        }
+                    }
                 },
                 Widgets = new Dictionary<string, WidgetDefinition>
                 {
@@ -48,10 +58,11 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             deserialized.Title.Should().Be("Test Dashboard");
             deserialized.Layout.Should().HaveCount(1);
             deserialized.Layout[0].Id.Should().Be("widget1");
-            deserialized.Layout[0].LG.Should().Be(3);
-            deserialized.Layout[0].MD.Should().Be(4);
-            deserialized.Layout[0].SM.Should().Be(6);
-            deserialized.Layout[0].XS.Should().Be(12);
+            deserialized.Layout[0].Breakpoints.Should().NotBeNull();
+            deserialized.Layout[0].Breakpoints!.Lg!.W.Should().Be(3);
+            deserialized.Layout[0].Breakpoints!.Md!.W.Should().Be(4);
+            deserialized.Layout[0].Breakpoints!.Sm!.W.Should().Be(6);
+            deserialized.Layout[0].Breakpoints!.Xs!.W.Should().Be(12);
             deserialized.Widgets.Should().ContainKey("widget1");
         }
 

--- a/test/WalkingTec.Mvvm.Core.Test/Integration/SupplyChainIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/SupplyChainIntegrationTests.cs
@@ -1015,14 +1015,8 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
             var whitelist = AnalysisFieldScanner.ScanModel(typeof(InventoryMovement));
 
             // 應正常回傳（Analysis 不計算周轉率，只聚合原始欄位）
-            AnalysisQueryResponse result = null!;
-            Assert.IsTrue(
-                (() =>
-                {
-                    result = _engine.Execute(zeroInventoryData.AsQueryable(), req, whitelist);
-                    return true;
-                })(),
-                "庫存量為 0 的 Analysis 查詢不應拋出例外");
+            var result = _engine.Execute(zeroInventoryData.AsQueryable(), req, whitelist);
+            Assert.IsNotNull(result, "庫存量為 0 的 Analysis 查詢不應拋出例外");
 
             Assert.AreEqual(1, result.Rows.Count, "應有 1 個分組");
             Assert.AreEqual(0m, Convert.ToDecimal(result.Rows[0]["InventoryValue_Avg"]),


### PR DESCRIPTION
## Summary

- `Query` and `Export` had null-body → 400 and invalid-field → 400 coverage, but equivalent paths for `Pivot` and `PivotExport` were untested
- Added 6 tests using a `PivotReq()` helper matching the existing `Req()` pattern
- Covers: null body, PivotDimension not in Dimensions list (engine validation), dimension field not in whitelist (ValidateFields)

## Test plan

- [x] `Pivot_null_request_returns_400`
- [x] `PivotExport_null_request_returns_400`
- [x] `Pivot_returns_400_when_PivotDimension_not_in_dimensions_list`
- [x] `Pivot_returns_400_for_invalid_pivot_dimension_field`
- [x] `PivotExport_returns_400_when_PivotDimension_not_in_dimensions_list`
- [x] `PivotExport_returns_400_for_invalid_dimension_field`
- [x] All 67 `AnalysisControllerTests` pass

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)