### PR TITLE
feat(dashboard): KPI alert threshold coloring for risk control scenarios (#386)

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_dashboard.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_dashboard.js
@@ -307,6 +307,39 @@
         valueDiv.className = 'wtm-kpi-value';
         var val = data ? data.value : 0;
         valueDiv.textContent = Utils.formatValue(val, config.format, config.prefix);
+
+        // ── Threshold / alert coloring ─────────────────────────────────────
+        // config.thresholds: [{ value: Number, color: String, label?: String }]
+        // Supports ascending (warn/danger) and descending (below-safe) modes.
+        // config.thresholdDirection: 'above' (default) | 'below'
+        var thresholds = Array.isArray(config.thresholds) ? config.thresholds : [];
+        if (thresholds.length > 0) {
+            var direction = config.thresholdDirection === 'below' ? 'below' : 'above';
+            // Sort descending by value so we match the highest triggered level first
+            var sorted = thresholds.slice().sort(function (a, b) {
+                return direction === 'above' ? b.value - a.value : a.value - b.value;
+            });
+            var matched = null;
+            for (var t = 0; t < sorted.length; t++) {
+                var th = sorted[t];
+                if ((direction === 'above' && val >= th.value) ||
+                    (direction === 'below' && val <= th.value)) {
+                    matched = th;
+                    break;
+                }
+            }
+            if (matched) {
+                valueDiv.style.color = matched.color;
+                if (matched.label) {
+                    var alertSpan = document.createElement('span');
+                    alertSpan.className = 'wtm-kpi-alert-label';
+                    alertSpan.textContent = ' ' + matched.label;
+                    alertSpan.style.color = matched.color;
+                    alertSpan.style.fontSize = '0.7em';
+                    valueDiv.appendChild(alertSpan);
+                }
+            }
+        }
         
         container.appendChild(titleDiv);
         container.appendChild(valueDiv);

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/widget-renderers.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/widget-renderers.test.js
@@ -240,3 +240,114 @@ describe('WtmDashboard.WidgetRendererFactory', () => {
         expect(container.textContent).toMatch(/blocked|invalid/i);
     });
 });
+
+// ─── KPI threshold / alert coloring #386 ───────────────────────────────────
+describe('renderKpi threshold coloring #386', () => {
+    function makeKpiEnv() {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        container.children = [];
+        return { wd, mockDocument, container };
+    }
+
+    function kpiRender(wd, container, val, thresholds, direction) {
+        const config = { title: 'Risk', thresholds: thresholds };
+        if (direction) config.thresholdDirection = direction;
+        wd.WidgetRendererFactory.getRenderer('kpi')(container, { value: val }, config);
+    }
+
+    test('no thresholds — valueDiv has no color', () => {
+        const { wd, container } = makeKpiEnv();
+        kpiRender(wd, container, 5000, []);
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        expect(valueDiv).toBeDefined();
+        expect(valueDiv.style.color || '').toBe('');
+    });
+
+    test('value below all thresholds — no color applied', () => {
+        const { wd, container } = makeKpiEnv();
+        const thresholds = [
+            { value: 10000, color: '#faad14', label: '警告' },
+            { value: 50000, color: '#ff4d4f', label: '危險' }
+        ];
+        kpiRender(wd, container, 5000, thresholds);
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        expect(valueDiv.style.color || '').toBe('');
+    });
+
+    test('value exceeds warning threshold — yellow applied', () => {
+        const { wd, container } = makeKpiEnv();
+        const thresholds = [
+            { value: 10000, color: '#faad14', label: '警告' },
+            { value: 50000, color: '#ff4d4f', label: '危險' }
+        ];
+        kpiRender(wd, container, 20000, thresholds);
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        expect(valueDiv.style.color).toBe('#faad14');
+    });
+
+    test('value exceeds danger threshold — red applied (highest level wins)', () => {
+        const { wd, container } = makeKpiEnv();
+        const thresholds = [
+            { value: 10000, color: '#faad14', label: '警告' },
+            { value: 50000, color: '#ff4d4f', label: '危險' }
+        ];
+        kpiRender(wd, container, 60000, thresholds);
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        expect(valueDiv.style.color).toBe('#ff4d4f');
+    });
+
+    test('matched threshold with label — alert span appended', () => {
+        const { wd, container } = makeKpiEnv();
+        const thresholds = [{ value: 10000, color: '#faad14', label: '警告' }];
+        kpiRender(wd, container, 15000, thresholds);
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        const alertSpan = valueDiv.children && valueDiv.children.find(c => c.className === 'wtm-kpi-alert-label');
+        expect(alertSpan).toBeDefined();
+        expect(alertSpan.textContent).toContain('警告');
+        expect(alertSpan.style.color).toBe('#faad14');
+    });
+
+    test('threshold without label — no alert span', () => {
+        const { wd, container } = makeKpiEnv();
+        const thresholds = [{ value: 10000, color: '#faad14' }];
+        kpiRender(wd, container, 15000, thresholds);
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        const alertSpan = valueDiv.children && valueDiv.children.find(c => c.className === 'wtm-kpi-alert-label');
+        expect(alertSpan).toBeUndefined();
+    });
+
+    test('direction=below — color applied when value is at or below threshold', () => {
+        const { wd, container } = makeKpiEnv();
+        const thresholds = [
+            { value: 5000, color: '#faad14', label: '低水位警告' },
+            { value: 1000, color: '#ff4d4f', label: '危急' }
+        ];
+        kpiRender(wd, container, 3000, thresholds, 'below');
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        expect(valueDiv.style.color).toBe('#faad14');
+    });
+
+    test('direction=below — critical level when value drops further', () => {
+        const { wd, container } = makeKpiEnv();
+        const thresholds = [
+            { value: 5000, color: '#faad14', label: '低水位警告' },
+            { value: 1000, color: '#ff4d4f', label: '危急' }
+        ];
+        kpiRender(wd, container, 500, thresholds, 'below');
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        expect(valueDiv.style.color).toBe('#ff4d4f');
+    });
+
+    test('non-array thresholds config — gracefully ignored', () => {
+        const { wd, container } = makeKpiEnv();
+        expect(() => {
+            wd.WidgetRendererFactory.getRenderer('kpi')(container, { value: 99999 }, {
+                title: 'X',
+                thresholds: 'invalid'
+            });
+        }).not.toThrow();
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        expect(valueDiv.style.color || '').toBe('');
+    });
+});


### PR DESCRIPTION
## Summary

- **新增 KPI 告警閾值機制**：`renderKpi` 現在讀取 `config.thresholds` 並在數值超過閾值時套用顏色 + 標籤
- **支援雙向模式**：`direction='above'`（預設，數值超過觸發）和 `direction='below'`（低水位警示觸發）
- **最高等級優先**：多閾值時自動找出被觸發的最高等級（例如同時超過警告和危險，顯示危險）
- **向後相容**：無 `thresholds` 設定時行為完全不變

## Config 格式

```json
{
  "type": "kpi",
  "config": {
    "thresholds": [
      { "value": 10000000, "color": "#faad14", "label": "警告" },
      { "value": 50000000, "color": "#ff4d4f", "label": "危險" }
    ]
  }
}
```

低水位模式（流動性不足警示）：
```json
{
  "thresholdDirection": "below",
  "thresholds": [
    { "value": 5000000, "color": "#faad14", "label": "低水位警告" },
    { "value": 1000000, "color": "#ff4d4f", "label": "危急" }
  ]
}
```

## Test plan

- [x] 9 個 Jest 測試全通過：無閾值、未達閾值、警告級、危險級、有/無 label、direction=below、無效設定
- [x] 原有 `renderKpi creates DOM with value` 測試未受影響
- [x] 全套 JS tests pass

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)