### PR TITLE
fix(analysis): deserialize Nullable<TEnum> Searcher fields from HTML form strings

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -29,7 +29,11 @@ namespace WalkingTec.Mvvm.Mvc
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             PropertyNameCaseInsensitive = true,
-            Converters = { new DateTimeConverter() }
+            // NullableEnumStringConverterFactory: HTML form values are always strings.
+            // When a Nullable<TEnum> Searcher field is populated, the form sends "1" (numeric
+            // string) or "Card" (enum name). STJ cannot convert these without a custom converter.
+            // Fixes #471.
+            Converters = { new NullableEnumStringConverterFactory(), new DateTimeConverter() }
         };
 
         private readonly AnalysisVmRegistry _registry;
@@ -467,6 +471,61 @@ namespace WalkingTec.Mvvm.Mvc
             }
             
             return s;
+        }
+
+        /// <summary>
+        /// 處理 Nullable&lt;TEnum&gt; 反序列化：HTML form 一律送字串，
+        /// 接受 "1"（數字字串）、"Card"（enum 名稱）、數字 literal、null 或空字串。
+        /// </summary>
+        private class NullableEnumStringConverterFactory : JsonConverterFactory
+        {
+            public override bool CanConvert(Type typeToConvert)
+            {
+                var underlying = Nullable.GetUnderlyingType(typeToConvert);
+                return underlying?.IsEnum == true;
+            }
+
+            public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+            {
+                var underlying = Nullable.GetUnderlyingType(typeToConvert)!;
+                var converterType = typeof(NullableEnumStringConverter<>).MakeGenericType(underlying);
+                return (JsonConverter?)Activator.CreateInstance(converterType);
+            }
+        }
+
+        private class NullableEnumStringConverter<T> : JsonConverter<T?> where T : struct, Enum
+        {
+            public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.Null) return null;
+
+                if (reader.TokenType == JsonTokenType.Number)
+                {
+                    if (reader.TryGetInt32(out int num)) return (T)(object)num;
+                }
+
+                if (reader.TokenType == JsonTokenType.String)
+                {
+                    var str = reader.GetString();
+                    if (string.IsNullOrEmpty(str)) return null;
+
+                    // Form sends integer string first ("1", "2") — most common case
+                    if (int.TryParse(str, out int n)) return (T)(object)n;
+
+                    // Fall back to enum name ("Card", "card")
+                    if (Enum.TryParse<T>(str, ignoreCase: true, out var val)) return val;
+
+                    throw new JsonException($"Cannot convert '{str}' to {typeof(T).Name}.");
+                }
+
+                throw new JsonException($"Unexpected token {reader.TokenType} for {typeof(T).Name}.");
+            }
+
+            public override void Write(Utf8JsonWriter writer, T? value, JsonSerializerOptions options)
+            {
+                if (value == null) writer.WriteNullValue();
+                else writer.WriteNumberValue(Convert.ToInt32(value));
+            }
         }
 
         /// <summary>

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -92,6 +92,22 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 => _testData.AsQueryable().OrderByDescending(x => x.ID);
         }
 
+        // ─── nullable enum 搜尋條件（SearcherFormData nullable enum 測試，#471）─────
+
+        private enum PaymentKind { Cash = 0, Card = 1, Transfer = 2 }
+
+        private class EnumSearcher : BaseSearcher
+        {
+            public PaymentKind? Payment { get; set; }
+        }
+
+        [EnableAnalysis]
+        private class EnumSearchListVM : BasePagedListVM<SaleRecord, EnumSearcher>
+        {
+            public override IOrderedQueryable<SaleRecord> GetSearchQuery()
+                => _testData.AsQueryable().OrderByDescending(x => x.ID);
+        }
+
         // ─── 基礎設施 ──────────────────────────────────────────────────────────
 
         private AnalysisVmRegistry _registry;
@@ -586,6 +602,53 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
 
             var result = CreateController().Query(req) as BadRequestObjectResult;
             Assert.IsNotNull(result, "無效日期格式應回傳 400");
+        }
+
+        // ─── SearcherFormData nullable enum 反序列化（Fixes #471）──────────────
+
+        [DataTestMethod]
+        [DataRow("{\"payment\":\"1\"}", "numeric string")]
+        [DataRow("{\"payment\":\"Card\"}", "enum name string")]
+        [DataRow("{\"payment\":1}",       "numeric literal")]
+        public void Query_accepts_nullable_enum_in_SearcherFormData(string json, string label)
+        {
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華東", Category = "A", Amount = 100m }
+            };
+
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(EnumSearchListVM).FullName,
+                Dimensions = new List<string> { "Region" },
+                Measures = new List<MeasureRequest> { new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum } },
+                SearcherFormData = json
+            };
+
+            var result = CreateController().Query(req);
+            Assert.IsNotInstanceOfType(result, typeof(BadRequestObjectResult),
+                $"nullable enum 格式 '{label}' 應被接受，不應回傳 400");
+        }
+
+        [TestMethod]
+        public void Query_accepts_absent_nullable_enum_in_SearcherFormData()
+        {
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華東", Category = "A", Amount = 100m }
+            };
+
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(EnumSearchListVM).FullName,
+                Dimensions = new List<string> { "Region" },
+                Measures = new List<MeasureRequest> { new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum } },
+                SearcherFormData = "{}" // 空搜尋條件（前端未選擇 enum dropdown）
+            };
+
+            var result = CreateController().Query(req);
+            Assert.IsNotInstanceOfType(result, typeof(BadRequestObjectResult),
+                "未選擇 enum 時應正常執行，不應回傳 400");
         }
 
         // ─── Null request guard (#268) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- HTML form values are always strings; when a `Nullable<TEnum>` Searcher field is filled, `ff.GetSearchFormData()` returns `"1"` (numeric string) or `"Card"` (enum name). STJ's default converter rejects both, causing **400 on every analysis request after list filtering**.
- Add `NullableEnumStringConverterFactory` to `_camelCase` JsonSerializerOptions — handles numeric strings, enum name strings, numeric literals, and null/empty.
- Add 4 MSTest cases covering all three string forms and the absent-field case.

Closes #471

## Test plan

- [x] `Query_accepts_nullable_enum_in_SearcherFormData` — 3 DataRow cases (`"1"`, `"Card"`, `1`)
- [x] `Query_accepts_absent_nullable_enum_in_SearcherFormData` — empty `{}`
- [x] All 95 AnalysisControllerTests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)