### PR TITLE
test(analysis): verify Excel numeric format is exactly #,##0.00 (#437)

### DIFF
--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisExcelExporterTests.cs
@@ -482,6 +482,28 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
         [TestMethod]
+        public void Export_numeric_columns_use_comma_separated_two_decimal_format()
+        {
+            // #437: verify exact format string is "#,##0.00" (thousands separator + 2 decimals)
+            var resp = MakeResponse(
+                new List<string> { "Region", "Amount_Sum" },
+                new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "North", ["Amount_Sum"] = 1_234_567.89m }
+                });
+
+            var wb = OpenWorkbook(AnalysisExcelExporter.Export(resp));
+            var sheet = wb.GetSheetAt(0);
+            var numericCell = sheet.GetRow(1).GetCell(1); // Amount_Sum
+
+            Assert.IsNotNull(numericCell.CellStyle);
+            var xssfStyle = (NPOI.XSSF.UserModel.XSSFCellStyle)numericCell.CellStyle;
+            var formatStr = xssfStyle.GetDataFormatString();
+            Assert.AreEqual("#,##0.00", formatStr,
+                "Numeric measure columns must use '#,##0.00' format (thousands separator + 2 decimals)");
+        }
+
+        [TestMethod]
         public void Export_string_columns_do_not_have_numeric_format()
         {
             var resp = MakeResponse(


### PR DESCRIPTION
## Summary

- Add `Export_numeric_columns_use_comma_separated_two_decimal_format` test
- Downcasts to `XSSFCellStyle` to call `GetDataFormatString()` and assert exact `"#,##0.00"` format string

## Test plan
- [x] Test passes — format string confirmed as `#,##0.00`
- [x] If a future change uses `#,##0` or `0`, the test will catch the regression

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)