### PR TITLE
test(analysis): multi-condition AND filter coverage (#440)

### DIFF
--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -840,6 +840,42 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
 
         [TestMethod]
         [TestCategory("Analysis")]
+        public void Query_with_multiple_filter_conditions_AND_logic_returns_narrowed_result()
+        {
+            // Arrange — 3 records; only 華東+Amount>150 (i.e. 華東 B=200) should survive AND
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華東", Category = "A", Amount = 100m },
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華東", Category = "B", Amount = 200m },
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華南", Category = "A", Amount = 300m },
+            };
+
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(SaleRecordListVM).FullName,
+                Dimensions = new List<string> { "Region" },
+                Measures   = new List<MeasureRequest>
+                {
+                    new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum }
+                },
+                Filters = new List<FilterCondition>
+                {
+                    new FilterCondition { Field = "Region", Operator = FilterOperator.Eq, Value = "華東" },
+                    new FilterCondition { Field = "Amount", Operator = FilterOperator.Gt, Value = "150" }
+                }
+            };
+
+            var result = CreateController().Query(req) as JsonResult;
+            Assert.IsNotNull(result, "多條件 AND filter 應回傳 200");
+
+            var response = result.Value as AnalysisQueryResponse;
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, response.Rows.Count, "AND: Region=華東 AND Amount>150 → 只剩 1 列");
+            Assert.AreEqual(200m, Convert.ToDecimal(response.Rows[0]["Amount_Sum"]));
+        }
+
+        [TestMethod]
+        [TestCategory("Analysis")]
         public void Query_filter_with_non_whitelist_field_returns_400()
         {
             _testData = new List<SaleRecord>

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
@@ -425,6 +425,43 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.IsFalse(result.Truncated);
         }
 
+        /// <summary>多條件 AND：Region=華東 AND Amount&gt;150 → 只剩華東 B=200</summary>
+        [TestMethod]
+        public void Filter_multiple_conditions_AND_logic_narrows_result()
+        {
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                filters: new[] {
+                    ("Region", FilterOperator.Eq, "華東"),   // 排除華南 A=300
+                    ("Amount", FilterOperator.Gt, "150")    // 排除華東 A=100
+                });
+
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            Assert.AreEqual(1, result.Rows.Count, "AND: 只有華東 Amount>150 的一列應通過");
+            Assert.AreEqual(200m, Convert.ToDecimal(result.Rows[0]["Amount_Sum"]));
+        }
+
+        /// <summary>三條件 AND：Region=華東 AND Amount&gt;=100 AND Amount&lt;200 → 只剩華東 A=100</summary>
+        [TestMethod]
+        public void Filter_three_conditions_AND_logic_all_must_match()
+        {
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                filters: new[] {
+                    ("Region", FilterOperator.Eq,  "華東"),
+                    ("Amount", FilterOperator.Gte, "100"),
+                    ("Amount", FilterOperator.Lt,  "200")
+                });
+
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            Assert.AreEqual(1, result.Rows.Count, "AND: Region=華東 AND 100≤Amount<200 → 只有華東 A=100");
+            Assert.AreEqual(100m, Convert.ToDecimal(result.Rows[0]["Amount_Sum"]));
+        }
+
         // ─── AggregateFunc 分支 ────────────────────────────────────────────────
 
         /// <summary>Count 聚合：華東有 2 筆 → Count=2</summary>


### PR DESCRIPTION
## Summary

- Add 2 engine-level tests for `Expression.AndAlso` chain in `AnalysisQueryEngineTests`: two-condition AND and three-condition AND
- Add 1 controller-level end-to-end test in `AnalysisControllerTests` verifying the full JSON → FilterCondition → engine path

## Test plan
- [x] `Filter_multiple_conditions_AND_logic_narrows_result` — Region=華東 AND Amount>150 → 1 row (Sum=200)
- [x] `Filter_three_conditions_AND_logic_all_must_match` — Region=華東 AND Amount>=100 AND Amount<200 → 1 row (Sum=100)
- [x] `Query_with_multiple_filter_conditions_AND_logic_returns_narrowed_result` — controller integration of two-condition AND
- [x] No production code changes; pure test coverage gap closure

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)