### PR TITLE
fix(analysis): add DataTruncated flag when source data exceeds 50k limit (#490)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -48,6 +48,11 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
             var filtered = ApplyFilters(baseQuery, req.Filters, wl);
 
+            // 探測原始資料是否會超過 MaxMaterializeRows (50,000)。
+            // Take(N+1) 讓 DB/記憶體只掃到第 N+1 筆即停止，代價遠小於 COUNT(*)。
+            var probeCount = filtered.Take(InProcessGroupByStrategy.MaxMaterializeRows + 1).Count();
+            var dataTruncated = probeCount > InProcessGroupByStrategy.MaxMaterializeRows;
+
             var strategy = _resolver.Resolve(dbType, req);
             List<Dictionary<string, object?>> rows;
             try
@@ -78,6 +83,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 Rows = rows,
                 TotalCount = totalCount,
                 Truncated = truncated,
+                DataTruncated = dataTruncated,
                 QueryHash = queryHash
             };
 

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryResponse.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryResponse.cs
@@ -20,6 +20,12 @@ namespace WalkingTec.Mvvm.Core.Analysis
         /// <summary>是否因超過 10,000 筆而截斷。</summary>
         public bool Truncated { get; set; }
 
+        /// <summary>
+        /// 原始資料列數是否超過 50,000 而被截斷。
+        /// 當為 true 時，Sum/Avg 等聚合結果僅基於部分資料，可能不準確。
+        /// </summary>
+        public bool DataTruncated { get; set; }
+
         /// <summary>Phase 2 快取識別用，目前留空。</summary>
         public string QueryHash { get; set; } = string.Empty;
     }

--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -1013,6 +1013,12 @@
             if (!resultDiv) return;
             clearChildren(resultDiv);
 
+            if (result.dataTruncated) {
+                var dataWarn = document.createElement('div');
+                dataWarn.className = 'layui-alert layui-alert-orange';
+                dataWarn.textContent = '⚠ 來源資料超過 50,000 筆，已截斷。聚合結果（合計、平均等）可能不準確。';
+                resultDiv.appendChild(dataWarn);
+            }
             if (result.truncated) {
                 var warn = document.createElement('div');
                 warn.className = 'layui-alert layui-alert-warm';
@@ -1499,6 +1505,12 @@
         .then(function (result) {
             if (!resultDiv) return;
             clearChildren(resultDiv);
+            if (result.dataTruncated) {
+                var dataWarn = document.createElement('div');
+                dataWarn.className = 'layui-alert layui-alert-orange';
+                dataWarn.textContent = '⚠ 來源資料超過 50,000 筆，已截斷。聚合結果（合計、平均等）可能不準確。';
+                resultDiv.appendChild(dataWarn);
+            }
             if (result.truncated) {
                 var warn = document.createElement('div');
                 warn.className = 'layui-alert layui-alert-warm';

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
@@ -757,6 +757,39 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.AreEqual(2, result.TotalCount);
         }
 
+        /// <summary>來源資料超過 50,000 筆時 DataTruncated=true（#490）</summary>
+        [TestMethod]
+        public void DataTruncated_is_true_when_source_exceeds_50000_rows()
+        {
+            // 加入 50,000 筆（超過 MaxMaterializeRows）
+            var bulk = Enumerable.Range(1, 50_000)
+                .Select(i => new SaleRecord { ID = Guid.NewGuid(), Region = $"R{i}", Category = "X", Amount = i });
+            _ctx.SaleRecords.AddRange(bulk);
+            _ctx.SaveChanges();
+
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            Assert.IsTrue(result.DataTruncated, "來源 > 50,000 時 DataTruncated 應為 true");
+        }
+
+        /// <summary>來源資料未超過 50,000 筆時 DataTruncated=false（#490）</summary>
+        [TestMethod]
+        public void DataTruncated_is_false_when_source_within_50000_rows()
+        {
+            // 基準資料只有 3 筆，遠低於 MaxMaterializeRows
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            Assert.IsFalse(result.DataTruncated, "來源 <= 50,000 時 DataTruncated 應為 false");
+        }
+
         // ─── 結果結構 ────────────────────────────────────────────────────────
 
         /// <summary>Columns 包含維度欄位名 + 度量欄位名_函式名</summary>

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -307,6 +307,76 @@ describe('wtmAnalysis.query', () => {
         expect(warningNode.textContent).toMatch(/截斷/);
     });
 
+    test('result.dataTruncated=true → 顯示來源截斷橘色警告 (#490)', async () => {
+        const { wa, makePanel, mockFetch, mockDocument } = makeEnv();
+        const panel = makePanel('analysis-panel-grid4dt');
+        const appended = [];
+        const resultDiv = {
+            id: 'analysis-result-grid4dt', textContent: '', children: [],
+            appendChild: jest.fn((c) => appended.push(c)),
+            firstChild: null, removeChild: jest.fn(),
+        };
+        mockDocument.getElementById.mockImplementation((id) => {
+            if (id === 'analysis-panel-grid4dt') return panel;
+            if (id === 'analysis-result-grid4dt') return resultDiv;
+            return null;
+        });
+        mockDocument.querySelectorAll.mockReturnValue(fakeCheckedCbs('grid4dt'));
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, text: jest.fn().mockResolvedValue('err') }) // loadMeta
+            .mockResolvedValueOnce({
+                ok: true,
+                json: jest.fn().mockResolvedValue({
+                    dataTruncated: true, truncated: false, totalCount: 500,
+                    columns: ['Region'], rows: [{ Region: '華東' }]
+                })
+            });
+
+        wa.toggle('grid4dt', 'MyVm');
+        wa.query('grid4dt');
+
+        await new Promise(r => setTimeout(r, 50));
+
+        const dataWarnNode = appended.find(c => c.className && c.className.includes('alert-orange'));
+        expect(dataWarnNode).toBeDefined();
+        expect(dataWarnNode.textContent).toMatch(/50,000/);
+        expect(dataWarnNode.textContent).toMatch(/不準確/);
+    });
+
+    test('result.dataTruncated=false → 不顯示來源截斷警告 (#490)', async () => {
+        const { wa, makePanel, mockFetch, mockDocument } = makeEnv();
+        const panel = makePanel('analysis-panel-grid4dtf');
+        const appended = [];
+        const resultDiv = {
+            id: 'analysis-result-grid4dtf', textContent: '', children: [],
+            appendChild: jest.fn((c) => appended.push(c)),
+            firstChild: null, removeChild: jest.fn(),
+        };
+        mockDocument.getElementById.mockImplementation((id) => {
+            if (id === 'analysis-panel-grid4dtf') return panel;
+            if (id === 'analysis-result-grid4dtf') return resultDiv;
+            return null;
+        });
+        mockDocument.querySelectorAll.mockReturnValue(fakeCheckedCbs('grid4dtf'));
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, text: jest.fn().mockResolvedValue('err') }) // loadMeta
+            .mockResolvedValueOnce({
+                ok: true,
+                json: jest.fn().mockResolvedValue({
+                    dataTruncated: false, truncated: false, totalCount: 3,
+                    columns: ['Region'], rows: [{ Region: '華東' }]
+                })
+            });
+
+        wa.toggle('grid4dtf', 'MyVm');
+        wa.query('grid4dtf');
+
+        await new Promise(r => setTimeout(r, 50));
+
+        const dataWarnNode = appended.find(c => c.className && c.className.includes('alert-orange'));
+        expect(dataWarnNode).toBeUndefined();
+    });
+
     test('rows=[] → clearChildren 清除舊資料後顯示 analysis-empty-state (#441)', async () => {
         const { wa, makePanel, mockFetch, mockDocument } = makeEnv();
         const panel = makePanel('analysis-panel-grid4e');
@@ -1065,6 +1135,70 @@ describe('[cov] waReq.query — branches', () => {
         waReq.query('scovQ3');
         await new Promise(r => setTimeout(r, 40));
         expect(resultDiv.innerHTML).toMatch(/截斷/);
+    });
+
+    test('query dataTruncated=true → shows orange data-truncation banner (#490)', async () => {
+        const panel = document.createElement('div');
+        panel.id = 'analysis-panel-scovDT1';
+        const resultDiv = document.createElement('div');
+        resultDiv.id = 'analysis-result-scovDT1';
+        global.fetch = jest.fn()
+            .mockResolvedValueOnce({ ok: false, text: jest.fn().mockResolvedValue('err') })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: jest.fn().mockResolvedValue({
+                    dataTruncated: true, truncated: false, totalCount: 200,
+                    columns: ['R'], rows: [{ R: 'x' }]
+                })
+            });
+        const dimCb = { dataset: { kind: 'Dimension', fieldName: 'R', gridId: 'scovDT1' }, nextElementSibling: null };
+        const msrCb = { dataset: { kind: 'Measure', fieldName: 'A', gridId: 'scovDT1', defaultFunc: 'Sum' }, nextElementSibling: null };
+        spySetup(
+            function(id) {
+                if (id === 'analysis-panel-scovDT1') return panel;
+                if (id === 'analysis-result-scovDT1') return resultDiv;
+                return null;
+            },
+            function() { return [dimCb, msrCb]; }
+        );
+        waReq.toggle('scovDT1', 'VmDT1');
+        await new Promise(r => setTimeout(r, 20));
+        waReq.query('scovDT1');
+        await new Promise(r => setTimeout(r, 40));
+        expect(resultDiv.innerHTML).toMatch(/alert-orange/);
+        expect(resultDiv.innerHTML).toMatch(/50,000/);
+        expect(resultDiv.innerHTML).toMatch(/不準確/);
+    });
+
+    test('query dataTruncated=false → no orange banner (#490)', async () => {
+        const panel = document.createElement('div');
+        panel.id = 'analysis-panel-scovDT2';
+        const resultDiv = document.createElement('div');
+        resultDiv.id = 'analysis-result-scovDT2';
+        global.fetch = jest.fn()
+            .mockResolvedValueOnce({ ok: false, text: jest.fn().mockResolvedValue('err') })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: jest.fn().mockResolvedValue({
+                    dataTruncated: false, truncated: false, totalCount: 5,
+                    columns: ['R'], rows: [{ R: 'x' }]
+                })
+            });
+        const dimCb = { dataset: { kind: 'Dimension', fieldName: 'R', gridId: 'scovDT2' }, nextElementSibling: null };
+        const msrCb = { dataset: { kind: 'Measure', fieldName: 'A', gridId: 'scovDT2', defaultFunc: 'Sum' }, nextElementSibling: null };
+        spySetup(
+            function(id) {
+                if (id === 'analysis-panel-scovDT2') return panel;
+                if (id === 'analysis-result-scovDT2') return resultDiv;
+                return null;
+            },
+            function() { return [dimCb, msrCb]; }
+        );
+        waReq.toggle('scovDT2', 'VmDT2');
+        await new Promise(r => setTimeout(r, 20));
+        waReq.query('scovDT2');
+        await new Promise(r => setTimeout(r, 40));
+        expect(resultDiv.innerHTML).not.toMatch(/alert-orange/);
     });
 
     test('query toggleRow → sets display=block after success', async () => {


### PR DESCRIPTION
## Changes

- `AnalysisQueryResponse`: new `DataTruncated: bool` property
- `AnalysisQueryEngine`: probe source count with `Take(50001).Count()` before strategy execution; sets `DataTruncated = true` if truncated
- `framework_analysis.js`: shows orange warning banner when `result.dataTruncated === true`
- +2 MSTest, +4 Jest tests

Closes #490