### PR TITLE
fix(analysis): remove auto-collapse of field selector after query

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -1048,10 +1048,6 @@
                 if (toggleRow) toggleRow.style.display = 'flex';
             }
 
-            // Auto-collapse field selector after query
-            if (!st.collapsed) {
-                toggleCollapse(gridId, 'analysis-panel-body', 'collapsed');
-            }
         })
         .catch(function (err) {
             if (resultDiv) resultDiv.textContent = '查詢失敗：' + parseFriendlyError(err);


### PR DESCRIPTION
## Summary

- 移除查詢成功後自動摺疊「分析欄位選擇器」的行為
- 使用者調整欄位後再查詢不再需要手動重新展開面板

## Test plan

- [ ] 開啟任一 Analysis 面板，選擇欄位後點擊「查詢」
- [ ] 確認面板不自動摺疊，欄位選擇器保持展開
- [ ] 確認手動點擊 header 仍可正常摺疊/展開
- [ ] `npm test` 通過（framework_analysis.js 無迴歸）

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)