### PR TITLE
fix(etl): count ExtractedRows from source before TransformFunc

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
@@ -75,19 +75,20 @@ public class EtlPipelineExecutor
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                // Count source rows before transform (for audit trail)
+                int extractedBatchRows = batch.Rows.Count;
+                totalExtracted += extractedBatchRows;
+
                 // Transform hook
                 var transformed = config.TransformFunc != null
                     ? config.TransformFunc(batch)
                     : batch;
 
-                int batchRows = transformed.Rows.Count;
-                totalExtracted += batchRows;
-
                 await _loader.BulkLoadAsync(
                     config.TargetConnectionString, config.StagingTable.TableName,
                     transformed, cancellationToken);
 
-                totalLoaded += batchRows;
+                totalLoaded += transformed.Rows.Count;
 
                 // 更新 watermark 暫存
                 if (watermark.Type != EtlWatermarkType.FullLoad && !string.IsNullOrEmpty(watermark.Column))

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EdgeCaseTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EdgeCaseTests.cs
@@ -101,9 +101,12 @@ public class EdgeCaseTests
         var result = await executor.ExecuteAsync(config, watermark);
 
         result.Success.Should().BeTrue();
+        // ExtractedRows must reflect source rows BEFORE transform (fix for #426)
+        result.ExtractedRows.Should().Be(1_000, "source had 1000 rows regardless of transform filtering");
         // Amount = 100 + (i % 1000), so values > 500 are i%1000 > 400 → 599 out of 1000
         result.LoadedRows.Should().BeLessThan(1_000);
         result.LoadedRows.Should().BeGreaterThan(0);
+        result.LoadedRows.Should().NotBe(result.ExtractedRows, "transform filtered some rows so counts should diverge");
         _loader.MergeCalled.Should().BeTrue();
     }
 
@@ -129,6 +132,8 @@ public class EdgeCaseTests
         var result = await executor.ExecuteAsync(config, watermark);
 
         result.Success.Should().BeTrue();
+        // ExtractedRows must reflect source rows BEFORE transform (fix for #426)
+        result.ExtractedRows.Should().Be(100, "source had 100 rows regardless of transform filtering all out");
         result.LoadedRows.Should().Be(0);
     }
 


### PR DESCRIPTION
## Summary

- `EtlExecutionResult.ExtractedRows` was counting rows **after** `TransformFunc`, making the audit trail wrong when transform filters rows out
- Fix: capture `batch.Rows.Count` **before** calling `TransformFunc` so `ExtractedRows` always reflects what was read from the source
- `LoadedRows` correctly reflects what was written to staging (post-transform)

## Changes

- `src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs` — separate pre/post transform row counting
- `test/WalkingTec.Mvvm.Etl.Test/Pipeline/EdgeCaseTests.cs` — add regression assertions: `ExtractedRows == 1000` when source has 1000 rows regardless of filtering

## Test plan

- [x] `Transform_filtering_reduces_loaded_rows` — now asserts `ExtractedRows == 1000` and `LoadedRows != ExtractedRows`
- [x] `Transform_filtering_all_rows_results_in_zero_loaded` — now asserts `ExtractedRows == 100`, `LoadedRows == 0`
- [x] All 9 EdgeCaseTests pass
- [x] Full suite: Core 872 ✅ / Mvc 38 ✅ / Admin 75 ✅ / ETL 121 ✅ / JS 379 ✅

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)