### PR TITLE
feat(dashboard): add inferChartType auto chart type selection

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_dashboard.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_dashboard.js
@@ -354,23 +354,56 @@
         }
     }
 
+    /**
+     * Infers the most appropriate ECharts series type when config.chartType is absent.
+     *
+     * Rules (applied in order):
+     *  1. Time dimension (column name contains year/month/quarter/week/day/date keywords
+     *     or follows yyyy-MM / yyyyMM / yyyyQn patterns) → 'line'
+     *  2. Single dimension + single measure + ≤ 8 distinct category values → 'pie'
+     *  3. Everything else → 'bar'
+     */
+    function inferChartType(config, data) {
+        if (config && config.chartType) return config.chartType;
+        if (!data || !data.columns || !data.rows) return 'bar';
+
+        var dimField = data.columns[0];
+        var rowCount = data.rows.length;
+
+        // Rule 1: time-like dimension name
+        var timeKeywords = /year|month|quarter|week|day|date|年|月|季|週|日/i;
+        var timePattern = /^\d{4}[-/]?\d{0,2}$|^Q[1-4]$/i;
+        if (dimField && timeKeywords.test(dimField)) return 'line';
+        if (rowCount > 0) {
+            var sample = String(data.rows[0][dimField] || '');
+            if (timePattern.test(sample.trim())) return 'line';
+        }
+
+        // Rule 2: few categories → pie
+        if (data.columns.length === 2 && rowCount > 0 && rowCount <= 8) return 'pie';
+
+        return 'bar';
+    }
+
     function renderChart(container, data, config) {
         if (!global.echarts) return;
         var chart = global.echarts.init(container);
-        
+
         // Simple fallback
         if (!data || !data.columns || !data.rows) return;
-        
+
         var xAxisData = [];
         var seriesData = [];
         var dimField = data.columns[0];
         var msrField = data.columns[1];
-        
+
         for (var i = 0; i < data.rows.length; i++) {
             xAxisData.push(data.rows[i][dimField]);
             seriesData.push(data.rows[i][msrField]);
         }
-        
+
+        var resolvedType = inferChartType(config, data);
+
         var option = {
             xAxis: {
                 type: 'category',
@@ -381,10 +414,10 @@
             },
             series: [{
                 data: seriesData,
-                type: config.chartType || 'bar'
+                type: resolvedType
             }]
         };
-        
+
         chart.setOption(option);
     }
 
@@ -832,7 +865,8 @@
         _internal: {
             detectBreakpoint: detectBreakpoint,
             applyBreakpointToLayout: applyBreakpointToLayout,
-            BREAKPOINTS: BREAKPOINTS
+            BREAKPOINTS: BREAKPOINTS,
+            inferChartType: inferChartType
         }
     };
 

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/widget-renderers.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/dashboard/widget-renderers.test.js
@@ -351,3 +351,57 @@ describe('renderKpi threshold coloring #386', () => {
         expect(valueDiv.style.color || '').toBe('');
     });
 });
+
+// ─── inferChartType auto-selection (#431) ─────────────────────────────────
+describe('inferChartType auto chart type selection (#431)', () => {
+    function infer(config, data) {
+        const { wd } = makeEnv();
+        return wd._internal.inferChartType(config, data);
+    }
+
+    const twoColData = (dimField, dimValues) => ({
+        columns: [dimField, 'Amount_Sum'],
+        rows: dimValues.map(v => ({ [dimField]: v, Amount_Sum: 100 }))
+    });
+
+    test('explicit chartType is always honoured', () => {
+        expect(infer({ chartType: 'scatter' }, twoColData('Region', ['A']))).toBe('scatter');
+    });
+
+    test('time keyword in dim name → line', () => {
+        expect(infer({}, twoColData('month', ['2024-01']))).toBe('line');
+        expect(infer({}, twoColData('Year', ['2024']))).toBe('line');
+        expect(infer({}, twoColData('date', ['2024-01-01']))).toBe('line');
+        expect(infer({}, twoColData('月份', ['2024-01']))).toBe('line');
+    });
+
+    test('time-pattern value in first row → line', () => {
+        expect(infer({}, twoColData('Period', ['2024-01']))).toBe('line');
+        expect(infer({}, twoColData('Period', ['202401']))).toBe('line');
+    });
+
+    test('≤8 categories, 2 columns → pie', () => {
+        const vals = ['A', 'B', 'C', 'D', 'E'];
+        expect(infer({}, twoColData('Category', vals))).toBe('pie');
+    });
+
+    test('exactly 8 categories → pie', () => {
+        const vals = ['A','B','C','D','E','F','G','H'];
+        expect(infer({}, twoColData('Category', vals))).toBe('pie');
+    });
+
+    test('>8 categories → bar', () => {
+        const vals = Array.from({ length: 9 }, (_, i) => 'C' + i);
+        expect(infer({}, twoColData('Category', vals))).toBe('bar');
+    });
+
+    test('missing data → bar', () => {
+        expect(infer({}, null)).toBe('bar');
+        expect(infer({}, { columns: [], rows: [] })).toBe('bar');
+    });
+
+    test('no config and no chartType → bar for many categories', () => {
+        const vals = Array.from({ length: 15 }, (_, i) => 'R' + i);
+        expect(infer(null, twoColData('Region', vals))).toBe('bar');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `inferChartType(config, data)` pure function with three rules:
  1. Time-like dimension name (year/month/date/週/月 etc.) → `line`
  2. Time-pattern value in first row (2024-01, 202401) → `line`
  3. ≤8 distinct category values (2-column data) → `pie`
  4. Otherwise → `bar`
- `renderChart` now calls `inferChartType` instead of `config.chartType || 'bar'`
- Exposes `inferChartType` via `WtmDashboard._internal` for testability

## Test plan
- [x] 8 Jest tests covering all inference rules + edge cases → 34/34 pass in widget-renderers.test.js

Closes #431