### PR TITLE
fix(analysis): remove leaveOpen:true to fix corrupt Excel export (#477)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
@@ -148,8 +148,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
                     metaRow.CreateCell(1).SetCellValue(rows[i].Item2);
                 }
             }
-            using var ms = new MemoryStream();
-            workbook.Write(ms, leaveOpen: true);
+            var ms = new MemoryStream();
+            workbook.Write(ms);
             return ms.ToArray();
         }
 


### PR DESCRIPTION
## Summary

- 移除 `AnalysisExcelExporter.Write(ms, leaveOpen: true)`，改為 `Write(ms)`
- NPOI 的 `leaveOpen:true` 阻止內部 ZipOutputStream 被關閉，導致 ZIP Central Directory 未寫入，Excel 開啟時顯示「檔案損毀」
- `MemoryStream.ToArray()` 在 stream close 後仍有效（MSDN 明確記載），無需 `leaveOpen:true`

Closes #477

## Test plan

- [x] `dotnet build` 通過（0 警告 0 錯誤）
- [x] 338 個 Analysis 測試全部通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)