### PR TITLE
feat(analysis): add NotEq, NotContains, NotIn filter operators

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -253,7 +253,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 Expression? filterExpr = null;
                 try
                 {
-                    if (f.Operator == FilterOperator.In)
+                    if (f.Operator == FilterOperator.In || f.Operator == FilterOperator.NotIn)
                     {
                         System.Collections.IEnumerable? values = null;
                         if (f.Value is string s)
@@ -265,15 +265,15 @@ namespace WalkingTec.Mvvm.Core.Analysis
                             values = f.Value as System.Collections.IEnumerable;
                         }
 
-                        if (values == null) throw new InvalidOperationException("Value for 'In' operator must be an array, list or comma-separated string.");
-                        
+                        if (values == null) throw new InvalidOperationException("Value for 'In'/'NotIn' operator must be an array, list or comma-separated string.");
+
                         var list = new System.Collections.ArrayList();
                         foreach (var v in values)
                         {
                             list.Add(ChangeType(v, underlyingType));
                         }
-                        if (list.Count == 0) throw new InvalidOperationException("'In' operator requires at least one value.");
-                        if (list.Count > 100) throw new InvalidOperationException("'In' operator supports up to 100 values.");
+                        if (list.Count == 0) throw new InvalidOperationException("'In'/'NotIn' operator requires at least one value.");
+                        if (list.Count > 100) throw new InvalidOperationException("'In'/'NotIn' operator supports up to 100 values.");
 
                         var typedList = Array.CreateInstance(underlyingType, list.Count);
                         list.CopyTo(typedList);
@@ -284,25 +284,28 @@ namespace WalkingTec.Mvvm.Core.Analysis
                             .MakeGenericMethod(underlyingType);
 
                         Expression propForIn = prop;
+                        Expression inExpr;
                         if (Nullable.GetUnderlyingType(targetType) != null)
                         {
                             propForIn = Expression.Property(prop, "Value");
-                            filterExpr = Expression.AndAlso(
+                            inExpr = Expression.AndAlso(
                                 Expression.NotEqual(prop, Expression.Constant(null, targetType)),
                                 Expression.Call(containsMethod, listConst, propForIn)
                             );
                         }
                         else
                         {
-                            filterExpr = Expression.Call(containsMethod, listConst, propForIn);
+                            inExpr = Expression.Call(containsMethod, listConst, propForIn);
                         }
+                        filterExpr = f.Operator == FilterOperator.NotIn ? Expression.Not(inExpr) : inExpr;
                     }
-                    else if (f.Operator == FilterOperator.Contains)
+                    else if (f.Operator == FilterOperator.Contains || f.Operator == FilterOperator.NotContains)
                     {
                         if (targetType != typeof(string))
-                            throw new InvalidOperationException($"'Contains' operator is only supported for string fields, not '{targetType.Name}'.");
+                            throw new InvalidOperationException($"'Contains'/'NotContains' operator is only supported for string fields, not '{targetType.Name}'.");
                         var val = Expression.Constant(f.Value?.ToString() ?? "");
-                        filterExpr = Expression.Call(prop, typeof(string).GetMethod("Contains", new[] { typeof(string) })!, val);
+                        Expression containsExpr = Expression.Call(prop, typeof(string).GetMethod("Contains", new[] { typeof(string) })!, val);
+                        filterExpr = f.Operator == FilterOperator.NotContains ? Expression.Not(containsExpr) : containsExpr;
                     }
                     else
                     {
@@ -316,6 +319,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
                         Expression cmp = f.Operator switch
                         {
                             FilterOperator.Eq => Expression.Equal(propForCmp, val),
+                            FilterOperator.NotEq => Expression.NotEqual(propForCmp, val),
                             FilterOperator.Gt => Expression.GreaterThan(propForCmp, val),
                             FilterOperator.Gte => Expression.GreaterThanOrEqual(propForCmp, val),
                             FilterOperator.Lt => Expression.LessThan(propForCmp, val),

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryRequest.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryRequest.cs
@@ -62,6 +62,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
     /// </summary>
     public enum FilterOperator
     {
-        Eq, Gt, Gte, Lt, Lte, Contains, In
+        Eq, Gt, Gte, Lt, Lte, Contains, In,
+        NotEq, NotContains, NotIn
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -825,13 +825,16 @@
     // ─── Ad-hoc 篩選條件 ─────────────────────────────────────────────────────
 
     var _FILTER_OPS = [
-        { value: 'Eq',       label: '等於' },
-        { value: 'Gt',       label: '大於' },
-        { value: 'Gte',      label: '大於等於' },
-        { value: 'Lt',       label: '小於' },
-        { value: 'Lte',      label: '小於等於' },
-        { value: 'Contains', label: '包含' },
-        { value: 'In',       label: 'In' }
+        { value: 'Eq',          label: '等於' },
+        { value: 'NotEq',       label: '不等於' },
+        { value: 'Gt',          label: '大於' },
+        { value: 'Gte',         label: '大於等於' },
+        { value: 'Lt',          label: '小於' },
+        { value: 'Lte',         label: '小於等於' },
+        { value: 'Contains',    label: '包含' },
+        { value: 'NotContains', label: '不包含' },
+        { value: 'In',          label: 'In' },
+        { value: 'NotIn',       label: 'Not In' }
     ];
 
     /**

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
@@ -285,6 +285,68 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.ThrowsException<InvalidOperationException>(() => Engine().Execute(Q(), req, _whitelist));
         }
 
+        // ─── NotEq / NotContains / NotIn (#428) ──────────────────────────────
+
+        [TestMethod]
+        public void Filter_NotEq_excludes_matching_rows()
+        {
+            // Baseline data: 華東(100), 華東(200), 華南(300)
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                filters: new[] { ("Region", FilterOperator.NotEq, "華東") });
+
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            Assert.IsFalse(result.Rows.Any(r => r["Region"]?.ToString() == "華東"),
+                "NotEq 應排除 '華東'");
+            Assert.IsTrue(result.Rows.Any(r => r["Region"]?.ToString() == "華南"),
+                "NotEq 應保留 '華南'");
+        }
+
+        [TestMethod]
+        public void Filter_NotContains_excludes_matching_rows()
+        {
+            // "華東" contains "東" → excluded; "華南" does not → retained
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                filters: new[] { ("Region", FilterOperator.NotContains, "東") });
+
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            Assert.IsFalse(result.Rows.Any(r => r["Region"]?.ToString()?.Contains("東") == true),
+                "NotContains '東' 應排除所有含 '東' 的地區");
+            Assert.IsTrue(result.Rows.Any(r => r["Region"]?.ToString() == "華南"),
+                "NotContains 應保留不含 '東' 的地區（華南）");
+        }
+
+        [TestMethod]
+        public void Filter_NotIn_excludes_listed_values()
+        {
+            // NotIn 華東,華南 → all rows excluded
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                filters: new[] { ("Region", FilterOperator.NotIn, "華東,華南") });
+
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            Assert.AreEqual(0, result.Rows.Count,
+                "NotIn 華東,華南 應排除全部資料列");
+        }
+
+        [TestMethod]
+        public void Filter_NotContains_on_non_string_field_throws()
+        {
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) },
+                filters: new[] { ("Amount", FilterOperator.NotContains, "100") });
+
+            Assert.ThrowsException<InvalidOperationException>(() => Engine().Execute(Q(), req, _whitelist));
+        }
+
         // ─── SQL Injection 回歸保護 ────────────────────────────────────────────
         //
         // Expression Tree 在結構上防止 SQL injection：filter value 轉為

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -2838,10 +2838,10 @@ describe('#298 Ad-hoc filter UI', () => {
 
         waReq.addFilterRow(gridId);
         const opSel = panel.querySelector('.analysis-filter-op');
-        expect(opSel.options.length).toBe(7);
+        expect(opSel.options.length).toBe(10);
 
         const opValues = Array.from(opSel.options).map(o => o.value);
-        expect(opValues).toEqual(['Eq', 'Gt', 'Gte', 'Lt', 'Lte', 'Contains', 'In']);
+        expect(opValues).toEqual(['Eq', 'NotEq', 'Gt', 'Gte', 'Lt', 'Lte', 'Contains', 'NotContains', 'In', 'NotIn']);
         idSpy.mockRestore();
     });
 });


### PR DESCRIPTION
## Summary
- Adds `NotEq`, `NotContains`, `NotIn` to `FilterOperator` enum
- `AnalysisQueryEngine`: extends expression builder to handle all three — `NotEq` via `Expression.NotEqual`, `NotContains` via `Expression.Not(string.Contains)`, `NotIn` via `Expression.Not(Enumerable.Contains)`
- `framework_analysis.js`: adds the 3 new operators to `_FILTER_OPS` UI list with Traditional Chinese labels

## Motivation
BA usability: "exclude" logic (排除已沖銷交易、排除 VIP 客戶) previously required multi-query workarounds. Now expressible directly in a single filter condition.

## Test plan
- [x] 4 MSTest: `Filter_NotEq`, `Filter_NotContains`, `Filter_NotIn`, `Filter_NotContains_on_non_string_throws` → 4/4 pass
- [x] JS test updated for new operator count (7→10) → 252/252 pass

Closes #428