### PR TITLE
fix(test): ETL integration tests skip gracefully when DB unavailable

### DIFF
--- a/test/WalkingTec.Mvvm.Etl.Test/Integration/EndToEndPipelineTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Integration/EndToEndPipelineTests.cs
@@ -33,6 +33,8 @@ public class EndToEndPipelineTests : IntegrationTestBase
     [ClassInitialize]
     public static async Task ClassInit(TestContext _)
     {
+        if (!IsMssqlAvailable())
+            Assert.Inconclusive("MSSQL not available — skipping integration tests. Run: docker compose -f test/docker-compose.etl-test.yml up -d");
         await EnsureMssqlDatabaseAsync();
     }
 

--- a/test/WalkingTec.Mvvm.Etl.Test/Integration/IntegrationTestBase.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Integration/IntegrationTestBase.cs
@@ -157,6 +157,40 @@ public abstract class IntegrationTestBase
         return dt;
     }
 
+    /// <summary>
+    /// 探測 MSSQL 是否可連線。無法連線時測試應呼叫 Assert.Inconclusive()。
+    /// </summary>
+    protected static bool IsMssqlAvailable()
+    {
+        try
+        {
+            using var conn = new SqlConnection(MssqlConnectionString);
+            conn.Open();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 探測 Oracle 是否可連線。無法連線時測試應呼叫 Assert.Inconclusive()。
+    /// </summary>
+    protected static bool IsOracleAvailable()
+    {
+        try
+        {
+            using var conn = new Oracle.ManagedDataAccess.Client.OracleConnection(OracleConnectionString);
+            conn.Open();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static async Task ExecuteMssqlAsync(SqlConnection conn, string sql)
     {
         await using var cmd = conn.CreateCommand();

--- a/test/WalkingTec.Mvvm.Etl.Test/Integration/MssqlBulkLoaderIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Integration/MssqlBulkLoaderIntegrationTests.cs
@@ -30,6 +30,8 @@ public class MssqlBulkLoaderIntegrationTests : IntegrationTestBase
     [ClassInitialize]
     public static async Task ClassInit(TestContext _)
     {
+        if (!IsMssqlAvailable())
+            Assert.Inconclusive("MSSQL not available — skipping integration tests. Run: docker compose -f test/docker-compose.etl-test.yml up -d");
         await EnsureMssqlDatabaseAsync();
     }
 

--- a/test/WalkingTec.Mvvm.Etl.Test/Integration/OracleBulkLoaderIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Integration/OracleBulkLoaderIntegrationTests.cs
@@ -29,6 +29,13 @@ public class OracleBulkLoaderIntegrationTests : IntegrationTestBase
         new StagingColumn("UPDATEDAT", "TIMESTAMP")
     );
 
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        if (!IsOracleAvailable())
+            Assert.Inconclusive("Oracle not available — skipping integration tests. Run: docker compose -f test/docker-compose.etl-test.yml up -d");
+    }
+
     [TestInitialize]
     public async Task Setup()
     {

--- a/test/WalkingTec.Mvvm.Etl.Test/Integration/OracleEndToEndPipelineTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Integration/OracleEndToEndPipelineTests.cs
@@ -29,6 +29,13 @@ public class OracleEndToEndPipelineTests : IntegrationTestBase
         new StagingColumn("UPDATEDAT", "TIMESTAMP")
     );
 
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        if (!IsOracleAvailable())
+            Assert.Inconclusive("Oracle not available — skipping integration tests. Run: docker compose -f test/docker-compose.etl-test.yml up -d");
+    }
+
     [TestInitialize]
     public async Task Setup()
     {


### PR DESCRIPTION
## Summary

- ETL integration tests (`EndToEndPipelineTests`, `MssqlBulkLoaderIntegrationTests`, `OracleBulkLoaderIntegrationTests`, `OracleEndToEndPipelineTests`) were throwing `SqlException`/`OracleException` during setup and showing as **Failed**, masking real failures in CI
- Added `IsMssqlAvailable()` / `IsOracleAvailable()` connection probe methods to `IntegrationTestBase`
- Each class now calls `Assert.Inconclusive()` at `ClassInitialize` when the target DB is unreachable

## Result

| | Before | After |
|--|--------|-------|
| Failed | 17 | **0** |
| Skipped | 0 | **17** |
| Passed | 121 | 121 |

## Running with Docker

```bash
docker compose -f test/docker-compose.etl-test.yml up -d
dotnet test --filter "TestCategory=Integration"
```

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)