### PR TITLE
test(security): boundary regression tests — SQL injection, XSS, ETL Unicode (#377)

### DIFF
--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -6,6 +6,9 @@ using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Analysis;
 using WalkingTec.Mvvm.Mvc;
@@ -1481,5 +1484,142 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.AreEqual(0xBB, result.FileContents[1], "第 2 byte 應為 BOM BB");
             Assert.AreEqual(0xBF, result.FileContents[2], "第 3 byte 應為 BOM BF");
         }
+        // ─── #377: SQL injection / XSS / 邊界安全測試 ───────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Analysis")]
+        public void Query_filter_value_with_sql_injection_pattern_does_not_throw()
+        {
+            // Expression Tree approach treats filter values as parameters, never raw SQL.
+            // This test locks in that guarantee: a SQL injection string must not throw or 500.
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "North", Category = "A", Amount = 100m },
+                new SaleRecord { ID = Guid.NewGuid(), Region = "'; DROP TABLE OrderItems --", Category = "B", Amount = 200m },
+            };
+
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(SaleRecordListVM).FullName,
+                Dimensions = new List<string> { "Region" },
+                Measures   = new List<MeasureRequest>
+                {
+                    new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum }
+                },
+                Filters = new List<FilterCondition>
+                {
+                    new FilterCondition { Field = "Region", Operator = FilterOperator.Eq, Value = "'; DROP TABLE OrderItems --" }
+                },
+            };
+
+            // Must not throw; must return 200 with exactly 1 matching row
+            var result = CreateController().Query(req) as JsonResult;
+            Assert.IsNotNull(result, "SQL injection in filter value must not throw — should return 200");
+            var response = result.Value as AnalysisQueryResponse;
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, response.Rows.Count, "Exactly 1 row matches the injection string as a literal value");
+        }
+
+        [TestMethod]
+        [TestCategory("Analysis")]
+        public void Query_filter_value_with_xss_payload_does_not_throw()
+        {
+            // XSS payload as a filter value must be treated as a plain string.
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "<script>alert(1)</script>", Category = "A", Amount = 50m },
+                new SaleRecord { ID = Guid.NewGuid(), Region = "Safe", Category = "B", Amount = 150m },
+            };
+
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(SaleRecordListVM).FullName,
+                Dimensions = new List<string> { "Region" },
+                Measures   = new List<MeasureRequest>
+                {
+                    new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum }
+                },
+                Filters = new List<FilterCondition>
+                {
+                    new FilterCondition { Field = "Region", Operator = FilterOperator.Eq, Value = "<script>alert(1)</script>" }
+                },
+            };
+
+            var result = CreateController().Query(req) as JsonResult;
+            Assert.IsNotNull(result, "XSS payload in filter value must return 200");
+            var response = result.Value as AnalysisQueryResponse;
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, response.Rows.Count);
+            Assert.AreEqual("<script>alert(1)</script>", response.Rows[0]["Region"]?.ToString());
+        }
+
+        [TestMethod]
+        [TestCategory("Analysis")]
+        public void Export_csv_with_xss_payload_in_dimension_value_stores_verbatim()
+        {
+            // XSS payload in dimension value must appear verbatim in CSV (no HTML-encoding).
+            // CSV is plain text — the browser/Excel parses it, not an HTML parser.
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "<script>alert(1)</script>", Category = "A", Amount = 100m },
+            };
+
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(SaleRecordListVM).FullName,
+                Dimensions = new List<string> { "Region" },
+                Measures   = new List<MeasureRequest>
+                {
+                    new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum }
+                },
+            };
+
+            var result = CreateController().Export(req, "csv") as FileContentResult;
+            Assert.IsNotNull(result, "Export CSV should return FileContentResult");
+
+            var raw = result.FileContents;
+            int bom = (raw.Length >= 3 && raw[0] == 0xEF && raw[1] == 0xBB && raw[2] == 0xBF) ? 3 : 0;
+            var text = System.Text.Encoding.UTF8.GetString(raw, bom, raw.Length - bom);
+
+            // The raw XSS string should appear in the CSV output — no HTML encoding
+            Assert.IsTrue(text.Contains("<script>alert(1)</script>"),
+                $"CSV should contain verbatim XSS string. Actual CSV:\n{text}");
+        }
+
+        [TestMethod]
+        [TestCategory("Analysis")]
+        public void Export_xlsx_with_xss_payload_in_dimension_value_stored_as_plain_string()
+        {
+            // XSS payload in xlsx must be stored as a string cell with the literal value,
+            // not HTML-encoded or interpreted as executable content.
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "<script>alert(1)</script>", Category = "A", Amount = 100m },
+            };
+
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(SaleRecordListVM).FullName,
+                Dimensions = new List<string> { "Region" },
+                Measures   = new List<MeasureRequest>
+                {
+                    new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum }
+                },
+            };
+
+            var result = CreateController().Export(req, "xlsx") as FileContentResult;
+            Assert.IsNotNull(result, "Export xlsx should return FileContentResult");
+
+            using var ms = new MemoryStream(result.FileContents);
+            var wb = new XSSFWorkbook(ms);
+            var sheet = wb.GetSheetAt(0);
+            // Row 1 (index 1) is the first data row; column 0 is the Region dimension
+            var cell = sheet.GetRow(1)?.GetCell(0);
+            Assert.IsNotNull(cell, "Data row should exist");
+            Assert.AreEqual(CellType.String, cell.CellType);
+            Assert.AreEqual("<script>alert(1)</script>", cell.StringCellValue,
+                "xlsx cell should store verbatim XSS string, not HTML-encoded");
+        }
+
     }
 }

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EdgeCaseTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EdgeCaseTests.cs
@@ -194,4 +194,104 @@ public class EdgeCaseTests
         var firstRow = capturedBatch.Rows[0];
         ((decimal)firstRow["DoubleAmount"]).Should().Be((decimal)firstRow["Amount"] * 2);
     }
+    // ─── #377: Unicode / special characters ───────────────────────────────────
+
+    [TestMethod]
+    public async Task Execute_with_unicode_field_values_loads_correctly()
+    {
+        // Verify pipeline correctly passes through Unicode strings (CJK, emoji, Arabic)
+        // without truncation or corruption — regression test for #377.
+        var dt = new DataTable();
+        dt.Columns.Add("OrderNo", typeof(string));
+        dt.Columns.Add("Amount", typeof(decimal));
+        dt.Columns.Add("UpdatedAt", typeof(DateTime));
+
+        var unicodeValues = new[]
+        {
+            "訂單-中文測試-001",          // CJK
+            "注文-日本語テスト-002",       // Japanese
+            "ORD-Emoji-🎉🚀💡-003",       // Emoji
+            "طلب-عربي-004",               // Arabic (RTL)
+        };
+
+        foreach (var val in unicodeValues)
+        {
+            var row = dt.NewRow();
+            row["OrderNo"] = val;
+            row["Amount"] = 100m;
+            row["UpdatedAt"] = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            dt.Rows.Add(row);
+        }
+
+        _source.SetData(dt);
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue("pipeline should succeed with Unicode values");
+        _loader.TotalRows.Should().Be(4, "all 4 Unicode rows should be loaded");
+
+        // Verify each Unicode value is preserved verbatim in the loaded batch
+        var loadedOrders = _loader.LoadedBatches
+            .SelectMany(b => b.Rows.Cast<DataRow>())
+            .Select(r => r["OrderNo"].ToString())
+            .ToList();
+
+        foreach (var expected in unicodeValues)
+        {
+            loadedOrders.Should().Contain(expected, $"Unicode value '{expected}' should be preserved verbatim");
+        }
+    }
+
+    [TestMethod]
+    public async Task Execute_with_special_chars_in_string_field_handles_correctly()
+    {
+        // Verify pipeline handles embedded special characters (newline, tab, null-byte removal)
+        // without throwing or corrupting data — regression test for #377.
+        var dt = new DataTable();
+        dt.Columns.Add("OrderNo", typeof(string));
+        dt.Columns.Add("Amount", typeof(decimal));
+        dt.Columns.Add("UpdatedAt", typeof(DateTime));
+
+        // Newline and tab are valid in NVARCHAR; null byte would fail DB insert but we test pipeline handling
+        var specialValues = new[]
+        {
+            "Line1\nLine2",        // embedded newline
+            "Col1\tCol2",          // embedded tab
+            "Quote\"Inside",       // embedded double-quote
+            @"Back\Slash",         // backslash
+        };
+
+        foreach (var val in specialValues)
+        {
+            var row = dt.NewRow();
+            row["OrderNo"] = val;
+            row["Amount"] = 50m;
+            row["UpdatedAt"] = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            dt.Rows.Add(row);
+        }
+
+        _source.SetData(dt);
+        var config = TestHelpers.CreateTestConfig();
+        var watermark = new WatermarkStrategy(EtlWatermarkType.FullLoad, null, null);
+        var executor = new EtlPipelineExecutor(_source, _loader);
+
+        var result = await executor.ExecuteAsync(config, watermark);
+
+        result.Success.Should().BeTrue("pipeline should succeed with special chars");
+        _loader.TotalRows.Should().Be(4, "all 4 rows with special chars should be loaded");
+
+        var loadedOrders = _loader.LoadedBatches
+            .SelectMany(b => b.Rows.Cast<DataRow>())
+            .Select(r => r["OrderNo"].ToString())
+            .ToList();
+
+        foreach (var expected in specialValues)
+        {
+            loadedOrders.Should().Contain(expected, $"Special char value '{expected}' should be preserved");
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

Adds 6 security boundary regression tests documenting that existing mechanisms correctly handle adversarial input. Purpose: lock in these guarantees so future refactors can't silently break them.

### Analysis Controller (4 tests)

| Test | Mechanism verified |
|------|--------------------|
| SQL injection string as filter value → correct row returned, no throw | Expression Tree passes values as LINQ params, never raw SQL |
| XSS payload as filter value → treated as plain string | Same Expression Tree guarantee |
| CSV export with XSS payload → value stored verbatim | CSV is plain text; no HTML-encoding needed or applied |
| xlsx export with XSS payload → `CellType.String` with literal value | NPOI stores cell content as data, not markup |

### ETL Pipeline (2 tests)

| Test | Mechanism verified |
|------|--------------------|
| Unicode values (CJK, emoji, Arabic) preserved verbatim | `DataTable` / `MockBulkLoader` copies strings without transformation |
| Special chars (newline, tab, quote, backslash) preserved | Same — no string sanitization in pipeline |

## Test plan

- [x] `dotnet test --filter TestCategory=Analysis` → 42/42 passed
- [x] ETL unit/pipeline tests → 104/104 passed
- [x] No production code changed — tests only

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)