### PR TITLE
test(dashboard): add boundary tests for data: and vbscript: embed URL schemes

### DIFF
--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/widget-renderers.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/widget-renderers.test.js
@@ -239,6 +239,30 @@ describe('WtmDashboard.WidgetRendererFactory', () => {
         expect(hasIframe).toBeFalsy();
         expect(container.textContent).toMatch(/blocked|invalid/i);
     });
+
+    test('renderEmbed rejects data: URLs (#434)', () => {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        const config = { url: 'data:text/html,<script>alert(1)</script>' };
+
+        wd.WidgetRendererFactory.getRenderer('embed')(container, {}, config);
+
+        const hasIframe = container.children && container.children.some(c => c.tag === 'iframe');
+        expect(hasIframe).toBeFalsy();
+        expect(container.textContent).toMatch(/blocked|invalid/i);
+    });
+
+    test('renderEmbed rejects vbscript: URLs (#434)', () => {
+        const { wd, mockDocument } = makeEnv();
+        const container = mockDocument.createElement('div');
+        const config = { url: 'vbscript:msgbox(1)' };
+
+        wd.WidgetRendererFactory.getRenderer('embed')(container, {}, config);
+
+        const hasIframe = container.children && container.children.some(c => c.tag === 'iframe');
+        expect(hasIframe).toBeFalsy();
+        expect(container.textContent).toMatch(/blocked|invalid/i);
+    });
 });
 
 // ─── KPI threshold / alert coloring #386 ───────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `renderEmbed rejects data: URLs` — verifies HTML data URL injection is blocked
- Adds `renderEmbed rejects vbscript: URLs` — verifies legacy VBScript scheme is blocked
- Both tests mirror the existing `javascript:` rejection pattern

## Test plan
- [x] `npm test -- --testPathPattern=widget-renderers` → 28/28 pass

Closes #434