### PR TITLE
fix(analysis): NotIn on Nullable<T> dimension incorrectly includes null rows

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -284,20 +284,27 @@ namespace WalkingTec.Mvvm.Core.Analysis
                             .MakeGenericMethod(underlyingType);
 
                         Expression propForIn = prop;
-                        Expression inExpr;
                         if (Nullable.GetUnderlyingType(targetType) != null)
                         {
                             propForIn = Expression.Property(prop, "Value");
-                            inExpr = Expression.AndAlso(
-                                Expression.NotEqual(prop, Expression.Constant(null, targetType)),
-                                Expression.Call(containsMethod, listConst, propForIn)
-                            );
+                            var nullGuard = Expression.NotEqual(prop, Expression.Constant(null, targetType));
+                            var containsExpr = Expression.Call(containsMethod, listConst, propForIn);
+                            if (f.Operator == FilterOperator.NotIn)
+                            {
+                                // NOT_NULL AND NOT_CONTAINS — keeps null rows excluded, consistent with
+                                // In / NotEq / Gt etc. and SQL semantics (NULL NOT IN … → excluded). (#481)
+                                filterExpr = Expression.AndAlso(nullGuard, Expression.Not(containsExpr));
+                            }
+                            else
+                            {
+                                filterExpr = Expression.AndAlso(nullGuard, containsExpr);
+                            }
                         }
                         else
                         {
-                            inExpr = Expression.Call(containsMethod, listConst, propForIn);
+                            var inExpr = Expression.Call(containsMethod, listConst, propForIn);
+                            filterExpr = f.Operator == FilterOperator.NotIn ? Expression.Not(inExpr) : inExpr;
                         }
-                        filterExpr = f.Operator == FilterOperator.NotIn ? Expression.Not(inExpr) : inExpr;
                     }
                     else if (f.Operator == FilterOperator.Contains || f.Operator == FilterOperator.NotContains)
                     {

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
@@ -54,6 +54,20 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             public DbSet<SaleRecord> SaleRecords { get; set; }
         }
 
+        // ─── NullableChannel 測試模型（#481 NotIn null-row exclusion）────────────
+
+        private class NullableChannelRecord : TopBasePoco
+        {
+            [Dimension(DisplayName = "通路")] public SaleChannel? Channel { get; set; }
+            [Measure(AllowedFuncs = AggregateFunc.Count, DisplayName = "筆數")] public decimal Count { get; set; }
+        }
+
+        private class NullableChannelContext : DbContext
+        {
+            public NullableChannelContext(DbContextOptions opts) : base(opts) { }
+            public DbSet<NullableChannelRecord> Records { get; set; }
+        }
+
         // ─── CustomerTier 測試模型（#473 enum display-name filter）───────────────
 
         private class CustomerRecord : TopBasePoco
@@ -367,6 +381,44 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 filters: new[] { ("Amount", FilterOperator.NotContains, "100") });
 
             Assert.ThrowsException<InvalidOperationException>(() => Engine().Execute(Q(), req, _whitelist));
+        }
+
+        // ─── NotIn / Nullable<T> null-row exclusion (#481) ───────────────────────
+
+        [TestMethod]
+        public void Filter_NotIn_nullable_enum_excludes_null_rows()
+        {
+            // Regression: NOT (NOT_NULL AND CONTAINS) let null rows pass (#481).
+            // Expected: null rows are excluded, consistent with In / NotEq / SQL semantics.
+            var conn = new SqliteConnection("DataSource=:memory:");
+            conn.Open();
+            var ctx = new NullableChannelContext(
+                new DbContextOptionsBuilder<NullableChannelContext>().UseSqlite(conn).Options);
+            ctx.Database.EnsureCreated();
+            ctx.Records.AddRange(
+                new NullableChannelRecord { ID = Guid.NewGuid(), Channel = SaleChannel.Online,  Count = 1 },
+                new NullableChannelRecord { ID = Guid.NewGuid(), Channel = SaleChannel.Offline, Count = 1 },
+                new NullableChannelRecord { ID = Guid.NewGuid(), Channel = null,                Count = 1 }
+            );
+            ctx.SaveChanges();
+
+            var wl = AnalysisFieldScanner.ScanModel(typeof(NullableChannelRecord));
+            var req = Req(
+                dims: new[] { "Channel" },
+                msrs: new[] { ("Count", AggregateFunc.Count) },
+                filters: new[] { ("Channel", FilterOperator.NotIn, "Online") });
+
+            var result = new AnalysisQueryEngine(GroupByStrategyResolver.Default)
+                .Execute(ctx.Records.AsQueryable(), req, wl);
+
+            // Offline row: included (not in list) ✓
+            Assert.IsTrue(result.Rows.Any(r => r["Channel"]?.ToString() == "Offline"),
+                "Offline 應包含在 NotIn Online 結果中");
+            // null row: must be excluded (#481)
+            Assert.IsFalse(result.Rows.Any(r => r["Channel"] == null || r["Channel"]?.ToString() == ""),
+                "null Channel 不應出現在 NotIn 結果中");
+
+            conn.Close();
         }
 
         // ─── SQL Injection 回歸保護 ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Bug**: `NotIn` filter on `Nullable<T>` dimensions (e.g. `Status?`, `SaleChannel?`) incorrectly included rows where the field is `null`.
- **Root cause**: The expression `NOT (NOT_NULL AND CONTAINS)` evaluates to `true` when `prop` is null — De Morgan's law means null rows slip through.
- **Fix**: Use `NOT_NULL AND NOT_CONTAINS` in the nullable branch, consistent with all other operators (`In`, `NotEq`, `Gt`, etc.) and SQL semantics (`NULL NOT IN (…)` → excluded).

Closes #481

## Changes

- `AnalysisQueryEngine.cs`: Restructure the nullable `In`/`NotIn` branch to build `NOT_NULL AND NOT_CONTAINS` for `NotIn` instead of `NOT (NOT_NULL AND CONTAINS)`.
- `AnalysisQueryEngineTests.cs`: Add `NullableChannelRecord` model + `Filter_NotIn_nullable_enum_excludes_null_rows` regression test (3 rows: Online, Offline, null — `NotIn Online` must return only Offline).

## Test plan

- [x] New regression test `Filter_NotIn_nullable_enum_excludes_null_rows` passes
- [x] All 60 `AnalysisQueryEngineTests` pass (0 failures)
- [x] `In` with null still correctly excludes null rows (no change to that path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)