### PR TITLE
fix(analysis): add DataTruncatedMessage for human-readable data truncation notice

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
@@ -142,8 +142,10 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 {
                     ("匯出時間", DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss") + " UTC"),
                     ("QueryHash",  result.QueryHash  ?? ""),
-                    ("資料筆數",   result.TotalCount.ToString()),
-                    ("已截斷",     result.Truncated ? "是" : "否"),
+                    ("資料筆數",       result.TotalCount.ToString()),
+                    ("已截斷",         result.Truncated ? "是" : "否"),
+                    ("來源資料截斷",   result.DataTruncated ? "是" : "否"),
+                    ("來源截斷說明",   result.DataTruncatedMessage ?? ""),
                 };
                 for (int i = 0; i < rows.Length; i++)
                 {

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -99,6 +99,9 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 TotalCount = totalCount,
                 Truncated = truncated,
                 DataTruncated = dataTruncated,
+                DataTruncatedMessage = dataTruncated
+                    ? "聚合結果僅基於前 50,000 筆原始資料，可能不代表完整數據。建議縮小篩選條件或聯繫管理員啟用 ServerSide 策略。"
+                    : null,
                 QueryHash = queryHash,
                 ColumnDisplayNames = displayNames
             };

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryResponse.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryResponse.cs
@@ -26,6 +26,12 @@ namespace WalkingTec.Mvvm.Core.Analysis
         /// </summary>
         public bool DataTruncated { get; set; }
 
+        /// <summary>
+        /// 當 DataTruncated 為 true 時，提供給終端使用者的說明訊息（含建議操作）。
+        /// DataTruncated 為 false 時為 null。
+        /// </summary>
+        public string? DataTruncatedMessage { get; set; }
+
         /// <summary>Phase 2 快取識別用，目前留空。</summary>
         public string QueryHash { get; set; } = string.Empty;
 

--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -1084,7 +1084,7 @@
             if (result.dataTruncated) {
                 var dataWarn = document.createElement('div');
                 dataWarn.className = 'layui-alert layui-alert-orange';
-                dataWarn.textContent = '⚠ 來源資料超過 50,000 筆，已截斷。聚合結果（合計、平均等）可能不準確。';
+                dataWarn.textContent = '⚠ ' + (result.dataTruncatedMessage || '來源資料超過 50,000 筆，已截斷。聚合結果（合計、平均等）可能不準確。');
                 resultDiv.appendChild(dataWarn);
             }
             if (result.truncated) {
@@ -1601,7 +1601,7 @@
             if (result.dataTruncated) {
                 var dataWarn = document.createElement('div');
                 dataWarn.className = 'layui-alert layui-alert-orange';
-                dataWarn.textContent = '⚠ 來源資料超過 50,000 筆，已截斷。聚合結果（合計、平均等）可能不準確。';
+                dataWarn.textContent = '⚠ ' + (result.dataTruncatedMessage || '來源資料超過 50,000 筆，已截斷。聚合結果（合計、平均等）可能不準確。');
                 resultDiv.appendChild(dataWarn);
             }
             if (result.truncated) {

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
@@ -1295,6 +1295,56 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 "InProcessGroupByStrategy 路徑下，超過 MaxMaterializeRows 時 DataTruncated 應為 true");
         }
 
+        // ─── DataTruncatedMessage（#524）─────────────────────────────────────
+
+        /// <summary>
+        /// DataTruncated = true 時，DataTruncatedMessage 應包含有意義的說明文字。
+        /// </summary>
+        [TestMethod]
+        public void DataTruncatedMessage_is_populated_when_DataTruncated_is_true()
+        {
+            var bigData = Enumerable.Range(0, InProcessGroupByStrategy.MaxMaterializeRows + 1)
+                .Select(i => new SaleRecord
+                {
+                    ID       = Guid.NewGuid(),
+                    Region   = i % 2 == 0 ? "華東" : "華南",
+                    Category = "A",
+                    Channel  = SaleChannel.Online,
+                    Amount   = 1m
+                })
+                .AsQueryable();
+
+            var whitelist = AnalysisFieldScanner.ScanModel(typeof(SaleRecord));
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            var result = Engine().Execute(bigData, req, whitelist, DBTypeEnum.SQLite);
+
+            Assert.IsTrue(result.DataTruncated);
+            Assert.IsNotNull(result.DataTruncatedMessage,
+                "DataTruncated=true 時，DataTruncatedMessage 不應為 null（#524）");
+            StringAssert.Contains(result.DataTruncatedMessage, "50,000",
+                "說明訊息應提及 50,000 筆上限");
+        }
+
+        /// <summary>
+        /// DataTruncated = false 時，DataTruncatedMessage 應為 null（不發出無謂雜訊）。
+        /// </summary>
+        [TestMethod]
+        public void DataTruncatedMessage_is_null_when_DataTruncated_is_false()
+        {
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            var result = Engine().Execute(Q(), req, _whitelist);
+
+            Assert.IsFalse(result.DataTruncated);
+            Assert.IsNull(result.DataTruncatedMessage,
+                "DataTruncated=false 時，DataTruncatedMessage 應為 null（#524）");
+        }
+
         /// <summary>FakeServerSideStrategy：繼承 ServerSideGroupByStrategy，委派給 InProcessGroupByStrategy</summary>
         private class FakeServerSideStrategy : ServerSideGroupByStrategy
         {


### PR DESCRIPTION
## Summary

- Add `DataTruncatedMessage string?` to `AnalysisQueryResponse` — populated when source data exceeds 50,000 rows
- `AnalysisQueryEngine` sets the localised message when `dataTruncated = true`, `null` otherwise
- `framework_analysis.js` yellow banner uses `result.dataTruncatedMessage` with fallback for backward compat
- `AnalysisExcelExporter` adds **來源資料截斷** + **來源截斷說明** rows to Metadata sheet
- 2 new MSTests (message populated when truncated; null when not)

## Test plan

- [x] `DataTruncatedMessage_is_populated_when_DataTruncated_is_true` — passes
- [x] `DataTruncatedMessage_is_null_when_DataTruncated_is_false` — passes
- [x] `dotnet build src/WalkingTec.Mvvm.Core` — clean, 0 errors

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)