### PR TITLE
fix(etl): sanitize error messages to prevent secret leakage (#518)

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlErrorSanitizer.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlErrorSanitizer.cs
@@ -9,7 +9,7 @@ namespace WalkingTec.Mvvm.Etl.Pipeline;
 /// Prevents connection strings and stack traces from leaking into the database.
 /// Full stack traces should be written to structured logging (ILogger) instead.
 /// </summary>
-internal static class EtlErrorSanitizer
+public static class EtlErrorSanitizer
 {
     // Patterns covering common ADO.NET / EF Core connection string fragments
     private static readonly Regex[] _sensitivePatterns =

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlErrorSanitizer.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlErrorSanitizer.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System;
+using System.Text.RegularExpressions;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// Sanitizes exception messages before storing in RunLog.
+/// Prevents connection strings and stack traces from leaking into the database.
+/// Full stack traces should be written to structured logging (ILogger) instead.
+/// </summary>
+internal static class EtlErrorSanitizer
+{
+    // Patterns covering common ADO.NET / EF Core connection string fragments
+    private static readonly Regex[] _sensitivePatterns =
+    [
+        new Regex(@"Password\s*=[^;""']*",   RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new Regex(@"Pwd\s*=[^;""']*",        RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new Regex(@"User Id\s*=[^;""']*",    RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new Regex(@"Uid\s*=[^;""']*",        RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new Regex(@"Data Source\s*=[^;""']*",RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new Regex(@"Server\s*=[^;""']*",     RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new Regex(@"Database\s*=[^;""']*",   RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    private const int MaxLength = 2000;
+
+    /// <summary>
+    /// Returns a sanitized, length-capped message suitable for RunLog storage.
+    /// Uses ex.Message only (no stack trace) and redacts connection string fragments.
+    /// </summary>
+    public static string Sanitize(Exception ex)
+    {
+        var message = ex.Message;
+        foreach (var pattern in _sensitivePatterns)
+            message = pattern.Replace(message, "[redacted]");
+        return message.Length > MaxLength ? message[..MaxLength] : message;
+    }
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
@@ -146,7 +146,7 @@ public class EtlPipelineExecutor
                 ExtractedRows = totalExtracted,
                 LoadedRows = totalLoaded,
                 ElapsedMs = sw.ElapsedMilliseconds,
-                ErrorMessage = ex.ToString()
+                ErrorMessage = EtlErrorSanitizer.Sanitize(ex)
             };
         }
     }

--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlQuartzJob.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlQuartzJob.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Quartz;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Support.Quartz;
@@ -152,13 +153,16 @@ public class EtlQuartzJob : WtmJob
         }
         catch (Exception ex)
         {
+            Sp.GetService<ILogger<EtlQuartzJob>>()
+                ?.LogError(ex, "ETL job {JobId} failed with unhandled exception", jobDefId);
+            var sanitized = EtlErrorSanitizer.Sanitize(ex);
             result = new EtlExecutionResult
             {
                 Success = false,
-                ErrorMessage = ex.ToString(),
+                ErrorMessage = sanitized,
                 ElapsedMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds
             };
-            jobDef.LastError = ex.Message.Length > 2000 ? ex.Message[..2000] : ex.Message;
+            jobDef.LastError = sanitized;
             jobDef.Status = EtlJobStatus.Failed;
         }
         finally

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EtlErrorSanitizerTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EtlErrorSanitizerTests.cs
@@ -1,0 +1,65 @@
+#nullable enable
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline;
+
+[TestClass]
+public class EtlErrorSanitizerTests
+{
+    [TestMethod]
+    public void Sanitize_plain_exception_returns_message_without_stack_trace()
+    {
+        Exception ex;
+        try { throw new InvalidOperationException("something went wrong"); }
+        catch (Exception e) { ex = e; }
+
+        var result = EtlErrorSanitizer.Sanitize(ex);
+
+        Assert.AreEqual("something went wrong", result);
+        Assert.IsFalse(result.Contains("at WalkingTec"), "Stack trace should not appear in sanitized message");
+    }
+
+    [TestMethod]
+    public void Sanitize_redacts_Password_in_message()
+    {
+        var ex = new Exception("Login failed for server; Password=S3cr3t;Database=MyDb");
+
+        var result = EtlErrorSanitizer.Sanitize(ex);
+
+        Assert.IsFalse(result.Contains("S3cr3t"), "Password value must be redacted");
+        Assert.IsTrue(result.Contains("[redacted]"), "Redaction placeholder must be present");
+    }
+
+    [TestMethod]
+    public void Sanitize_redacts_Data_Source_in_message()
+    {
+        var ex = new Exception("Cannot open server; Data Source=192.168.1.1;User Id=sa;Password=abc123");
+
+        var result = EtlErrorSanitizer.Sanitize(ex);
+
+        Assert.IsFalse(result.Contains("192.168.1.1"), "Data Source value must be redacted");
+        Assert.IsFalse(result.Contains("abc123"), "Password value must be redacted");
+    }
+
+    [TestMethod]
+    public void Sanitize_truncates_message_exceeding_2000_chars()
+    {
+        var ex = new Exception(new string('x', 3000));
+
+        var result = EtlErrorSanitizer.Sanitize(ex);
+
+        Assert.AreEqual(2000, result.Length);
+    }
+
+    [TestMethod]
+    public void Sanitize_message_without_sensitive_data_is_unchanged()
+    {
+        var ex = new Exception("ETL step failed: source returned 0 rows");
+
+        var result = EtlErrorSanitizer.Sanitize(ex);
+
+        Assert.AreEqual("ETL step failed: source returned 0 rows", result);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `ex.ToString()` with `EtlErrorSanitizer.Sanitize()` in `EtlPipelineExecutor` and `EtlQuartzJob`
- Add `EtlErrorSanitizer` (regex redaction of Password/Pwd/User Id/Server/Database/Data Source fragments, 2000-char cap)
- Route full stack traces to `ILogger<EtlQuartzJob>` for structured log storage instead of DB columns
- Add 5 MSTest cases in `EtlErrorSanitizerTests` covering redaction, truncation, and no-ops

## Test plan

- [x] `dotnet test WalkingTec.Mvvm.Etl.Test` — 141 passed, 0 failed
- [x] `EtlErrorSanitizerTests` (5 new tests) all pass
- [x] No secrets stored in `EtlRunLog.ErrorMessage` or `EtlJobDefinition.LastError`

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)