### PR TITLE
fix(analysis): fix Count non-generic lambda and extend ServerSide to MySql/PgSql (#496)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/GroupByStrategyResolver.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/GroupByStrategyResolver.cs
@@ -4,8 +4,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
 {
     /// <summary>
     /// 根據資料庫類型和查詢特徵選擇 GroupBy 策略。
-    /// SqlServer/Oracle 使用 ServerSideGroupByStrategy（SQL 推送 GroupBy）；
-    /// 其餘（SQLite、MySQL、PgSql、Memory、DaMeng）使用 InProcessGroupByStrategy。
+    /// SqlServer、Oracle、MySql、PgSql 使用 ServerSideGroupByStrategy（SQL 推送 GroupBy）；
+    /// 其餘（SQLite、Memory、DaMeng）使用 InProcessGroupByStrategy。
     /// </summary>
     public class GroupByStrategyResolver
     {
@@ -17,14 +17,18 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
         /// <summary>
         /// 根據 DB 類型和查詢請求解析 GroupBy 策略。
+        /// SqlServer、Oracle、MySql、PgSql 均支援標準 SQL GROUP BY，使用 ServerSideGroupByStrategy；
+        /// SQLite 的 GroupBy Expression Tree 翻譯有限制，使用 InProcessGroupByStrategy。
         /// </summary>
         public virtual IGroupByStrategy Resolve(DBTypeEnum dbType, AnalysisQueryRequest req)
         {
             return dbType switch
             {
                 DBTypeEnum.SqlServer => ServerSide,
-                DBTypeEnum.Oracle => ServerSide,
-                _ => InProcess
+                DBTypeEnum.Oracle    => ServerSide,
+                DBTypeEnum.MySql     => ServerSide,
+                DBTypeEnum.PgSql     => ServerSide,
+                _                    => InProcess
             };
         }
     }

--- a/src/WalkingTec.Mvvm.Core/Analysis/ServerSideGroupByStrategy.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/ServerSideGroupByStrategy.cs
@@ -151,27 +151,42 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
             if (measure.Func == AggregateFunc.Count)
             {
-                Expression propAccess = Expression.Property(innerParam, measure.Field);
-                Expression predicateBody;
-                if (Nullable.GetUnderlyingType(propType) != null || !propType.IsValueType)
+                // Use Enumerable.Count<TSource>(IEnumerable<TSource>) for non-nullable value types,
+                // or Enumerable.Count<TSource>(IEnumerable<TSource>, Func<TSource,bool>) for nullable.
+                // The predicate overload requires a strongly-typed Func<TModel,bool> lambda so that
+                // EF Core's GroupBy translator can match and emit "COUNT(*)" or "COUNT(col)".
+                bool isNullable = Nullable.GetUnderlyingType(propType) != null || !propType.IsValueType;
+
+                if (isNullable)
                 {
-                    predicateBody = Expression.NotEqual(propAccess, Expression.Constant(null, propType));
+                    Expression propAccess = Expression.Property(innerParam, measure.Field);
+                    var predicateBody = Expression.NotEqual(propAccess, Expression.Constant(null, propType));
+                    var predicate = Expression.Lambda<Func<TModel, bool>>(predicateBody, innerParam);
+
+                    var countWithPredicateMethod = typeof(Enumerable)
+                        .GetMethods()
+                        .First(m => m.Name == nameof(Enumerable.Count)
+                                    && m.IsGenericMethod
+                                    && m.GetParameters().Length == 2)
+                        .MakeGenericMethod(typeof(TModel));
+
+                    return Expression.Convert(
+                        Expression.Call(countWithPredicateMethod, gParam, predicate),
+                        typeof(double?));
                 }
                 else
                 {
-                    predicateBody = Expression.Constant(true);
+                    var countMethod = typeof(Enumerable)
+                        .GetMethods()
+                        .First(m => m.Name == nameof(Enumerable.Count)
+                                    && m.IsGenericMethod
+                                    && m.GetParameters().Length == 1)
+                        .MakeGenericMethod(typeof(TModel));
+
+                    return Expression.Convert(
+                        Expression.Call(countMethod, gParam),
+                        typeof(double?));
                 }
-                
-                var predicate = Expression.Lambda(predicateBody, innerParam);
-                
-                var countMethod = typeof(Enumerable)
-                    .GetMethods()
-                    .First(m => m.Name == nameof(Enumerable.Count) && m.GetParameters().Length == 2)
-                    .MakeGenericMethod(typeof(TModel));
-                
-                return Expression.Convert(
-                    Expression.Call(countMethod, gParam, predicate),
-                    typeof(double?));
             }
 
             Expression pAccess = Expression.Property(innerParam, measure.Field);
@@ -179,6 +194,10 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
             var valueSelector = Expression.Lambda<Func<TModel, double?>>(pAccess, innerParam);
 
+            // Enumerable.Sum/Average/Max/Min are used here (not Queryable) because the grouping
+            // element type is IGrouping<K,TModel> which implements IEnumerable<TModel>.
+            // EF Core 8 GroupBy translator recognises Enumerable aggregate calls within a
+            // GroupBy.Select() expression tree and emits the corresponding SQL aggregate function.
             string methodName = measure.Func switch
             {
                 AggregateFunc.Sum => nameof(Enumerable.Sum),

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/GroupByStrategyResolverTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/GroupByStrategyResolverTests.cs
@@ -33,19 +33,19 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
         [TestMethod]
-        public void Default_resolver_returns_InProcess_for_MySql()
+        public void Default_resolver_returns_ServerSide_for_MySql()
         {
             var req = new AnalysisQueryRequest();
             var strategy = GroupByStrategyResolver.Default.Resolve(DBTypeEnum.MySql, req);
-            Assert.IsInstanceOfType(strategy, typeof(InProcessGroupByStrategy));
+            Assert.IsInstanceOfType(strategy, typeof(ServerSideGroupByStrategy));
         }
 
         [TestMethod]
-        public void Default_resolver_returns_InProcess_for_PgSql()
+        public void Default_resolver_returns_ServerSide_for_PgSql()
         {
             var req = new AnalysisQueryRequest();
             var strategy = GroupByStrategyResolver.Default.Resolve(DBTypeEnum.PgSql, req);
-            Assert.IsInstanceOfType(strategy, typeof(InProcessGroupByStrategy));
+            Assert.IsInstanceOfType(strategy, typeof(ServerSideGroupByStrategy));
         }
 
         [TestMethod]
@@ -69,9 +69,23 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         public void InProcess_returns_same_instance_across_calls()
         {
             var req = new AnalysisQueryRequest();
+            // SQLite and Memory are both InProcess — verify they share the same singleton instance
             var s1 = GroupByStrategyResolver.Default.Resolve(DBTypeEnum.SQLite, req);
-            var s2 = GroupByStrategyResolver.Default.Resolve(DBTypeEnum.MySql, req);
+            var s2 = GroupByStrategyResolver.Default.Resolve(DBTypeEnum.Memory, req);
             Assert.AreSame(s1, s2, "InProcess should be a singleton instance.");
+        }
+
+        [TestMethod]
+        public void ServerSide_returns_same_instance_for_all_server_side_dbs()
+        {
+            var req = new AnalysisQueryRequest();
+            var s1 = GroupByStrategyResolver.Default.Resolve(DBTypeEnum.SqlServer, req);
+            var s2 = GroupByStrategyResolver.Default.Resolve(DBTypeEnum.Oracle, req);
+            var s3 = GroupByStrategyResolver.Default.Resolve(DBTypeEnum.MySql, req);
+            var s4 = GroupByStrategyResolver.Default.Resolve(DBTypeEnum.PgSql, req);
+            Assert.AreSame(s1, s2, "SqlServer and Oracle should share ServerSide singleton.");
+            Assert.AreSame(s1, s3, "MySql should share ServerSide singleton.");
+            Assert.AreSame(s1, s4, "PgSql should share ServerSide singleton.");
         }
     }
 }

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/ServerSideGroupByStrategyTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/ServerSideGroupByStrategyTests.cs
@@ -2,8 +2,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Analysis;
@@ -295,6 +297,92 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.AreEqual(300m, Convert.ToDecimal(huaDong["Amount_Sum"]));
             Assert.AreEqual(15m, Convert.ToDecimal(huaDong["Quantity_Avg"]));
             Assert.AreEqual(10m, Convert.ToDecimal(huaDong["Discount_Max"]));
+        }
+
+        /// <summary>
+        /// Verifies that the generated SQL actually contains "GROUP BY".
+        /// Uses EF Core SQL logging to capture the emitted query and asserts
+        /// the database-side aggregation is not silently falling back to in-process.
+        /// </summary>
+        [TestMethod]
+        public void Execute_emits_SQL_with_GROUP_BY()
+        {
+            // Arrange: rebuild context with SQL logging enabled
+            var sqlLog = new StringBuilder();
+            var loggingOpts = new DbContextOptionsBuilder<SaleTestContext>()
+                .UseSqlite(_conn)
+                .LogTo(
+                    msg => { sqlLog.AppendLine(msg); },
+                    new[] { DbLoggerCategory.Database.Command.Name },
+                    LogLevel.Information)
+                .EnableSensitiveDataLogging()
+                .Options;
+
+            using var loggingCtx = new SaleTestContext(loggingOpts);
+            loggingCtx.Database.EnsureCreated();
+            loggingCtx.SaleRecords.AddRange(
+                new SaleRecord { ID = Guid.NewGuid(), Region = "北區", Category = "X", Year = "2025", Amount = 50m, Quantity = 5m, Discount = 2m },
+                new SaleRecord { ID = Guid.NewGuid(), Region = "北區", Category = "X", Year = "2025", Amount = 150m, Quantity = 15m, Discount = 8m },
+                new SaleRecord { ID = Guid.NewGuid(), Region = "南區", Category = "Y", Year = "2025", Amount = 200m, Quantity = 20m, Discount = 10m }
+            );
+            loggingCtx.SaveChanges();
+
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            // Act
+            sqlLog.Clear();
+            _strategy.Execute(loggingCtx.SaleRecords.AsQueryable(), req, _whitelist);
+            var capturedSql = sqlLog.ToString();
+
+            // Assert: the emitted SQL must contain GROUP BY, proving server-side aggregation
+            StringAssert.Contains(
+                capturedSql.ToUpperInvariant(),
+                "GROUP BY",
+                $"Expected SQL to contain GROUP BY but got:\n{capturedSql}");
+        }
+
+        [TestMethod]
+        public void Count_on_nullable_field_emits_SQL_with_GROUP_BY()
+        {
+            // Arrange: rebuild context with SQL logging enabled
+            var sqlLog = new StringBuilder();
+            var loggingOpts = new DbContextOptionsBuilder<SaleTestContext>()
+                .UseSqlite(_conn)
+                .LogTo(
+                    msg => { sqlLog.AppendLine(msg); },
+                    new[] { DbLoggerCategory.Database.Command.Name },
+                    LogLevel.Information)
+                .EnableSensitiveDataLogging()
+                .Options;
+
+            using var loggingCtx = new SaleTestContext(loggingOpts);
+            loggingCtx.Database.EnsureCreated();
+            loggingCtx.SaleRecords.AddRange(
+                new SaleRecord { ID = Guid.NewGuid(), Region = "東區", Category = "Z", Year = "2025", Amount = 10m, Quantity = 1m, Discount = 1m },
+                new SaleRecord { ID = Guid.NewGuid(), Region = "東區", Category = "Z", Year = "2025", Amount = 20m, Quantity = 2m, Discount = 2m }
+            );
+            loggingCtx.SaveChanges();
+
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Count) });
+
+            // Act
+            sqlLog.Clear();
+            var rows = _strategy.Execute(loggingCtx.SaleRecords.AsQueryable(), req, _whitelist);
+            var capturedSql = sqlLog.ToString();
+
+            // Assert: GROUP BY is present in generated SQL
+            StringAssert.Contains(
+                capturedSql.ToUpperInvariant(),
+                "GROUP BY",
+                $"Expected SQL to contain GROUP BY for Count but got:\n{capturedSql}");
+
+            // Assert: result is correct
+            Assert.AreEqual(1, rows.Count);
+            Assert.AreEqual(2m, Convert.ToDecimal(rows[0]["Amount_Count"]));
         }
     }
 }


### PR DESCRIPTION
## Summary

- **根因**：`BuildAggregateExpression()` 的 Count 路徑使用 `Expression.Lambda()`（非強型別 `LambdaExpression`），EF Core GroupBy translator 無法識別此 pattern，導致翻譯失敗
- **修正**：Count 改用 `Expression.Lambda<Func<TModel, bool>>`（nullable 欄位）或 zero-argument `Enumerable.Count`（non-nullable value type），兩種形式 EF Core 均可正確翻譯為 SQL `COUNT`
- **擴展**：`GroupByStrategyResolver` 新增 `MySql` 和 `PgSql` → `ServerSideGroupByStrategy`（兩者均完整支援 SQL GROUP BY，之前錯誤地路由到 InProcess）
- **可觀察性**：加入 2 個 SQL logging 測試，透過 EF Core `LogTo()` 捕捉生成 SQL 並 assert 含 `GROUP BY`，防止未來靜默 regression

## Test plan

- [x] `ServerSideGroupByStrategyTests` — 9 個測試（含 2 個新 SQL logging 測試）全通過
- [x] `GroupByStrategyResolverTests` — 9 個測試（含 1 個新 ServerSide singleton 測試）全通過
- [x] 完整 `WalkingTec.Mvvm.Core.Test` — 912/912 通過，0 failures

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)