### PR TITLE
feat(analysis): Excel export formatting — bold header, auto-width, number format (#378)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
@@ -15,25 +15,57 @@ namespace WalkingTec.Mvvm.Core.Analysis
     /// </summary>
     public static class AnalysisExcelExporter
     {
+        // Maximum column width in NPOI units (1/256 of a character). Caps at 50 characters.
+        internal const int MaxColumnWidth = 50 * 256;
+
         /// <summary>
         /// 匯出分析結果為 Excel（xlsx），回傳位元組陣列。
         /// </summary>
         /// <param name="result">查詢結果</param>
         /// <param name="includeChart">是否嵌入圖表（預設 false）</param>
         /// <param name="chartType">圖表類型：bar, pie, line, bar-stacked（預設 bar）</param>
+
         public static byte[] Export(AnalysisQueryResponse result, bool includeChart = false, string? chartType = null)
         {
             using var workbook = new XSSFWorkbook();
             var sheet = workbook.CreateSheet("Analysis");
 
-            // Header row — write original column names without unit decoration
+            // ── Styles ────────────────────────────────────────────────────────────
+            // Header: bold font + light-gray background
+            var headerFont = workbook.CreateFont();
+            headerFont.IsBold = true;
+            var headerStyle = workbook.CreateCellStyle();
+            headerStyle.SetFont(headerFont);
+            headerStyle.FillForegroundColor = IndexedColors.Grey25Percent.Index;
+            headerStyle.FillPattern = FillPattern.SolidForeground;
+
+            // Numeric data: thousand-separator format (e.g. 1,234,567.89)
+            var numericStyle = workbook.CreateCellStyle();
+            var numericFormat = workbook.CreateDataFormat();
+            numericStyle.DataFormat = numericFormat.GetFormat("#,##0.00");
+
+            // ── Header row — write original column names without unit decoration ──
             var header = sheet.CreateRow(0);
             for (int i = 0; i < result.Columns.Count; i++)
             {
-                header.CreateCell(i).SetCellValue(result.Columns[i]);
+                var cell = header.CreateCell(i);
+                cell.SetCellValue(result.Columns[i]);
+                cell.CellStyle = headerStyle;
             }
 
-            // Data rows
+            // ── Detect numeric (measure) columns from first data row ──────────────
+            var numericColIndices = new HashSet<int>();
+            if (result.Rows.Count > 0)
+            {
+                for (int c = 0; c < result.Columns.Count; c++)
+                {
+                    result.Rows[0].TryGetValue(result.Columns[c], out var firstVal);
+                    if (firstVal is decimal or double or float or int or long)
+                        numericColIndices.Add(c);
+                }
+            }
+
+            // ── Data rows ─────────────────────────────────────────────────────────
             for (int r = 0; r < result.Rows.Count; r++)
             {
                 var row = sheet.CreateRow(r + 1);
@@ -45,15 +77,26 @@ namespace WalkingTec.Mvvm.Core.Analysis
                         cell.SetCellValue((double)d);
                     else if (val is double db)
                         cell.SetCellValue(db);
-                    else if (val is float f)
-                        cell.SetCellValue(f);
-                    else if (val is int i)
-                        cell.SetCellValue(i);
-                    else if (val is long l)
-                        cell.SetCellValue(l);
+                    else if (val is float fv)
+                        cell.SetCellValue(fv);
+                    else if (val is int iv)
+                        cell.SetCellValue(iv);
+                    else if (val is long lv)
+                        cell.SetCellValue(lv);
                     else
                         cell.SetCellValue(val?.ToString() ?? "");
+
+                    if (numericColIndices.Contains(c))
+                        cell.CellStyle = numericStyle;
                 }
+            }
+
+            // ── Auto-size all columns, cap at MaxColumnWidth ──────────────────────
+            for (int i = 0; i < result.Columns.Count; i++)
+            {
+                sheet.AutoSizeColumn(i);
+                if (sheet.GetColumnWidth(i) > MaxColumnWidth)
+                    sheet.SetColumnWidth(i, MaxColumnWidth);
             }
 
             if (includeChart && result.Rows.Count > 0 && result.Columns.Count >= 2)

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
@@ -94,7 +94,17 @@ namespace WalkingTec.Mvvm.Core.Analysis
             // ── Auto-size all columns, cap at MaxColumnWidth ──────────────────────
             for (int i = 0; i < result.Columns.Count; i++)
             {
-                sheet.AutoSizeColumn(i);
+                // AutoSizeColumn requires system fonts (SixLabors.Fonts). On CI Linux runners
+                // without fonts installed, it throws. Fall back to a header-length heuristic.
+                try
+                {
+                    sheet.AutoSizeColumn(i);
+                }
+                catch
+                {
+                    int headerLen = result.Columns[i].Length;
+                    sheet.SetColumnWidth(i, Math.Min(Math.Max(headerLen * 512, 3000), MaxColumnWidth));
+                }
                 if (sheet.GetColumnWidth(i) > MaxColumnWidth)
                     sheet.SetColumnWidth(i, MaxColumnWidth);
             }

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
@@ -417,5 +417,135 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.IsNotNull(bytes);
             Assert.IsTrue(bytes.Length > 0);
         }
+
+        // ─── #378: Header formatting (bold + gray background) ─────────────────
+
+        [TestMethod]
+        public void Export_header_cells_are_bold()
+        {
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = 100m }
+                });
+
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
+            var sheet = wb.GetSheetAt(0);
+            var headerCell = sheet.GetRow(0).GetCell(0);
+
+            Assert.IsNotNull(headerCell.CellStyle, "Header cell should have a style");
+            Assert.IsTrue(wb.GetFontAt(headerCell.CellStyle.FontIndex).IsBold,
+                "Header font should be bold");
+        }
+
+        [TestMethod]
+        public void Export_header_cells_have_gray_background()
+        {
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = 100m }
+                });
+
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
+            var sheet = wb.GetSheetAt(0);
+            var headerCell = sheet.GetRow(0).GetCell(0);
+
+            Assert.AreEqual(FillPattern.SolidForeground, headerCell.CellStyle.FillPattern,
+                "Header cell should use SolidForeground fill pattern");
+            Assert.AreNotEqual(0, headerCell.CellStyle.FillForegroundColor,
+                "Header cell should have a non-default fill colour");
+        }
+
+        // ─── #378: Numeric format for measure columns ─────────────────────────
+
+        [TestMethod]
+        public void Export_numeric_columns_have_number_format_applied()
+        {
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = 1_234_567.89m }
+                });
+
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
+            var sheet = wb.GetSheetAt(0);
+            var numericCell = sheet.GetRow(1).GetCell(1); // Amount_Sum
+
+            Assert.IsNotNull(numericCell.CellStyle);
+            // DataFormat index 0 = "General" (no formatting); any custom format > 0
+            Assert.AreNotEqual(0, numericCell.CellStyle.DataFormat,
+                "Numeric measure cell should have a custom number format (not General)");
+        }
+
+        [TestMethod]
+        public void Export_string_columns_do_not_have_numeric_format()
+        {
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = 100m }
+                });
+
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
+            var sheet = wb.GetSheetAt(0);
+            var stringCell = sheet.GetRow(1).GetCell(0); // Region (string)
+
+            // String cell should either have no style or the General (0) format
+            var fmt = stringCell.CellStyle?.DataFormat ?? 0;
+            Assert.AreEqual(0, fmt, "String dimension cell should use General format (no custom numeric format)");
+        }
+
+        // ─── #378: Column auto-sizing ─────────────────────────────────────────
+
+        [TestMethod]
+        public void Export_columns_are_wider_than_single_char_default()
+        {
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = 100m }
+                });
+
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
+            var sheet = wb.GetSheetAt(0);
+
+            // Default NPOI column width is 2048 units (8 chars * 256); after AutoSizeColumn
+            // it should be wider than 1 character (256 units).
+            for (int c = 0; c < 2; c++)
+            {
+                Assert.IsTrue(sheet.GetColumnWidth(c) > 256,
+                    $"Column {c} width should exceed 1 character after AutoSizeColumn");
+            }
+        }
+
+        [TestMethod]
+        public void Export_very_long_column_content_is_capped_at_max_width()
+        {
+            var longValue = new string('A', 200); // 200-char string > 50-char cap
+            var resp = MakeResponse(
+                new List<string> { "LongCol" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["LongCol"] = longValue }
+                });
+
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
+            var sheet = wb.GetSheetAt(0);
+
+            Assert.IsTrue(sheet.GetColumnWidth(0) <= AnalysisExcelExporter.MaxColumnWidth,
+                "Column width should be capped at MaxColumnWidth");
+        }
+
+        [TestMethod]
+        public void MaxColumnWidth_is_fifty_chars()
+        {
+            Assert.AreEqual(50 * 256, AnalysisExcelExporter.MaxColumnWidth);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **粗體 + 灰色背景**：Header 列改用粗體字型 + `Grey25Percent` 填色，標題與資料列視覺區分清晰
- **千分位數字格式**：自動偵測第一筆資料列中的數字欄（`decimal/double/float/int/long`），套用 `#,##0.00` cell style，財務數字直接可讀
- **欄寬自動調整**：所有資料行寫完後呼叫 `AutoSizeColumn()`，防止截斷；同時 cap 在 `MaxColumnWidth`（50 chars = 12,800 NPOI units），避免超長欄位
- **AutoSizeColumn Linux 相容性修復**：`AutoSizeColumn()` 在無系統字體的 Linux CI 環境會因 `SixLabors.Fonts` 拋例外而崩潰；以 try-catch 包覆，fallback 為 header 長度啟發式計算（`headerLen * 512`，最小 3000，最大 MaxColumnWidth）
- 新增 7 個 MSTest 測試：header bold、header fill、numeric format、string column 不套用格式、auto-size、長內容 cap、MaxColumnWidth 值

## Test plan

- [x] 30 個 `AnalysisExcelExporterTests` 全通過（含 7 個新測試）
- [x] 向後相容：`includeChart`、`chartType`、無資料行等原有行為不受影響
- [x] `VP_ExportsPerformanceReport_ExcelColumnsMatchAnalysisResult` 通過（#416 迴歸）
- [x] `SalesManager_ExportsExcel_ColumnsMatchAnalysisResult` 通過（#416 迴歸）

Closes #378
Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)