### PR TITLE
feat(dashboard): log warning when JsonFile storage backend is used

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/DashboardServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ namespace WalkingTec.Mvvm.Core.Dashboard
     {
         public static IServiceCollection AddWtmDashboard(this IServiceCollection services, Action<DashboardOptions>? setupAction = null)
         {
+            services.AddLogging();
             services.AddOptions<DashboardOptions>();
             if (setupAction != null)
             {

--- a/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace WalkingTec.Mvvm.Core.Dashboard;
@@ -21,13 +22,21 @@ public class JsonFileDashboardService : IDashboardService
     private bool _initialized;
     private readonly SemaphoreSlim _initLock = new(1, 1);
 
-    public JsonFileDashboardService(IOptions<DashboardOptions> options, IEnumerable<IWidgetDataSource> dataSources)
+    public JsonFileDashboardService(
+        IOptions<DashboardOptions> options,
+        IEnumerable<IWidgetDataSource> dataSources,
+        ILogger<JsonFileDashboardService> logger)
     {
         _options = options.Value;
         _dataSources = dataSources;
         // Spec: scan _baseDir
         // Path resolution: Use base directory
         _baseDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, _options.DashboardDirectory);
+
+        logger.LogWarning(
+            "[WTM Dashboard] Using JsonFile storage backend. " +
+            "This is NOT suitable for multi-node (load-balanced) deployments. " +
+            "Configure a database backend for production use.");
     }
 
     private async Task EnsureInitializedAsync()

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/JsonFileDashboardServiceTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/JsonFileDashboardServiceTests.cs
@@ -30,7 +30,8 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             // or we need to ensure it uses an absolute path if provided.
             // Oh, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, tempPath) if tempPath is absolute will return tempPath in Windows but not always what we expect. Let's fix DashboardDirectory to be an absolute path here, and see if Path.Combine handles it correctly. Path.Combine(baseDir, absPath) returns absPath in .NET Core.
             
-            _service = new JsonFileDashboardService(options, Array.Empty<IWidgetDataSource>());
+            _service = new JsonFileDashboardService(options, Array.Empty<IWidgetDataSource>(),
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<JsonFileDashboardService>.Instance);
         }
 
         [TestCleanup]
@@ -230,7 +231,8 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         private JsonFileDashboardService CreateServiceWithDataSource(IWidgetDataSource ds)
         {
             var options = Options.Create(new DashboardOptions { DashboardDirectory = _tempDir });
-            return new JsonFileDashboardService(options, new[] { ds });
+            return new JsonFileDashboardService(options, new[] { ds },
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<JsonFileDashboardService>.Instance);
         }
 
         [TestMethod]
@@ -330,7 +332,8 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
                 .ReturnsAsync(new WidgetDataResult { Value = 99 });
 
             var options = Options.Create(new DashboardOptions { DashboardDirectory = _tempDir });
-            var svc = new JsonFileDashboardService(options, new IWidgetDataSource[] { kindDs.Object });
+            var svc = new JsonFileDashboardService(options, new IWidgetDataSource[] { kindDs.Object },
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<JsonFileDashboardService>.Instance);
 
             var def = new DashboardDefinition
             {

--- a/test/WalkingTec.Mvvm.Core.Test/Integration/CfoFinancialDashboardIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/CfoFinancialDashboardIntegrationTests.cs
@@ -1023,7 +1023,8 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
                 {
                     DashboardDirectory = $"test_dashboards_{Guid.NewGuid():N}"
                 }),
-                Enumerable.Empty<IWidgetDataSource>());
+                Enumerable.Empty<IWidgetDataSource>(),
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<JsonFileDashboardService>.Instance);
 
             // IT 角色不應能存取 CFO 儀表板
             service.CanAccess(cfoDashboard, "it_user", new[] { "IT" })


### PR DESCRIPTION
## 問題

`JsonFileDashboardService` 使用本機檔案系統儲存 Dashboard 定義，不支援多節點（負載均衡）部署。但目前沒有任何警告，使用者可能在不知情的情況下部署到多節點環境，導致資料不一致。

## 修改內容

**`JsonFileDashboardService`（constructor）**
- 注入 `ILogger<JsonFileDashboardService>`
- 在 constructor 發出 Warning log：
  ```
  [WTM Dashboard] Using JsonFile storage backend. This is NOT suitable
  for multi-node (load-balanced) deployments. Configure a database
  backend for production use.
  ```
- 作為 singleton，此 warning 只會在 startup 時出現一次

**`DashboardServiceCollectionExtensions.AddWtmDashboard()`**
- 加入 `services.AddLogging()` 確保 `ILogger` 在所有情境下都可 resolve（`AddLogging()` 是冪等的）

**測試更新（4 處）**
- `JsonFileDashboardServiceTests` (2 處)
- `DashboardServiceCollectionExtensionsTests` (1 處，透過 DI)
- `CfoFinancialDashboardIntegrationTests` (1 處)
- 全部改傳 `NullLogger<JsonFileDashboardService>.Instance`

## 測試結果

146 tests passed ✅

Closes #521