### PR TITLE
fix: volatile _initialized, [ApiController], deterministic ComputeHash (#541)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -461,6 +461,17 @@ namespace WalkingTec.Mvvm.Core.Analysis
         /// <summary>
         /// 聚合函式名稱的中文對照（用於匯出標頭）。
         /// </summary>
+        /// <summary>
+        /// 固定序列化選項：確保 ComputeHash() 在所有環境、STJ 版本下產生相同的 JSON 字串。
+        /// </summary>
+        private static readonly System.Text.Json.JsonSerializerOptions _hashSerializerOptions =
+            new System.Text.Json.JsonSerializerOptions
+            {
+                PropertyNamingPolicy = null,
+                WriteIndented = false,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+            };
+
         private static readonly Dictionary<AggregateFunc, string> _funcDisplayNames = new()
         {
             { AggregateFunc.Sum,   "合計" },
@@ -504,7 +515,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
         private static string ComputeHash(AnalysisQueryRequest req, string? identityKey = null)
         {
-            var raw = System.Text.Json.JsonSerializer.Serialize(req);
+            var raw = System.Text.Json.JsonSerializer.Serialize(req, _hashSerializerOptions);
             if (!string.IsNullOrEmpty(identityKey))
             {
                 raw += "|" + identityKey;

--- a/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
@@ -18,7 +18,7 @@ public class JsonFileDashboardService : IDashboardService
     private readonly ConcurrentDictionary<string, DashboardSummary> _index = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
     private readonly string _baseDir;
-    private bool _initialized;
+    private volatile bool _initialized;
     private readonly SemaphoreSlim _initLock = new(1, 1);
 
     public JsonFileDashboardService(IOptions<DashboardOptions> options, IEnumerable<IWidgetDataSource> dataSources)

--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
@@ -12,6 +12,7 @@ using WalkingTec.Mvvm.Mvc;
 
 namespace WalkingTec.Mvvm.Mvc;
 
+[ApiController]
 [ActionDescription("ETL Job 管理")]
 public class _EtlJobController : BaseController
 {


### PR DESCRIPTION
## Summary

Three independent code-quality bugs identified in #541:

1. **`volatile _initialized` (Dashboard)** — `JsonFileDashboardService._initialized` was non-volatile, which allows ARM CPUs (Apple Silicon, Graviton) to read a stale `false` through the double-checked lock pattern, causing redundant re-initialization.

2. **`[ApiController]` on `_EtlJobController`** — missing attribute that `_AnalysisController` and `_DashboardController` already carry. Without it: model-validation failures don't auto-return 400, and `[FromBody]` binding source isn't inferred.

3. **Deterministic `ComputeHash` (Analysis)** — `JsonSerializer.Serialize(req)` with no options relies on the global default `JsonSerializerOptions`, which can be overridden by the host or vary across STJ versions. A `static readonly` instance with `PropertyNamingPolicy=null, WriteIndented=false` ensures the same hash for the same request everywhere.

## Test plan

- [x] 65 existing `AnalysisQueryEngine` tests pass
- [x] `dotnet build` clean on Core + Etl projects

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)