### PR TITLE
fix(analysis): use RoleCode instead of RoleName in CheckAccess

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -313,7 +313,7 @@ namespace WalkingTec.Mvvm.Mvc
             var attr = vmType.GetCustomAttribute<EnableAnalysisAttribute>();
             if (attr == null || string.IsNullOrEmpty(attr.AllowedRoles)) return true;
 
-            var userRoles = Wtm?.LoginUserInfo?.Roles?.Select(r => r.RoleName) ?? Enumerable.Empty<string>();
+            var userRoles = Wtm?.LoginUserInfo?.Roles?.Select(r => r.RoleCode) ?? Enumerable.Empty<string>();
             if (userRoles.Any(r => string.Equals(r, "Admin", StringComparison.OrdinalIgnoreCase))) return true;
 
             var allowed = attr.AllowedRoles.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(r => r.Trim());

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -2005,7 +2005,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         {
             var controller = CreateController();
             controller.Wtm.LoginUserInfo.Roles = roles
-                .Select(r => new SimpleRole { RoleName = r })
+                .Select(r => new SimpleRole { RoleCode = r })
                 .ToList();
             return controller;
         }
@@ -2107,6 +2107,36 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
 
+
+        [TestMethod]
+        public void GetMeta_uses_RoleCode_not_RoleName_for_access_check()
+        {
+            // 驗證 CheckAccess 使用 RoleCode 而非 RoleName 做比對
+            // 當 RoleCode = "Analyst" 但 RoleName = "分析師" 時，
+            // AllowedRoles = "Analyst" 應該通過（因為比對 RoleCode）
+            var controller = CreateController();
+            controller.Wtm.LoginUserInfo.Roles = new List<SimpleRole>
+            {
+                new SimpleRole { RoleCode = "Analyst", RoleName = "分析師" }
+            };
+            var result = controller.GetMeta(typeof(RestrictedSaleListVM).FullName);
+            Assert.IsInstanceOfType(result, typeof(OkObjectResult),
+                "RoleCode 符合 AllowedRoles 應允許存取（即使 RoleName 不同）");
+        }
+
+        [TestMethod]
+        public void GetMeta_returns_403_when_RoleCode_mismatches_AllowedRoles()
+        {
+            // 即使 RoleName = "Analyst"，若 RoleCode = "viewer"，應被拒絕
+            var controller = CreateController();
+            controller.Wtm.LoginUserInfo.Roles = new List<SimpleRole>
+            {
+                new SimpleRole { RoleCode = "viewer", RoleName = "Analyst" }
+            };
+            var result = controller.GetMeta(typeof(RestrictedSaleListVM).FullName);
+            Assert.IsInstanceOfType(result, typeof(ForbidResult),
+                "RoleName 符合但 RoleCode 不符 AllowedRoles，應回傳 ForbidResult");
+        }
 
         [TestMethod]
         [TestCategory("Analysis")]


### PR DESCRIPTION
## 問題

`_AnalysisController.CheckAccess()` 使用 `r.RoleName` 比對 `AllowedRoles`，而 Dashboard 模組使用 `r.RoleCode`。在 WTM 中 RoleCode 和 RoleName 常常不同（例如 RoleCode=`"analyst"` / RoleName=`"分析師"`），導致 Analysis 存取規則實際上比對錯誤欄位，可能造成權限漏洞或誤判。

## 修改內容

- `_AnalysisController.CheckAccess()`：`r.RoleName` → `r.RoleCode`（與 Dashboard 模組一致）
- 測試 helper `CreateControllerWithRoles()`：設定 `RoleCode` 而非 `RoleName`
- 新增 2 個回歸測試：
  - `GetMeta_uses_RoleCode_not_RoleName_for_access_check` — RoleCode 符合 AllowedRoles，即使 RoleName 不同，應允許
  - `GetMeta_returns_403_when_RoleCode_mismatches_AllowedRoles` — RoleName 符合但 RoleCode 不符，應拒絕

## 測試結果

98 tests passed ✅

Closes #520