### PR TITLE
feat(analysis): smart filter controls — select for enums, datepicker hint for dates

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldMeta.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldMeta.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 
 namespace WalkingTec.Mvvm.Core.Analysis
 {
@@ -38,5 +39,11 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
         /// <summary>允許存取此欄位的角色列表（逗號分隔）。若為空則不限角色。</summary>
         public string? AllowedRoles { get; set; }
+
+        /// <summary>
+        /// 枚舉欄位的所有允許值（顯示名稱）。非枚舉欄位為 null。
+        /// 前端用於渲染 &lt;select&gt; 控件，避免使用者猜測枚舉值。
+        /// </summary>
+        public IReadOnlyList<string>? AllowedValues { get; init; }
     }
 }

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldScanner.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldScanner.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace WalkingTec.Mvvm.Core.Analysis
@@ -32,6 +33,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
                     var clrType = prop.PropertyType;
                     var underlying = Nullable.GetUnderlyingType(clrType) ?? clrType;
                     var isDate = underlying == typeof(DateTime);
+                    var allowedValues = BuildAllowedValues(underlying);
 
                     yield return new AnalysisFieldMeta
                     {
@@ -41,7 +43,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
                         ClrType = clrType,
                         IsDate = isDate,
                         Hierarchy = isDate ? dim.Hierarchy : DateHierarchy.None,
-                        AllowedRoles = dim.AllowedRoles
+                        AllowedRoles = dim.AllowedRoles,
+                        AllowedValues = allowedValues
                     };
                     continue;
                 }
@@ -60,6 +63,19 @@ namespace WalkingTec.Mvvm.Core.Analysis
                     };
                 }
             }
+        }
+
+        /// <summary>
+        /// 若 type 為枚舉，回傳所有成員的顯示名稱清單；否則回傳 null。
+        /// </summary>
+        private static IReadOnlyList<string>? BuildAllowedValues(Type type)
+        {
+            if (!type.IsEnum) return null;
+            return Enum.GetValues(type)
+                .Cast<Enum>()
+                .Select(e => e.GetEnumDisplayName() ?? e.ToString())
+                .ToList()
+                .AsReadOnly();
         }
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -861,7 +861,47 @@
     }
 
     /**
+     * 根據欄位 metadata 建立合適的值輸入控件：
+     *   - 枚舉（allowedValues 非空）→ <select>
+     *   - 日期（isDate === true）     → <input type="text"> + placeholder
+     *   - 其他                        → <input type="text">
+     */
+    function createValueInput(fieldMeta) {
+        var el;
+        if (fieldMeta && fieldMeta.allowedValues && fieldMeta.allowedValues.length > 0) {
+            el = document.createElement('select');
+            el.className = 'analysis-filter-value layui-input';
+            el.style.cssText = 'width:140px;display:inline-block;';
+            var emptyOpt = document.createElement('option');
+            emptyOpt.value = '';
+            emptyOpt.textContent = '-- 請選擇 --';
+            el.appendChild(emptyOpt);
+            fieldMeta.allowedValues.forEach(function (v) {
+                var opt = document.createElement('option');
+                opt.value = v;
+                opt.textContent = v;
+                el.appendChild(opt);
+            });
+        } else {
+            el = document.createElement('input');
+            el.type = 'text';
+            el.className = 'analysis-filter-value layui-input';
+            el.style.cssText = 'width:140px;display:inline-block;';
+            if (fieldMeta && fieldMeta.isDate) {
+                el.placeholder = 'yyyy-MM-dd';
+                if (typeof laydate !== 'undefined') {
+                    laydate.render({ elem: el });
+                }
+            } else {
+                el.placeholder = '篩選值\u2026';
+            }
+        }
+        return el;
+    }
+
+    /**
      * 在 filterBar 新增一行篩選列。
+     * 初始建立時使用預設 text input；欄位選取後動態替換為合適的控件。
      */
     function addFilterRow(gridId, fields) {
         var panel = document.getElementById('analysis-panel-' + gridId);
@@ -871,6 +911,10 @@
 
         var st = _state[gridId];
         var metaFields = fields || (st && st.fields) || [];
+
+        // 建立 fieldName → meta 的查找表
+        var metaByName = {};
+        metaFields.forEach(function (f) { metaByName[f.fieldName] = f; });
 
         var row = document.createElement('div');
         row.className = 'analysis-filter-row layui-inline';
@@ -902,12 +946,17 @@
         });
         row.appendChild(opSel);
 
-        var valInput = document.createElement('input');
-        valInput.type = 'text';
-        valInput.className = 'analysis-filter-value layui-input';
-        valInput.style.cssText = 'width:140px;display:inline-block;';
-        valInput.placeholder = '篩選值\u2026';
-        row.appendChild(valInput);
+        // 初始值控件：無欄位選取時使用預設 text input
+        var valEl = createValueInput(null);
+        row.appendChild(valEl);
+
+        // 欄位選取後，根據新欄位的 meta 替換值控件
+        fieldSel.addEventListener('change', function () {
+            var selectedMeta = metaByName[fieldSel.value] || null;
+            var newValEl = createValueInput(selectedMeta);
+            row.replaceChild(newValEl, valEl);
+            valEl = newValEl;
+        });
 
         var removeBtn = document.createElement('button');
         removeBtn.type = 'button';
@@ -1621,6 +1670,7 @@
         computeScale: computeScale,
         scaleSeriesData: scaleSeriesData,
         detectDualAxis: detectDualAxis,
+        createValueInput: createValueInput,
         addFilterRow: addFilterRow,
         collectFilters: collectFilters,
         updateFilterFieldOptions: updateFilterFieldOptions,

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisFieldScannerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisFieldScannerTests.cs
@@ -137,5 +137,69 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.IsTrue(field.IsDate);
             Assert.AreEqual(DateHierarchy.Year, field.Hierarchy);
         }
+
+        // --- #501 AllowedValues for enum fields ---
+
+        private enum OrderStatus { Pending, Active, Completed, Cancelled }
+
+        private class EnumModel
+        {
+            [Dimension(DisplayName = "狀態")]
+            public OrderStatus Status { get; set; }
+
+            [Dimension(DisplayName = "狀態（可空）")]
+            public OrderStatus? NullableStatus { get; set; }
+
+            [Dimension(DisplayName = "地區")]
+            public string Region { get; set; } = string.Empty;
+
+            [Measure(AllowedFuncs = AggregateFunc.Sum, DisplayName = "金額")]
+            public decimal Amount { get; set; }
+        }
+
+        [TestMethod]
+        public void Enum_dimension_has_AllowedValues_populated()
+        {
+            var field = AnalysisFieldScanner.ScanModel(typeof(EnumModel))
+                            .Single(f => f.FieldName == "Status");
+            Assert.IsNotNull(field.AllowedValues, "枚舉維度欄位的 AllowedValues 不應為 null");
+            Assert.AreEqual(4, field.AllowedValues!.Count);
+        }
+
+        [TestMethod]
+        public void Enum_dimension_AllowedValues_match_display_names()
+        {
+            var field = AnalysisFieldScanner.ScanModel(typeof(EnumModel))
+                            .Single(f => f.FieldName == "Status");
+            // GetEnumDisplayName 回傳 Display attribute 或 ToString() — 此枚舉沒有 Display attribute
+            CollectionAssert.AreEquivalent(
+                new[] { "Pending", "Active", "Completed", "Cancelled" },
+                field.AllowedValues!.ToList());
+        }
+
+        [TestMethod]
+        public void Nullable_enum_dimension_has_AllowedValues_populated()
+        {
+            var field = AnalysisFieldScanner.ScanModel(typeof(EnumModel))
+                            .Single(f => f.FieldName == "NullableStatus");
+            Assert.IsNotNull(field.AllowedValues, "Nullable 枚舉維度欄位的 AllowedValues 不應為 null");
+            Assert.AreEqual(4, field.AllowedValues!.Count);
+        }
+
+        [TestMethod]
+        public void String_dimension_has_null_AllowedValues()
+        {
+            var field = AnalysisFieldScanner.ScanModel(typeof(EnumModel))
+                            .Single(f => f.FieldName == "Region");
+            Assert.IsNull(field.AllowedValues, "非枚舉維度欄位的 AllowedValues 應為 null");
+        }
+
+        [TestMethod]
+        public void Measure_field_has_null_AllowedValues()
+        {
+            var field = AnalysisFieldScanner.ScanModel(typeof(EnumModel))
+                            .Single(f => f.FieldName == "Amount");
+            Assert.IsNull(field.AllowedValues, "Measure 欄位的 AllowedValues 應為 null");
+        }
     }
 }

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -4079,3 +4079,114 @@ describe('formatNumeric edge cases (#345)', () => {
     });
 });
 
+// ─── #501 createValueInput — smart filter controls ───────────────────────────
+describe('#501 createValueInput — smart filter controls', () => {
+    test('enum field (allowedValues non-empty) → renders <select> with correct options', () => {
+        const enumMeta = {
+            fieldName: 'Status',
+            displayName: '狀態',
+            isDate: false,
+            allowedValues: ['Active', 'Inactive', 'Pending'],
+        };
+        const el = waReq.createValueInput(enumMeta);
+        expect(el.tagName.toLowerCase()).toBe('select');
+        // options: empty placeholder + 3 enum values = 4 total
+        expect(el.options.length).toBe(4);
+        expect(el.options[0].value).toBe('');
+        expect(el.options[1].value).toBe('Active');
+        expect(el.options[2].value).toBe('Inactive');
+        expect(el.options[3].value).toBe('Pending');
+    });
+
+    test('enum field options use textContent not innerHTML (XSS safe)', () => {
+        const enumMeta = {
+            fieldName: 'Tag',
+            displayName: '標籤',
+            isDate: false,
+            allowedValues: ['<script>xss</script>', 'Normal'],
+        };
+        const el = waReq.createValueInput(enumMeta);
+        expect(el.tagName.toLowerCase()).toBe('select');
+        // values are set via .value and .textContent, not innerHTML
+        const xssOpt = el.options[1];
+        expect(xssOpt.value).toBe('<script>xss</script>');
+        expect(typeof xssOpt.textContent).toBe('string');
+    });
+
+    test('date field (isDate=true, no allowedValues) → renders <input> with yyyy-MM-dd placeholder', () => {
+        const dateMeta = {
+            fieldName: 'OrderDate',
+            displayName: '訂單日期',
+            isDate: true,
+            allowedValues: null,
+        };
+        const el = waReq.createValueInput(dateMeta);
+        expect(el.tagName.toLowerCase()).toBe('input');
+        expect(el.placeholder).toBe('yyyy-MM-dd');
+    });
+
+    test('plain text field (no allowedValues, not date) → renders <input> with generic placeholder', () => {
+        const textMeta = {
+            fieldName: 'Region',
+            displayName: '地區',
+            isDate: false,
+            allowedValues: null,
+        };
+        const el = waReq.createValueInput(textMeta);
+        expect(el.tagName.toLowerCase()).toBe('input');
+        expect(el.placeholder).not.toBe('yyyy-MM-dd');
+    });
+
+    test('null fieldMeta → renders default <input>', () => {
+        const el = waReq.createValueInput(null);
+        expect(el.tagName.toLowerCase()).toBe('input');
+    });
+
+    test('empty allowedValues array → falls through to <input> (not select)', () => {
+        const meta = {
+            fieldName: 'Score',
+            displayName: '分數',
+            isDate: false,
+            allowedValues: [],
+        };
+        const el = waReq.createValueInput(meta);
+        expect(el.tagName.toLowerCase()).toBe('input');
+    });
+
+    test('addFilterRow with enum field — collectFilters reads select.value correctly', async () => {
+        const gridId = 'filter501a';
+        const fields = [
+            { fieldName: 'Status', displayName: '狀態', isDate: false, allowedValues: ['Active', 'Inactive'] },
+        ];
+        const panel = document.createElement('div');
+        panel.id = 'analysis-panel-' + gridId;
+
+        const fetchOrig = global.fetch;
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue(fields),
+        });
+        const idSpy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-panel-' + gridId ? panel : null
+        );
+        waReq.toggle(gridId, 'TestVm501');
+        await new Promise(r => setTimeout(r, 50));
+
+        waReq.addFilterRow(gridId);
+        const row = panel.querySelector('.analysis-filter-row');
+        row.querySelector('.analysis-filter-field').value = 'Status';
+        // Simulate field change to swap in select
+        row.querySelector('.analysis-filter-field').dispatchEvent(new Event('change'));
+        // After change, the value control should reflect the new field.
+        // In jsdom, the new select is swapped in; set its value directly.
+        const valEl = row.querySelector('.analysis-filter-value');
+        valEl.value = 'Active';
+
+        const filters = waReq.collectFilters(gridId);
+        expect(filters).toEqual([{ field: 'Status', operator: 'Eq', value: 'Active' }]);
+
+        idSpy.mockRestore();
+        global.fetch = fetchOrig;
+    });
+});
+


### PR DESCRIPTION
## Summary

- `AnalysisFieldMeta` 新增 `AllowedValues: IReadOnlyList<string>?`，序列化至 `/meta` 端點供前端使用
- `AnalysisFieldScanner` 對枚舉型別 Dimension（含 `Nullable<TEnum>`）自動填充 `AllowedValues`（使用 `GetEnumDisplayName()`）
- `createValueInput(fieldMeta)` 新 helper：枚舉欄位渲染 `<select>`，日期欄位渲染有 `yyyy-MM-dd` placeholder 的 input，其他欄位維持 text input
- `addFilterRow()` 初始使用預設 input，欄位選取後透過 `change` 事件 in-place 替換為合適控件
- `collectFilters()` 無需變更 — `select.value` 與 `input.value` 均透過 `.analysis-filter-value` selector 正確讀取

## Test plan

- [x] 5 新 MSTest（`AnalysisFieldScannerTests`）：枚舉欄位 AllowedValues 填充、Nullable 枚舉、非枚舉/Measure 為 null
- [x] 7 新 Jest（`createValueInput`）：select 渲染、XSS 安全、日期 placeholder、預設 input、空 allowedValues、collectFilters 整合
- [x] `dotnet test` Analysis filter：345 passed, 0 failed
- [x] Jest：266 passed, 0 failed

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)