### PR TITLE
fix(dashboard): renderKpi shows 0 not undefined when data.value absent

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_dashboard.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_dashboard.js
@@ -305,7 +305,7 @@
         
         var valueDiv = document.createElement('div');
         valueDiv.className = 'wtm-kpi-value';
-        var val = data ? data.value : 0;
+        var val = (data && data.value != null) ? data.value : 0;
         valueDiv.textContent = Utils.formatValue(val, config.format, config.prefix);
 
         // ── Threshold / alert coloring ─────────────────────────────────────

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/widget-renderers.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/widget-renderers.test.js
@@ -124,6 +124,37 @@ describe('WtmDashboard.WidgetRendererFactory', () => {
         expect(container.children.some(c => c.textContent.indexOf('23.45%') >= 0)).toBe(true);
     });
 
+    test('renderKpi with data={} (missing value field) shows 0 not "undefined" (#435)', () => {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        wd.WidgetRendererFactory.getRenderer('kpi')(container, {}, { title: 'X' });
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        expect(valueDiv).toBeDefined();
+        expect(valueDiv.textContent).not.toBe('undefined');
+        expect(valueDiv.textContent).not.toContain('undefined');
+        expect(valueDiv.textContent).toBe('0');
+    });
+
+    test('renderKpi with data=null shows 0 not "undefined" (#435)', () => {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        wd.WidgetRendererFactory.getRenderer('kpi')(container, null, { title: 'X' });
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        expect(valueDiv).toBeDefined();
+        expect(valueDiv.textContent).not.toBe('undefined');
+        expect(valueDiv.textContent).toBe('0');
+    });
+
+    test('renderKpi with data.value=null shows 0 not "undefined" (#435)', () => {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        wd.WidgetRendererFactory.getRenderer('kpi')(container, { value: null }, { title: 'X' });
+        const valueDiv = container.children.find(c => c.className === 'wtm-kpi-value');
+        expect(valueDiv).toBeDefined();
+        expect(valueDiv.textContent).not.toBe('undefined');
+        expect(valueDiv.textContent).toBe('0');
+    });
+
     test('renderChart calls echarts.init', () => {
         const { wd, mockDocument, mockEcharts, capturedOptions } = makeEnv();
         const container = mockDocument.createElement('div');


### PR DESCRIPTION
## Summary

- `renderKpi()` used `data ? data.value : 0` — when `data = {}` or `data.value = null`, this passes `undefined` to `formatValue()`, which returns it unchanged, producing the literal string `"undefined"` in the DOM
- Fix: use `(data && data.value != null) ? data.value : 0` — mirrors the same guard already used in `renderProgress()`

## Root Cause

```js
// Before (bug)
var val = data ? data.value : 0;

// After (fix)
var val = (data && data.value != null) ? data.value : 0;
```

## Test Plan

- [x] `renderKpi with data={} (missing value field) shows 0 not "undefined"` ✅
- [x] `renderKpi with data=null shows 0 not "undefined"` ✅
- [x] `renderKpi with data.value=null shows 0 not "undefined"` ✅
- [x] Full JS suite: 382/382 passed ✅
- [x] All existing KPI threshold tests unchanged ✅

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)