### PR TITLE
feat(etl): add CompositeEtlSource for multi-source union pattern

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Pipeline/Sources/CompositeEtlSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/Sources/CompositeEtlSource.cs
@@ -1,0 +1,64 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline.Sources;
+
+/// <summary>
+/// An <see cref="IEtlSource"/> that unions data from multiple inner sources.
+/// Each inner source is paired with its own connection string and query template,
+/// so heterogeneous databases can be merged in a single ETL job.
+///
+/// Usage:
+/// <code>
+/// var composite = new CompositeEtlSource(new[]
+/// {
+///     ("Server=db1;...", "SELECT * FROM Orders",  new MssqlSource()),
+///     ("Server=db2;...", "SELECT * FROM Archive", new MssqlSource()),
+/// });
+/// </code>
+///
+/// Note: all inner sources must produce compatible schemas (same column names and types)
+/// for the downstream <see cref="IBulkLoader"/> to merge them correctly.
+/// </summary>
+public sealed class CompositeEtlSource : IEtlSource
+{
+    private readonly IReadOnlyList<(string ConnectionString, string QueryTemplate, IEtlSource Source)> _sources;
+
+    public CompositeEtlSource(
+        IEnumerable<(string ConnectionString, string QueryTemplate, IEtlSource Source)> sources)
+    {
+        _sources = new List<(string, string, IEtlSource)>(sources);
+    }
+
+    /// <summary>
+    /// Yields all batches from each inner source in declaration order.
+    /// The top-level <paramref name="connectionString"/> and <paramref name="queryTemplate"/>
+    /// parameters are ignored — each inner source uses its own values.
+    /// </summary>
+    public async IAsyncEnumerable<DataTable> ExtractBatchesAsync(
+        string connectionString,
+        string queryTemplate,
+        object? watermarkValue,
+        int batchSize,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var (cs, query, source) in _sources)
+        {
+            await foreach (var batch in source.ExtractBatchesAsync(
+                cs, query, watermarkValue, batchSize, cancellationToken))
+            {
+                yield return batch;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var (_, _, source) in _sources)
+            source.Dispose();
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/CompositeEtlSourceTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/CompositeEtlSourceTests.cs
@@ -1,0 +1,118 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Pipeline.Sources;
+using WalkingTec.Mvvm.Etl.Testing;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+[TestClass]
+public class CompositeEtlSourceTests
+{
+    private static MockEtlSource MakeSource(params (int id, string name)[] rows)
+    {
+        var dt = new DataTable();
+        dt.Columns.Add("Id",   typeof(int));
+        dt.Columns.Add("Name", typeof(string));
+        foreach (var (id, name) in rows)
+            dt.Rows.Add(id, name);
+
+        var src = new MockEtlSource();
+        src.SetData(dt);
+        return src;
+    }
+
+    [TestMethod]
+    public async Task Composite_unions_batches_from_two_sources_in_order()
+    {
+        var src1 = MakeSource((1, "Alice"), (2, "Bob"));
+        var src2 = MakeSource((3, "Charlie"));
+
+        using var composite = new CompositeEtlSource(new[]
+        {
+            ("cs1", "SELECT * FROM T1", (WalkingTec.Mvvm.Etl.Pipeline.IEtlSource)src1),
+            ("cs2", "SELECT * FROM T2", (WalkingTec.Mvvm.Etl.Pipeline.IEtlSource)src2),
+        });
+
+        var all = new List<DataRow>();
+        await foreach (var batch in composite.ExtractBatchesAsync("", "", null, 100))
+            foreach (DataRow row in batch.Rows)
+                all.Add(row);
+
+        Assert.AreEqual(3, all.Count, "composite should yield all rows from both sources");
+        Assert.AreEqual(1, all[0]["Id"], "first row from source 1");
+        Assert.AreEqual(2, all[1]["Id"], "second row from source 1");
+        Assert.AreEqual(3, all[2]["Id"], "row from source 2 appended last");
+    }
+
+    [TestMethod]
+    public async Task Composite_with_single_source_behaves_as_passthrough()
+    {
+        var src = MakeSource((10, "X"), (20, "Y"));
+
+        using var composite = new CompositeEtlSource(new[]
+        {
+            ("cs", "SELECT * FROM T", (WalkingTec.Mvvm.Etl.Pipeline.IEtlSource)src),
+        });
+
+        var count = 0;
+        await foreach (var batch in composite.ExtractBatchesAsync("", "", null, 100))
+            count += batch.Rows.Count;
+
+        Assert.AreEqual(2, count);
+    }
+
+    [TestMethod]
+    public async Task Composite_with_empty_source_list_yields_nothing()
+    {
+        using var composite = new CompositeEtlSource(
+            System.Array.Empty<(string, string, WalkingTec.Mvvm.Etl.Pipeline.IEtlSource)>());
+
+        var count = 0;
+        await foreach (var batch in composite.ExtractBatchesAsync("", "", null, 100))
+            count += batch.Rows.Count;
+
+        Assert.AreEqual(0, count);
+    }
+
+    [TestMethod]
+    public async Task Composite_top_level_connection_and_query_are_ignored()
+    {
+        // The inner source uses its own cs/query; top-level params should be irrelevant
+        var src = MakeSource((99, "Z"));
+
+        using var composite = new CompositeEtlSource(new[]
+        {
+            ("real-cs", "SELECT * FROM T", (WalkingTec.Mvvm.Etl.Pipeline.IEtlSource)src),
+        });
+
+        var count = 0;
+        await foreach (var batch in composite.ExtractBatchesAsync(
+            "IGNORED-CS", "IGNORED-QUERY", null, 100))
+            count += batch.Rows.Count;
+
+        Assert.AreEqual(1, count, "inner source should be used regardless of top-level params");
+    }
+
+    [TestMethod]
+    public async Task Composite_respects_batch_size_from_inner_sources()
+    {
+        var src = MakeSource((1, "A"), (2, "B"), (3, "C"), (4, "D"), (5, "E"));
+
+        using var composite = new CompositeEtlSource(new[]
+        {
+            ("cs", "SELECT * FROM T", (WalkingTec.Mvvm.Etl.Pipeline.IEtlSource)src),
+        });
+
+        var batches = new List<DataTable>();
+        await foreach (var batch in composite.ExtractBatchesAsync("", "", null, batchSize: 2))
+            batches.Add(batch);
+
+        Assert.AreEqual(3, batches.Count, "5 rows / batchSize 2 → 3 batches");
+        Assert.AreEqual(2, batches[0].Rows.Count);
+        Assert.AreEqual(2, batches[1].Rows.Count);
+        Assert.AreEqual(1, batches[2].Rows.Count);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `CompositeEtlSource` — an `IEtlSource` wrapper that unions data from multiple inner sources in a single ETL job execution.

Each inner source is declared with its own `(ConnectionString, QueryTemplate, IEtlSource)` tuple, enabling heterogeneous database merges without changes to `EtlPipelineExecutor`.

```csharp
var composite = new CompositeEtlSource(new[]
{
    ("Server=db1;...", "SELECT * FROM Orders",  new MssqlSource()),
    ("Server=db2;...", "SELECT * FROM Archive", new MssqlSource()),
});
// Plug directly into EtlPipelineExecutor as a regular IEtlSource
```

All inner sources must produce compatible schemas for the downstream `IBulkLoader`.

## Test plan
- [x] 5 MSTest covering: two-source union order, single-source passthrough, empty source list, top-level params ignored, batch size respected → 5/5 pass

Closes #425