### PR TITLE
fix(analysis): exported Excel chart type matches user's on-screen selection (#479)

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -380,7 +380,7 @@
                 pivotEnabled: false, pivotDim: null,
                 dims: [], msrs: [], dimHierarchies: {},
                 sortableInstances: {},
-                lastResult: null, lastReq: null, lastDimFields: null
+                lastResult: null, lastReq: null, lastDimFields: null, lastChartType: null
             };
         }
 
@@ -1209,9 +1209,11 @@
             return { fieldName: d, isDate: f ? f.isDate === true : false };
         });
         var chartType = forceChartType || detectChartType(dimMeta, req.measures);
+        // Persist effective chart type so exportData honours the user's manual selection (#479)
+        var st = _state[gridId];
+        if (st) st.lastChartType = chartType;
 
         // Build measure key → display label map for human-friendly legends
-        var st = _state[gridId];
         var fieldByName = {};
         if (st && st.fields) {
             st.fields.forEach(function (f) { fieldByName[f.fieldName] = f; });
@@ -1521,7 +1523,7 @@
         var dimMeta = dims.map(function (d) {
             return (st.fields || []).find(function (f) { return f.fieldName === d; }) || { isDate: false };
         });
-        var currentChartType = detectChartType(dimMeta, msrs);
+        var currentChartType = (st && st.lastChartType) || detectChartType(dimMeta, msrs);
         var endpoint = isPivot ? '/_analysis/pivot/export' : '/_analysis/export';
         return fetch(endpoint + '?format=' + encodeURIComponent(format) + '&includeChart=' + includeChart + '&chartType=' + encodeURIComponent(currentChartType), {
             method: 'POST',

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -1903,7 +1903,8 @@ describe('drill-down integration', () => {
         const { drillBar } = setupDrillState('dd8', env);
 
         env.wa.drillDown('dd8', 'Region', '華東', false);
-        env.wa.drillDown('dd8', 'Region', '上海', false);
+        // Second drill uses a different field (City) — guard blocks same-field repeated drill
+        env.wa.drillDown('dd8', 'City', '上海', false);
 
         expect(drillBar._children[0].textContent).toBe('全部 > 華東 > 上海');
     });
@@ -3345,7 +3346,8 @@ describe('[cov] waReq drillDown/drillBack/drillReset — lines 1291-1416 #307', 
         const { drillBar, st } = setupDrillCovState('covDC307e');
         global.fetch = jest.fn().mockResolvedValue({ ok: false, text: jest.fn().mockResolvedValue('e') });
         waReq.drillDown('covDC307e', 'Region', '華東', false);
-        waReq.drillDown('covDC307e', 'Region', '上海', false);
+        // Second drill uses a different field (City) — guard blocks same-field repeated drill
+        waReq.drillDown('covDC307e', 'City', '上海', false);
         expect(st.drillStack.length).toBe(2);
         global.fetch.mockClear();
         waReq.drillReset('covDC307e');
@@ -3362,7 +3364,8 @@ describe('[cov] waReq drillDown/drillBack/drillReset — lines 1291-1416 #307', 
         const { drillBar } = setupDrillCovState('covUDB307a');
         global.fetch = jest.fn().mockResolvedValue({ ok: false, text: jest.fn().mockResolvedValue('e') });
         waReq.drillDown('covUDB307a', 'Region', '華東', false);
-        waReq.drillDown('covUDB307a', 'Region', '上海', false);
+        // Second drill uses a different field (City) — guard blocks same-field repeated drill
+        waReq.drillDown('covUDB307a', 'City', '上海', false);
         const pathSpan = drillBar.querySelector('span');
         expect(pathSpan).toBeTruthy();
         expect(pathSpan.textContent).toBe('全部 > 華東 > 上海');


### PR DESCRIPTION
## Problem

When user manually switches chart type via the toggle buttons (bar/line/pie), then exports to Excel, the exported chart type is always the auto-detected type instead of what's displayed on screen.

Root cause: `exportData()` called `detectChartType()` which recomputes from dimension/measure metadata, ignoring `forceChartType` passed to `renderChart()`.

## Fix

Persist the effective chart type in `_state[gridId].lastChartType` whenever `renderChart()` resolves it, and read that value in `exportData()` before falling back to auto-detection.

## Changes

- `framework_analysis.js`:
  - Add `lastChartType: null` to `_state[gridId]` initializer
  - Save `st.lastChartType = chartType` in `renderChart()` after resolving the effective type
  - In `exportData()`: `var currentChartType = (st && st.lastChartType) || detectChartType(dimMeta, msrs)`
- `framework_analysis.test.js`: Fix 3 drill-down tests to use different fields per level (guard added in #480 correctly blocks repeated filters on same non-date field)

## Test plan

- [x] 397/397 Jest tests pass
- [ ] Manually: select bar chart → switch to pie → export → confirm Excel embeds pie chart

Closes #479