### PR TITLE
fix(etl): add InvalidOperationException handling to Rerun endpoint (#359)

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlRunLogController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlRunLogController.cs
@@ -42,7 +42,14 @@ public class _EtlRunLogController : BaseController
     [HttpPost]
     public async Task<IActionResult> Rerun(Guid runLogId)
     {
-        await _scheduler.RerunFromSnapshotAsync(runLogId);
-        return Ok(new { success = true, message = "已從該點重跑" });
+        try
+        {
+            await _scheduler.RerunFromSnapshotAsync(runLogId);
+            return Ok(new { success = true, message = "已從該點重跑" });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 }

--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlRunLogControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlRunLogControllerTests.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using WalkingTec.Mvvm.Etl.Scheduling;
+using WalkingTec.Mvvm.Mvc;
+using WalkingTec.Mvvm.Test.Mock;
+
+namespace WalkingTec.Mvvm.Etl.Test.Controllers;
+
+[TestClass]
+public class EtlRunLogControllerTests
+{
+    private Mock<EtlSchedulerService> _mockScheduler = null!;
+    private _EtlRunLogController _controller = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var mockSp = new Mock<IServiceProvider>();
+        _mockScheduler = new Mock<EtlSchedulerService>(mockSp.Object);
+
+        _controller = new _EtlRunLogController(_mockScheduler.Object);
+        _controller.Wtm = MockWtmContext.CreateWtmContext();
+
+        var mockHttpContext = new Mock<HttpContext>();
+        var mockSession = new MockHttpSession();
+        mockHttpContext.Setup(s => s.Session).Returns(mockSession);
+        mockHttpContext.Setup(x => x.Request).Returns(new DefaultHttpContext().Request);
+        _controller.ControllerContext.HttpContext = mockHttpContext.Object;
+        _controller.Wtm.MSD = new ModelStateServiceProvider(_controller.ModelState);
+    }
+
+    [TestMethod]
+    public async Task Rerun_calls_scheduler_and_returns_200()
+    {
+        var runLogId = Guid.NewGuid();
+        _mockScheduler.Setup(x => x.RerunFromSnapshotAsync(runLogId)).Returns(Task.CompletedTask);
+
+        var result = await _controller.Rerun(runLogId) as OkObjectResult;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(200, result!.StatusCode);
+        _mockScheduler.Verify(x => x.RerunFromSnapshotAsync(runLogId), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Rerun_returns_400_when_scheduler_throws_InvalidOperationException()
+    {
+        var runLogId = Guid.NewGuid();
+        _mockScheduler.Setup(x => x.RerunFromSnapshotAsync(runLogId))
+            .ThrowsAsync(new InvalidOperationException($"RunLog {runLogId} not found or job state prevents rerun."));
+
+        var result = await _controller.Rerun(runLogId) as BadRequestObjectResult;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(400, result!.StatusCode);
+        _mockScheduler.Verify(x => x.RerunFromSnapshotAsync(runLogId), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

- `_EtlRunLogController.Rerun` called `RerunFromSnapshotAsync` without try/catch, so scheduler exceptions (run log not found, invalid job state) propagated as **500** instead of **400**
- Inconsistent with `_EtlJobController.Abort` which correctly returns 400 on `InvalidOperationException`
- Fixed by adding matching try/catch; created `EtlRunLogControllerTests.cs` (no controller test file existed)

## Test plan

- [x] `Rerun_calls_scheduler_and_returns_200` — happy path
- [x] `Rerun_returns_400_when_scheduler_throws_InvalidOperationException` — error path
- [x] Both tests pass

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)