### PR TITLE
fix(etl): TriggerNow returns 404 for non-existent JobId

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
@@ -107,6 +107,10 @@ public class _EtlJobController : BaseController
             await _scheduler.TriggerNowAsync(id);
             return Ok(new { success = true, message = "已觸發執行" });
         }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+        {
+            return NotFound(new { error = ex.Message });
+        }
         catch (InvalidOperationException ex)
         {
             return BadRequest(new { error = ex.Message });

--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlSchedulerService.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlSchedulerService.cs
@@ -59,7 +59,8 @@ public class EtlSchedulerService
             using var scope = _sp.CreateScope();
             var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
             var jobDef = await wtm.DC.Set<EtlJobDefinition>().FindAsync(jobId);
-            if (jobDef == null) return;
+            if (jobDef == null)
+                throw new InvalidOperationException($"Job {jobId} not found.");
             await ScheduleJobAsync(jobDef);
         }
 

--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
@@ -375,6 +375,21 @@ public class EtlJobControllerTests
     }
 
     [TestMethod]
+    public async Task TriggerNow_returns_404_when_job_not_found_in_db()
+    {
+        // Regression test for #432: TriggerNowAsync throws InvalidOperationException("Job X not found.")
+        // when the jobId does not exist in the database. Controller must surface 404, not 200.
+        var id = Guid.NewGuid();
+        _mockScheduler.Setup(x => x.TriggerNowAsync(id))
+            .ThrowsAsync(new InvalidOperationException($"Job {id} not found."));
+
+        var result = await _controller.TriggerNow(id) as NotFoundObjectResult;
+
+        Assert.IsNotNull(result, "Expected 404 NotFound when job does not exist");
+        Assert.AreEqual(404, result!.StatusCode);
+    }
+
+    [TestMethod]
     public async Task Pause_returns_400_when_scheduler_throws_InvalidOperationException()
     {
         var id = Guid.NewGuid();


### PR DESCRIPTION
## Summary

`TriggerNowAsync()` silently `return`ed when the `jobId` wasn't found in the database. The controller received a normal completion and responded with `200 OK "已觸發執行"` — misleading operators into thinking the job ran.

## Root Cause & Fix

| Layer | Before | After |
|-------|--------|-------|
| `EtlSchedulerService.TriggerNowAsync` | `if (jobDef == null) return;` (silent) | `throw new InvalidOperationException($"Job {id} not found.")` |
| `_EtlJobController.TriggerNow` | `catch InvalidOperationException → 400` | Added `when (ex.Message.Contains("not found")) → 404`; other cases still → 400 |

The "not found" discriminator keeps the existing pattern: scheduler errors (already running, paused, etc.) stay as 400; resource-missing errors become 404.

## Test Plan

- [x] `TriggerNow_returns_404_when_job_not_found_in_db` — new regression test ✅
- [x] `TriggerNow_returns_400_when_scheduler_throws_InvalidOperationException` — existing test still passes (non-"not found" message → 400) ✅
- [x] `TriggerNow_calls_scheduler` — happy path unchanged ✅
- [x] All EtlJobControllerTests: 25/25 ✅

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)