### PR TITLE
fix(dashboard): log exceptions instead of silently swallowing in GetAsync/EnsureInitializedAsync

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/DashboardServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ namespace WalkingTec.Mvvm.Core.Dashboard
     {
         public static IServiceCollection AddWtmDashboard(this IServiceCollection services, Action<DashboardOptions>? setupAction = null)
         {
+            services.AddLogging();
             services.AddOptions<DashboardOptions>();
             if (setupAction != null)
             {

--- a/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace WalkingTec.Mvvm.Core.Dashboard;
@@ -15,18 +16,21 @@ public class JsonFileDashboardService : IDashboardService
 {
     private readonly DashboardOptions _options;
     private readonly IEnumerable<IWidgetDataSource> _dataSources;
+    private readonly ILogger<JsonFileDashboardService> _logger;
     private readonly ConcurrentDictionary<string, DashboardSummary> _index = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
     private readonly string _baseDir;
-    private bool _initialized;
+    private volatile bool _initialized;
     private readonly SemaphoreSlim _initLock = new(1, 1);
 
-    public JsonFileDashboardService(IOptions<DashboardOptions> options, IEnumerable<IWidgetDataSource> dataSources)
+    public JsonFileDashboardService(
+        IOptions<DashboardOptions> options,
+        IEnumerable<IWidgetDataSource> dataSources,
+        ILogger<JsonFileDashboardService> logger)
     {
         _options = options.Value;
         _dataSources = dataSources;
-        // Spec: scan _baseDir
-        // Path resolution: Use base directory
+        _logger = logger;
         _baseDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, _options.DashboardDirectory);
     }
 
@@ -65,9 +69,11 @@ public class JsonFileDashboardService : IDashboardService
                         };
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Ignore malformed files during init
+                    _logger.LogWarning(ex,
+                        "[Dashboard] Skipping malformed dashboard file during init. Path={FilePath}",
+                        file);
                 }
             }
 
@@ -123,8 +129,11 @@ public class JsonFileDashboardService : IDashboardService
             using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             return await JsonSerializer.DeserializeAsync<DashboardDefinition>(fs);
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogError(ex,
+                "[Dashboard] Failed to read dashboard file. DashboardId={DashboardId} Path={FilePath}",
+                dashboardId, path);
             return null;
         }
         finally

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/JsonFileDashboardServiceTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/JsonFileDashboardServiceTests.cs
@@ -30,7 +30,8 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             // or we need to ensure it uses an absolute path if provided.
             // Oh, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, tempPath) if tempPath is absolute will return tempPath in Windows but not always what we expect. Let's fix DashboardDirectory to be an absolute path here, and see if Path.Combine handles it correctly. Path.Combine(baseDir, absPath) returns absPath in .NET Core.
             
-            _service = new JsonFileDashboardService(options, Array.Empty<IWidgetDataSource>());
+            _service = new JsonFileDashboardService(options, Array.Empty<IWidgetDataSource>(),
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<JsonFileDashboardService>.Instance);
         }
 
         [TestCleanup]
@@ -230,7 +231,8 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
         private JsonFileDashboardService CreateServiceWithDataSource(IWidgetDataSource ds)
         {
             var options = Options.Create(new DashboardOptions { DashboardDirectory = _tempDir });
-            return new JsonFileDashboardService(options, new[] { ds });
+            return new JsonFileDashboardService(options, new[] { ds },
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<JsonFileDashboardService>.Instance);
         }
 
         [TestMethod]
@@ -330,7 +332,8 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
                 .ReturnsAsync(new WidgetDataResult { Value = 99 });
 
             var options = Options.Create(new DashboardOptions { DashboardDirectory = _tempDir });
-            var svc = new JsonFileDashboardService(options, new IWidgetDataSource[] { kindDs.Object });
+            var svc = new JsonFileDashboardService(options, new IWidgetDataSource[] { kindDs.Object },
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<JsonFileDashboardService>.Instance);
 
             var def = new DashboardDefinition
             {

--- a/test/WalkingTec.Mvvm.Core.Test/Integration/CfoFinancialDashboardIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/CfoFinancialDashboardIntegrationTests.cs
@@ -1023,7 +1023,8 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
                 {
                     DashboardDirectory = $"test_dashboards_{Guid.NewGuid():N}"
                 }),
-                Enumerable.Empty<IWidgetDataSource>());
+                Enumerable.Empty<IWidgetDataSource>(),
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<JsonFileDashboardService>.Instance);
 
             // IT 角色不應能存取 CFO 儀表板
             service.CanAccess(cfoDashboard, "it_user", new[] { "IT" })


### PR DESCRIPTION
## Summary

- `GetAsync`: catch block now calls `_logger.LogError(ex, ...)` with `DashboardId` and `FilePath` before returning `null` — ops can now correlate 404s to actual disk/deserialization errors
- `EnsureInitializedAsync`: catch block now calls `_logger.LogWarning(ex, ...)` with the file path instead of silently skipping malformed files
- Adds `ILogger<JsonFileDashboardService>` constructor parameter (injected via DI; `AddWtmDashboard()` calls `services.AddLogging()`)
- Also marks `_initialized` as `volatile` for ARM CPU safety
- 4 test call sites updated to pass `NullLogger<JsonFileDashboardService>.Instance`

> ⚠️ Note: PR #544 also adds `ILogger` to this service (for a deployment warning). This PR may conflict with #544 at merge time — simple resolution, merge whichever lands first.

## Test plan

- [x] 146 Dashboard + Integration tests pass
- [x] `dotnet build WalkingTec.Mvvm.Core` — clean (0 errors)

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)