### PR TITLE
fix(analysis): DataTruncated false positive for ServerSideGroupByStrategy (#514)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -53,21 +53,29 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
             var filtered = ApplyFilters(baseQuery, req.Filters, wl);
 
-            // 探測原始資料是否會超過 MaxMaterializeRows (50,000)。
-            // Take(N+1) 讓 DB/記憶體只掃到第 N+1 筆即停止，代價遠小於 COUNT(*)。
-            var probeCount = filtered.Take(InProcessGroupByStrategy.MaxMaterializeRows + 1).Count();
-            var dataTruncated = probeCount > InProcessGroupByStrategy.MaxMaterializeRows;
-
             var strategy = _resolver.Resolve(dbType, req);
+            bool dataTruncated = false;
             List<Dictionary<string, object?>> rows;
             try
             {
                 rows = strategy.Execute(filtered, req, wl, cancellationToken);
+                // ServerSideGroupByStrategy issues a SQL GROUP BY — all rows are aggregated
+                // at DB level, so source data is never truncated (#514).
             }
             catch (InvalidOperationException) when (strategy is ServerSideGroupByStrategy)
             {
-                // Server-side SQL 翻譯失敗 → fallback to in-process
+                // SQL 翻譯失敗 → fallback to in-process; probe is now needed.
+                // Take(N+1) 讓 DB/記憶體只掃到第 N+1 筆即停止，代價遠小於 COUNT(*)。
+                var fbProbe = filtered.Take(InProcessGroupByStrategy.MaxMaterializeRows + 1).Count();
+                dataTruncated = fbProbe > InProcessGroupByStrategy.MaxMaterializeRows;
                 rows = new InProcessGroupByStrategy().Execute(filtered, req, wl, cancellationToken);
+            }
+
+            // In-process path: probe whether source exceeds MaxMaterializeRows.
+            if (strategy is InProcessGroupByStrategy)
+            {
+                var probeCount = filtered.Take(InProcessGroupByStrategy.MaxMaterializeRows + 1).Count();
+                dataTruncated = probeCount > InProcessGroupByStrategy.MaxMaterializeRows;
             }
 
             // Resolve enum dimension values to their [Display] names

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
@@ -1223,5 +1223,97 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                     $"{key} 的顯示名稱應為 '{expected}'");
             }
         }
+
+        // ─── DataTruncated 探針位置修正（#514）────────────────────────────────
+
+        /// <summary>
+        /// ServerSideGroupByStrategy 成功執行時，即使來源資料超過 MaxMaterializeRows，
+        /// DataTruncated 應為 false — SQL GROUP BY 在 DB 端聚合，不截斷來源資料。
+        /// </summary>
+        [TestMethod]
+        public void DataTruncated_is_false_when_ServerSide_strategy_succeeds_with_large_dataset()
+        {
+            // 50,001 筆記錄：超過 MaxMaterializeRows(50,000)
+            // 使用 List.AsQueryable() 避免 DB 依賴，同時 Take().Count() 在 in-memory 正確運作
+            var bigData = Enumerable.Range(0, InProcessGroupByStrategy.MaxMaterializeRows + 1)
+                .Select(i => new SaleRecord
+                {
+                    ID       = Guid.NewGuid(),
+                    Region   = i % 2 == 0 ? "華東" : "華南",
+                    Category = "A",
+                    Channel  = SaleChannel.Online,
+                    Amount   = 1m
+                })
+                .AsQueryable();
+
+            var whitelist = AnalysisFieldScanner.ScanModel(typeof(SaleRecord));
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            // FakeServerSideStrategy: 繼承 ServerSideGroupByStrategy（使 type check 成立），
+            // 實際委派給 InProcessGroupByStrategy 以便在 in-memory 資料上執行。
+            var resolver = new FakeServerSideResolver();
+            var engine   = new AnalysisQueryEngine(resolver);
+
+            // dbType=SqlServer → FakeServerSideStrategy（is ServerSideGroupByStrategy = true）
+            // 修復前：probe 在策略選擇前執行 → dataTruncated = true（誤報）
+            // 修復後：probe 只在 InProcessGroupByStrategy 路徑執行 → dataTruncated = false
+            var result = engine.Execute(bigData, req, whitelist, DBTypeEnum.SqlServer);
+
+            Assert.IsFalse(result.DataTruncated,
+                "ServerSideGroupByStrategy 成功時，DataTruncated 應為 false（#514）");
+        }
+
+        /// <summary>
+        /// InProcessGroupByStrategy 路徑下，超過 MaxMaterializeRows 時 DataTruncated 應為 true。
+        /// 確保修復 #514 後 in-process 路徑的探針仍正確運作。
+        /// </summary>
+        [TestMethod]
+        public void DataTruncated_is_true_when_InProcess_strategy_has_large_dataset()
+        {
+            var bigData = Enumerable.Range(0, InProcessGroupByStrategy.MaxMaterializeRows + 1)
+                .Select(i => new SaleRecord
+                {
+                    ID       = Guid.NewGuid(),
+                    Region   = i % 2 == 0 ? "華東" : "華南",
+                    Category = "A",
+                    Channel  = SaleChannel.Online,
+                    Amount   = 1m
+                })
+                .AsQueryable();
+
+            var whitelist = AnalysisFieldScanner.ScanModel(typeof(SaleRecord));
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            // 預設 resolver + SQLite → InProcessGroupByStrategy
+            var result = Engine().Execute(bigData, req, whitelist, DBTypeEnum.SQLite);
+
+            Assert.IsTrue(result.DataTruncated,
+                "InProcessGroupByStrategy 路徑下，超過 MaxMaterializeRows 時 DataTruncated 應為 true");
+        }
+
+        /// <summary>FakeServerSideStrategy：繼承 ServerSideGroupByStrategy，委派給 InProcessGroupByStrategy</summary>
+        private class FakeServerSideStrategy : ServerSideGroupByStrategy
+        {
+            private static readonly InProcessGroupByStrategy _inner = new();
+
+            public override List<Dictionary<string, object?>> Execute<TModel>(
+                IQueryable<TModel> query,
+                AnalysisQueryRequest req,
+                Dictionary<string, AnalysisFieldMeta> whitelist,
+                System.Threading.CancellationToken cancellationToken = default)
+                => _inner.Execute(query, req, whitelist, cancellationToken);
+        }
+
+        private class FakeServerSideResolver : GroupByStrategyResolver
+        {
+            private static readonly FakeServerSideStrategy Fake = new();
+
+            public override IGroupByStrategy Resolve(DBTypeEnum dbType, AnalysisQueryRequest req)
+                => dbType == DBTypeEnum.SqlServer ? Fake : base.Resolve(dbType, req);
+        }
     }
 }


### PR DESCRIPTION
## Problem

`DataTruncated` probe ran **before** strategy selection. For queries routed to `ServerSideGroupByStrategy` (SQL GROUP BY), the probe would fire on 50,001+ rows and set `DataTruncated = true` — even though the database aggregates all rows at the SQL level with no truncation.

## Fix

Moved the `Take(N+1).Count()` probe inside the `InProcessGroupByStrategy` branch only. The fallback catch block (ServerSide → InProcess) retains its own probe since that path **does** materialize rows in memory.

```csharp
// Before: probe always ran here (wrong for ServerSide path)

// After:
if (strategy is InProcessGroupByStrategy)
{
    var probeCount = filtered.Take(MaxMaterializeRows + 1).Count();
    dataTruncated = probeCount > MaxMaterializeRows;
}
```

## Tests

2 new MSTest regression tests in `AnalysisQueryEngineTests.cs`:

- `DataTruncated_is_false_when_ServerSide_strategy_succeeds_with_large_dataset` — 50,001 in-memory records via `FakeServerSideStrategy`; asserts `DataTruncated == false`
- `DataTruncated_is_true_when_InProcess_strategy_has_large_dataset` — same dataset via default SQLite resolver; asserts `DataTruncated == true`

Closes #514