### PR TITLE
test(analysis): prior period (MoM) comparison integration test (#442)

### DIFF
--- a/test/WalkingTec.Mvvm.Core.Test/Integration/CfoFinancialDashboardIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/CfoFinancialDashboardIntegrationTests.cs
@@ -1121,6 +1121,71 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
         }
 
         // ═══════════════════════════════════════════════════════════════════
+        // 跨期比較 (#442)
+        // ═══════════════════════════════════════════════════════════════════
+
+        [TestMethod]
+        [Description("月結報表：2026-01 vs 2025-01 同部門收入比較，MoM% 正確計算 (#442)")]
+        public async Task CFO_MonthlyReport_PriorPeriodComparison_MomPercentCorrect()
+        {
+            var request = new WidgetDataRequest
+            {
+                Parameters = new Dictionary<string, string>
+                {
+                    ["listVmType"] = FinancialTxVmType,
+                    ["dimensions"] = JsonSerializer.Serialize(new[] { "Department" }),
+                    ["measures"] = JsonSerializer.Serialize(new[]
+                    {
+                        new { Field = "Amount", Func = AggregateFunc.Sum }
+                    })
+                }
+            };
+
+            // 2025-01 期：業務部 80_000，財務部 10_000
+            FinancialTransactionListVM.TestData = new List<FinancialTransaction>
+            {
+                new() { ID = Guid.NewGuid(), Department = "業務部", Amount = 80_000m,
+                        TransactionDate = new DateTime(2025, 1, 15), Currency = "TWD",
+                        ExchangeRate = 1m, AmountTwd = 80_000m, NetProfit = 8_000m },
+                new() { ID = Guid.NewGuid(), Department = "財務部", Amount = 10_000m,
+                        TransactionDate = new DateTime(2025, 1, 10), Currency = "TWD",
+                        ExchangeRate = 1m, AmountTwd = 10_000m, NetProfit = 1_000m },
+            };
+            var jan2025 = await CreateAnalysisDataSource().GetDataAsync(request);
+
+            // 2026-01 期：業務部 +25% → 100_000，財務部 不變 10_000
+            FinancialTransactionListVM.TestData = new List<FinancialTransaction>
+            {
+                new() { ID = Guid.NewGuid(), Department = "業務部", Amount = 100_000m,
+                        TransactionDate = new DateTime(2026, 1, 15), Currency = "TWD",
+                        ExchangeRate = 1m, AmountTwd = 100_000m, NetProfit = 10_000m },
+                new() { ID = Guid.NewGuid(), Department = "財務部", Amount = 10_000m,
+                        TransactionDate = new DateTime(2026, 1, 10), Currency = "TWD",
+                        ExchangeRate = 1m, AmountTwd = 10_000m, NetProfit = 1_000m },
+            };
+            var jan2026 = await CreateAnalysisDataSource().GetDataAsync(request);
+
+            // Assert — 結構一致（相同 Columns）
+            jan2025.Columns.Should().BeEquivalentTo(jan2026.Columns,
+                because: "跨期查詢應回傳相同的欄位結構，否則比較邏輯會 crash");
+
+            // Assert — MoM% 計算正確
+            var prev = Convert.ToDecimal(jan2025.Rows!.First(r => r["Department"]?.ToString() == "業務部")["Amount_Sum"]);
+            var curr = Convert.ToDecimal(jan2026.Rows!.First(r => r["Department"]?.ToString() == "業務部")["Amount_Sum"]);
+            var momPct = (curr - prev) / prev * 100;
+
+            prev.Should().Be(80_000m);
+            curr.Should().Be(100_000m);
+            momPct.Should().BeApproximately(25m, 0.01m,
+                because: "業務部 2026-01 vs 2025-01 應成長 25%");
+
+            // Assert — 財務部 MoM% = 0（金額未變）
+            var prevFin = Convert.ToDecimal(jan2025.Rows!.First(r => r["Department"]?.ToString() == "財務部")["Amount_Sum"]);
+            var currFin = Convert.ToDecimal(jan2026.Rows!.First(r => r["Department"]?.ToString() == "財務部")["Amount_Sum"]);
+            prevFin.Should().Be(currFin, because: "財務部金額未變動，MoM% 應為 0");
+        }
+
+        // ═══════════════════════════════════════════════════════════════════
         // 測試資料工廠
         // ═══════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Add `CFO_MonthlyReport_PriorPeriodComparison_MomPercentCorrect` integration test:
- Executes two queries with different period data (2025-01 vs 2026-01)
- Verifies cross-period queries return the same column structure
- Verifies 業務部 MoM% = 25%, 財務部 unchanged

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)