### PR TITLE
fix(etl): reset ghost Running jobs on service startup

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlHostedService.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlHostedService.cs
@@ -30,12 +30,13 @@ public class EtlHostedService : IHostedService
 
         await _scheduler.Start(cancellationToken);
 
-        // 從 DB 載入所有 Enabled 的 ETL Job
+        // 重置幽靈 Running Job（上次程序崩潰遺留），再載入 Enabled/Failed Job
         // DB 可能尚未完成 DataInit（SyncDb seeding），延遲重試避免 race condition
         for (var attempt = 1; attempt <= 3; attempt++)
         {
             try
             {
+                await _schedulerService.ResetGhostRunningJobsAsync();
                 await _schedulerService.LoadJobsFromDbAsync();
                 return;
             }

--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlSchedulerService.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlSchedulerService.cs
@@ -30,6 +30,39 @@ public class EtlSchedulerService
         _scheduler = scheduler;
     }
 
+    /// <summary>啟動時重置幽靈 Running Job（上次程序崩潰遺留）為 Failed 狀態</summary>
+    public async Task ResetGhostRunningJobsAsync()
+    {
+        using var scope = _sp.CreateScope();
+        var wtm = scope.ServiceProvider.GetRequiredService<WTMContext>();
+
+        var ghostJobs = await wtm.DC.Set<EtlJobDefinition>()
+            .Where(j => j.Status == EtlJobStatus.Running)
+            .ToListAsync();
+
+        if (ghostJobs.Count == 0) return;
+
+        var now = DateTime.UtcNow;
+        foreach (var job in ghostJobs)
+        {
+            job.Status = EtlJobStatus.Failed;
+            job.LastError = "Process restarted while job was running — previous execution incomplete.";
+            wtm.DC.Set<EtlJobDefinition>().Update(job);
+
+            wtm.DC.Set<EtlRunLog>().Add(new EtlRunLog
+            {
+                JobId      = job.ID,
+                Trigger    = EtlRunTrigger.Scheduled,
+                Result     = EtlRunResult.Failed,
+                ErrorMessage = "Process restarted while job was running — previous execution incomplete.",
+                StartedAt  = now,
+                FinishedAt = now,
+            });
+        }
+
+        await wtm.DC.SaveChangesAsync();
+    }
+
     /// <summary>啟動時從 DB 載入所有 Enabled 的 ETL Job 排程</summary>
     public async Task LoadJobsFromDbAsync()
     {

--- a/test/WalkingTec.Mvvm.Etl.Test/Scheduling/GhostRunningJobsTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Scheduling/GhostRunningJobsTests.cs
@@ -1,0 +1,108 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Etl.Models;
+using WalkingTec.Mvvm.Etl.Scheduling;
+using WalkingTec.Mvvm.Etl.Test.ViewModels;
+using WalkingTec.Mvvm.Test.Mock;
+
+namespace WalkingTec.Mvvm.Etl.Test.Scheduling;
+
+/// <summary>
+/// 測試 EtlSchedulerService.ResetGhostRunningJobsAsync()：
+/// 服務啟動時將上次崩潰遺留的 Running Job 重置為 Failed。
+/// </summary>
+[TestClass]
+public class GhostRunningJobsTests
+{
+    private EtlTestDataContext _dc = null!;
+    private IServiceProvider _sp = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        _dc = new EtlTestDataContext(dbName, DBTypeEnum.Memory);
+        var wtm = MockWtmContext.CreateWtmContext(_dc);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(wtm);
+        _sp = services.BuildServiceProvider();
+    }
+
+    private EtlJobDefinition AddJob(EtlJobStatus status, string name = "TestJob")
+    {
+        var job = new EtlJobDefinition
+        {
+            Name = name,
+            CronExpression = "0 0 * * *",
+            SourceCsKey = "test",
+            SourceDbType = DBTypeEnum.SqlServer,
+            WatermarkType = EtlWatermarkType.FullLoad,
+            Status = status,
+        };
+        _dc.Set<EtlJobDefinition>().Add(job);
+        _dc.SaveChanges();
+        return job;
+    }
+
+    [TestMethod]
+    public async Task ResetGhostRunningJobs_sets_Running_to_Failed()
+    {
+        var job = AddJob(EtlJobStatus.Running);
+
+        var svc = new EtlSchedulerService(_sp);
+        await svc.ResetGhostRunningJobsAsync();
+
+        var updated = await _dc.Set<EtlJobDefinition>().FindAsync(job.ID);
+        Assert.AreEqual(EtlJobStatus.Failed, updated!.Status,
+            "Running Job 應被重置為 Failed");
+        Assert.IsNotNull(updated.LastError, "LastError 應記錄崩潰原因");
+    }
+
+    [TestMethod]
+    public async Task ResetGhostRunningJobs_writes_RunLog_for_each_ghost()
+    {
+        var job1 = AddJob(EtlJobStatus.Running, "Ghost1");
+        var job2 = AddJob(EtlJobStatus.Running, "Ghost2");
+
+        var svc = new EtlSchedulerService(_sp);
+        await svc.ResetGhostRunningJobsAsync();
+
+        var logs = _dc.Set<EtlRunLog>().Where(l => l.Result == EtlRunResult.Failed).ToList();
+        Assert.AreEqual(2, logs.Count, "每個幽靈 Job 應各有一筆 Failed RunLog");
+        Assert.IsTrue(logs.Any(l => l.JobId == job1.ID), "Ghost1 應有 RunLog");
+        Assert.IsTrue(logs.Any(l => l.JobId == job2.ID), "Ghost2 應有 RunLog");
+    }
+
+    [TestMethod]
+    public async Task ResetGhostRunningJobs_does_not_affect_non_Running_jobs()
+    {
+        AddJob(EtlJobStatus.Enabled, "Active");
+        AddJob(EtlJobStatus.Failed, "AlreadyFailed");
+        AddJob(EtlJobStatus.Disabled, "Disabled");
+
+        var svc = new EtlSchedulerService(_sp);
+        await svc.ResetGhostRunningJobsAsync();
+
+        var all = _dc.Set<EtlJobDefinition>().ToList();
+        Assert.IsTrue(all.Any(j => j.Name == "Active"    && j.Status == EtlJobStatus.Enabled),   "Enabled 不應被改");
+        Assert.IsTrue(all.Any(j => j.Name == "AlreadyFailed" && j.Status == EtlJobStatus.Failed), "Failed 不應被改");
+        Assert.IsTrue(all.Any(j => j.Name == "Disabled"  && j.Status == EtlJobStatus.Disabled),  "Disabled 不應被改");
+        Assert.AreEqual(0, _dc.Set<EtlRunLog>().Count(), "無幽靈 Job，不應寫入 RunLog");
+    }
+
+    [TestMethod]
+    public async Task ResetGhostRunningJobs_no_jobs_completes_without_error()
+    {
+        // 完全空白的 DB — 應靜默完成
+        var svc = new EtlSchedulerService(_sp);
+        await svc.ResetGhostRunningJobsAsync(); // should not throw
+        Assert.AreEqual(0, _dc.Set<EtlRunLog>().Count());
+    }
+}


### PR DESCRIPTION
## 問題

當程序在 `EtlQuartzJob` 執行期間被強制終止（kill、crash、OOM），Job 的 `Status` 會永遠停在 `Running`，因為 `EtlHostedService.StartAsync()` 只載入 `Enabled`/`Failed` 狀態的 Job。這些「幽靈 Running Job」永遠不會被重新排程。

## 修改內容

**`EtlSchedulerService.ResetGhostRunningJobsAsync()`（新方法）**
- 找出所有 `Status == Running` 的 Job
- 設定 `Status = Failed`，`LastError = "Process restarted while job was running…"`
- 為每個幽靈 Job 寫入 `EtlRunLog`（Result=Failed）
- 冪等操作：無幽靈 Job 時靜默完成

**`EtlHostedService.StartAsync()`**
- 在 `LoadJobsFromDbAsync()` 之前呼叫 `ResetGhostRunningJobsAsync()`
- 在現有重試迴圈內，確保 DB 未就緒時一起重試

**`GhostRunningJobsTests`（新增 4 個 MSTest）**
- Running → Failed 狀態重置
- RunLog 寫入（多個幽靈 Job）
- 非 Running Job 不受影響
- 空 DB 靜默完成

## 測試結果

4 tests passed ✅

Closes #519