### PR TITLE
test(analysis): add security boundary regression tests — SQL injection & XSS (#377)

### DIFF
--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -395,6 +395,63 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.IsTrue(csv.Contains("\t+SUM"), "危險值應以 tab 前置");
         }
 
+        // ─── XSS Payload 回歸保護 ─────────────────────────────────────────────
+        //
+        // CSV 是純文字格式，不解析 HTML。測試確認：
+        //   1. XSS payload 不導致例外或崩潰
+        //   2. 輸出中 payload 以原始文字保留（不 HTML-encode 也不截斷）
+        //   3. 不以 formula 字元開頭（<script> 不是 =,+,-,@ 所以不觸發公式轉義）
+
+        [TestMethod]
+        public void Export_csv_with_xss_payload_in_dimension_value_does_not_throw()
+        {
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord
+                {
+                    ID       = Guid.NewGuid(),
+                    Region   = "<script>alert(1)</script>",
+                    Category = "A",
+                    Amount   = 100m
+                }
+            };
+
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            var result = CreateController().Export(req, "csv") as FileContentResult;
+
+            Assert.IsNotNull(result, "Export should not throw with XSS payload in dimension value");
+            var csv = System.Text.Encoding.UTF8.GetString(result.FileContents).TrimStart('\xEF', '\xBB', '\xBF');
+
+            // payload 應以明文保留（CSV 不解析 HTML）
+            Assert.IsTrue(csv.Contains("<script>"),
+                "XSS payload should be preserved as plain text in CSV");
+            // 不應被 HTML-encode（避免雙重逸脫）
+            Assert.IsFalse(csv.Contains("&lt;script&gt;"),
+                "CSV exporter must not HTML-encode cell values");
+        }
+
+        [TestMethod]
+        public void Export_csv_with_null_byte_in_dimension_value_does_not_throw()
+        {
+            // null byte (\0) 在維度值中不應造成崩潰
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "A\0B", Category = "X", Amount = 50m }
+            };
+
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            // Should not throw
+            var result = CreateController().Export(req, "csv") as FileContentResult;
+
+            Assert.IsNotNull(result, "Export should not crash on null byte in dimension value");
+        }
+
         // ─── DimensionHierarchies 驗證 ─────────────────────────────────────────
 
         [TestMethod]

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
@@ -285,6 +285,71 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.ThrowsException<InvalidOperationException>(() => Engine().Execute(Q(), req, _whitelist));
         }
 
+        // ─── SQL Injection 回歸保護 ────────────────────────────────────────────
+        //
+        // Expression Tree 在結構上防止 SQL injection：filter value 轉為
+        // Expression.Constant(value) → EF Core parameterized query（@p0），
+        // 從不拼接成 raw SQL。以下測試確保此防護持續有效。
+
+        [TestMethod]
+        public void Filter_Eq_sql_injection_pattern_in_value_does_not_throw_and_matches_nothing()
+        {
+            // Arrange: 典型的 SQL injection pattern 作為 filter value
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                filters: new[] { ("Region", FilterOperator.Eq, "'; DROP TABLE SaleRecords --") });
+
+            // Act: Expression Tree → parameterized SQL → 不應拋出例外
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            // Assert: injection pattern 不是合法的 Region 值 → 0 列
+            Assert.AreEqual(0, result.Rows.Count,
+                "SQL injection pattern in filter value should return 0 rows, not throw");
+            // 確認 table 仍存在（未被 DROP）
+            Assert.AreEqual(3, _ctx.SaleRecords.Count(),
+                "SaleRecords table must still contain all 3 rows — no injection occurred");
+        }
+
+        [TestMethod]
+        public void Filter_Contains_sql_injection_pattern_in_value_does_not_throw()
+        {
+            // Arrange: Contains 運算子 + SQL injection value
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                filters: new[] { ("Region", FilterOperator.Contains, "'; DROP TABLE--") });
+
+            // Act: String.Contains translates to SQL LIKE @p0 — safe
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            Assert.AreEqual(0, result.Rows.Count,
+                "SQL injection pattern should match no rows");
+            Assert.AreEqual(3, _ctx.SaleRecords.Count(),
+                "Table must still have 3 rows after Contains with injection-patterned value");
+        }
+
+        [TestMethod]
+        public void Filter_Eq_unicode_value_matches_correctly()
+        {
+            // Unicode filter values（中文、emoji）應正常運作
+            _ctx.SaleRecords.Add(new SaleRecord
+            {
+                ID = Guid.NewGuid(), Region = "東南亞🌏", Category = "A", Amount = 500m
+            });
+            _ctx.SaveChanges();
+
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                filters: new[] { ("Region", FilterOperator.Eq, "東南亞🌏") });
+
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            Assert.AreEqual(1, result.Rows.Count, "Unicode filter value should match exactly 1 row");
+            Assert.AreEqual("東南亞🌏", result.Rows[0]["Region"].ToString());
+        }
+
         /// <summary>Contains 運算子用於非字串欄位 → 拋 InvalidOperationException</summary>
         [TestMethod]
         public void Filter_Contains_on_non_string_field_throws()


### PR DESCRIPTION
## Summary

Adds 5 regression tests to lock in the structural safety of the Analysis engine and CSV export path against SQL injection and XSS payloads. These tests **don't fix bugs** — they confirm existing defenses work and will catch any future regression.

## Why these tests matter

| Threat | Structural defense | What was missing |
|--------|-------------------|-----------------|
| SQL injection in filter values | `Expression.Constant(value)` → EF Core parameterized SQL, never concatenated | No regression test — removing `Take(MaxMaterializeRows)` or switching to raw SQL would go undetected |
| XSS payload in dimension values | CSV is plain text, no HTML interpretation | No test confirming payload doesn't crash, HTML-encode, or corrupt output |

## Tests added

**`AnalysisQueryEngineTests`**
- `Filter_Eq_sql_injection_pattern_in_value_does_not_throw_and_matches_nothing` — `'; DROP TABLE SaleRecords --` as Eq filter value → 0 rows, table still exists
- `Filter_Contains_sql_injection_pattern_in_value_does_not_throw` — same for Contains (LIKE)
- `Filter_Eq_unicode_value_matches_correctly` — `东南亚🌏` filter value round-trips correctly

**`AnalysisControllerTests`**
- `Export_csv_with_xss_payload_in_dimension_value_does_not_throw` — `<script>alert(1)</script>` preserved as plain text, not HTML-encoded
- `Export_csv_with_null_byte_in_dimension_value_does_not_throw` — `A\0B` in dimension value doesn't crash export

## Test plan

- [x] All 5 new tests pass
- [x] 120/120 `AnalysisQueryEngineTests` + `AnalysisControllerTests` pass
- [x] Multi-tenant isolation (#374) and ETL Unicode (#377 item 4) tracked separately

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)