### PR TITLE
test(etl): add RBAC authorization tests for ETL controllers

### DIFF
--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlRbacTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlRbacTests.cs
@@ -1,0 +1,177 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Scheduling;
+using WalkingTec.Mvvm.Mvc;
+using WalkingTec.Mvvm.Test.Mock;
+
+namespace WalkingTec.Mvvm.Etl.Test.Controllers;
+
+/// <summary>
+/// ETL 控制器 RBAC 授權測試 — 對應 Issue #423
+///
+/// WTM RBAC 在 PrivilegeFilter（middleware）執行，非 controller 內部。
+/// 因此測試策略為：
+/// 1. Attribute 存在性測試 — 確認所有高風險 action 都有 [ActionDescription]，
+///    使 RBAC 系統能識別並保護它們。
+/// 2. Wtm.IsAccessable() 行為測試 — 直接測試 PrivilegeFilter 使用的授權邏輯，
+///    驗證未登入 / 無特權使用者無法存取 ETL 端點。
+/// </summary>
+[TestClass]
+public class EtlRbacTests
+{
+    // ─── Helper: ETL 高風險操作名稱 ─────────────────────────────────────────────
+
+    private static readonly string[] HighRiskJobActions =
+    {
+        "TriggerNow", "Pause", "Resume", "Abort", "SkipNext", "Reschedule",
+        "Create", "Edit", "Delete"
+    };
+
+    private static readonly string[] MonitorActions = { "Running", "Progress" };
+    private static readonly string[] RunLogActions  = { "Index", "Search", "Rerun" };
+
+    // ─── 1. Attribute 存在性測試 ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void EtlJobController_all_high_risk_actions_have_ActionDescription()
+    {
+        var type = typeof(_EtlJobController);
+        foreach (var name in HighRiskJobActions)
+        {
+            var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                              .Where(m => m.Name == name);
+            Assert.IsTrue(methods.Any(),
+                $"_EtlJobController 缺少 {name} 方法");
+
+            // At least one overload must carry [ActionDescription]
+            var hasAttr = methods.Any(m =>
+                m.IsDefined(typeof(ActionDescriptionAttribute), false) ||
+                type.IsDefined(typeof(ActionDescriptionAttribute), false));
+            Assert.IsTrue(hasAttr,
+                $"_EtlJobController.{name}（或其 Controller）缺少 [ActionDescription]，無法被 RBAC 識別");
+        }
+    }
+
+    [TestMethod]
+    public void EtlMonitorController_actions_have_ActionDescription()
+    {
+        var type = typeof(_EtlMonitorController);
+        Assert.IsTrue(type.IsDefined(typeof(ActionDescriptionAttribute), false),
+            "_EtlMonitorController 本身缺少 [ActionDescription]");
+
+        foreach (var name in MonitorActions)
+        {
+            var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                              .Where(m => m.Name == name);
+            Assert.IsTrue(methods.Any(),
+                $"_EtlMonitorController 缺少 {name} 方法");
+        }
+    }
+
+    [TestMethod]
+    public void EtlRunLogController_high_risk_action_Rerun_has_ActionDescription()
+    {
+        var type = typeof(_EtlRunLogController);
+        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                          .Where(m => m.Name == "Rerun");
+        Assert.IsTrue(methods.Any(),
+            "_EtlRunLogController 缺少 Rerun 方法");
+
+        var hasAttr = methods.Any(m =>
+            m.IsDefined(typeof(ActionDescriptionAttribute), false) ||
+            type.IsDefined(typeof(ActionDescriptionAttribute), false));
+        Assert.IsTrue(hasAttr,
+            "_EtlRunLogController.Rerun（或其 Controller）缺少 [ActionDescription]");
+    }
+
+    // ─── 2. Wtm.IsAccessable() — 無 FunctionPrivileges 使用者被拒 (→ 403) ──────
+    // Note: LoginUserInfo == null causes PrivilegeFilter to return 401; that code
+    // path is exercised by PrivilegeFilter itself (middleware level). Here we test
+    // the FunctionPrivileges == null branch (403), which is the same IsAccessable()
+    // logic used in both cases and is testable directly.
+
+    [TestMethod]
+    public void IsAccessable_returns_false_for_etl_url_when_user_has_empty_privileges()
+    {
+        // Explicit empty list (rather than null) — user is logged in but has no grants.
+        // PrivilegeFilter maps this to HTTP 403.
+        var wtm = MockWtmContext.CreateWtmContext();
+        wtm.LoginUserInfo!.FunctionPrivileges = new System.Collections.Generic.List<WalkingTec.Mvvm.Core.Support.Json.SimpleFunctionPri>();
+
+        Assert.IsFalse(wtm.IsAccessable("/_EtlJob/TriggerNow"),
+            "無授權使用者不應能存取 /_EtlJob/TriggerNow");
+        Assert.IsFalse(wtm.IsAccessable("/_EtlJob/Abort"),
+            "無授權使用者不應能存取 /_EtlJob/Abort");
+        Assert.IsFalse(wtm.IsAccessable("/_EtlMonitor/Running"),
+            "無授權使用者不應能存取 /_EtlMonitor/Running");
+        Assert.IsFalse(wtm.IsAccessable("/_EtlRunLog/Rerun"),
+            "無授權使用者不應能存取 /_EtlRunLog/Rerun");
+    }
+
+    // ─── 3. Wtm.IsAccessable() — 登入但無特權使用者被拒 (→ 403) ────────────────
+
+    [TestMethod]
+    public void IsAccessable_returns_false_for_etl_url_when_user_has_no_function_privileges()
+    {
+        // FunctionPrivileges == null means user has no page-level grants.
+        // PrivilegeFilter maps this to HTTP 403.
+        var wtm = MockWtmContext.CreateWtmContext();
+        // MockWtmContext sets LoginUserInfo with ITCode but no FunctionPrivileges
+        Assert.IsNull(wtm.LoginUserInfo?.FunctionPrivileges,
+            "MockWtmContext should create user with null FunctionPrivileges");
+
+        Assert.IsFalse(wtm.IsAccessable("/_EtlJob/TriggerNow"),
+            "無特權使用者不應能存取 /_EtlJob/TriggerNow");
+        Assert.IsFalse(wtm.IsAccessable("/_EtlJob/Pause"),
+            "無特權使用者不應能存取 /_EtlJob/Pause");
+        Assert.IsFalse(wtm.IsAccessable("/_EtlJob/Resume"),
+            "無特權使用者不應能存取 /_EtlJob/Resume");
+        Assert.IsFalse(wtm.IsAccessable("/_EtlJob/Abort"),
+            "無特權使用者不應能存取 /_EtlJob/Abort");
+        Assert.IsFalse(wtm.IsAccessable("/_EtlJob/Delete"),
+            "無特權使用者不應能存取 /_EtlJob/Delete");
+        Assert.IsFalse(wtm.IsAccessable("/_EtlMonitor/Running"),
+            "無特權使用者不應能存取 /_EtlMonitor/Running");
+        Assert.IsFalse(wtm.IsAccessable("/_EtlRunLog/Rerun"),
+            "無特權使用者不應能存取 /_EtlRunLog/Rerun");
+    }
+
+    // ─── 4. Wtm.IsAccessable() — ETL URL 不在 AllAccessUrls（非 public）──────
+
+    [TestMethod]
+    public void ETL_urls_are_not_in_AllAccessUrls_by_default()
+    {
+        var wtm = MockWtmContext.CreateWtmContext();
+        var allPublic = wtm.GlobaInfo.AllAccessUrls ?? new System.Collections.Generic.List<string>();
+
+        var etlUrls = new[]
+        {
+            "/_EtlJob/TriggerNow",
+            "/_EtlJob/Abort",
+            "/_EtlJob/Delete",
+            "/_EtlMonitor/Running",
+            "/_EtlRunLog/Rerun",
+        };
+
+        foreach (var url in etlUrls)
+        {
+            Assert.IsFalse(allPublic.Contains(url, StringComparer.OrdinalIgnoreCase),
+                $"ETL 端點 {url} 不應在 AllAccessUrls（公開）列表中");
+        }
+    }
+
+    // ─── 5. IsQuickDebug 預設為 false（確保 RBAC 預設啟用）────────────────────
+
+    [TestMethod]
+    public void MockWtmContext_IsQuickDebug_is_false_by_default()
+    {
+        var wtm = MockWtmContext.CreateWtmContext();
+        Assert.IsFalse(wtm.ConfigInfo?.IsQuickDebug ?? false,
+            "測試環境 IsQuickDebug 預設應為 false，否則 RBAC 全部繞過");
+    }
+}


### PR DESCRIPTION
## Summary

ETL controllers had zero RBAC/authorization tests despite handling high-risk operations (TriggerNow, Pause, Abort, Delete, Rerun).

## Approach

WTM RBAC runs in `PrivilegeFilter` (middleware), not inline in controller actions. Tests target two distinct layers:

**1. ActionDescription attribute presence** — verifies all high-risk actions in `_EtlJobController`, `_EtlMonitorController`, and `_EtlRunLogController` carry `[ActionDescription]`, which is what WTM's RBAC system uses to register and protect actions.

**2. `Wtm.IsAccessable()` behavior** — tests the actual authorization logic that `PrivilegeFilter` delegates to:
- `FunctionPrivileges == null` → `IsAccessable` returns false (403 scenario)
- Empty `FunctionPrivileges` list → same result
- ETL URLs not in `AllAccessUrls` by default (not publicly accessible)
- `IsQuickDebug` defaults to false (RBAC not bypassed in test context)

## Tests Added (`EtlRbacTests.cs` — 7 tests)

| Test | Covers |
|------|--------|
| `EtlJobController_all_high_risk_actions_have_ActionDescription` | TriggerNow/Pause/Resume/Abort/SkipNext/Reschedule/Create/Edit/Delete registered with RBAC |
| `EtlMonitorController_actions_have_ActionDescription` | Running/Progress registered |
| `EtlRunLogController_high_risk_action_Rerun_has_ActionDescription` | Rerun registered |
| `IsAccessable_returns_false_for_etl_url_when_user_has_no_function_privileges` | User with null FunctionPrivileges denied (→ 403) |
| `IsAccessable_returns_false_for_etl_url_when_user_has_empty_privileges` | User with empty grants denied (→ 403) |
| `ETL_urls_are_not_in_AllAccessUrls_by_default` | ETL endpoints are not publicly accessible |
| `MockWtmContext_IsQuickDebug_is_false_by_default` | RBAC is active in test context |

All 7 tests pass. No production code changes.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)