### PR TITLE
security(auth): reject well-known default JWT key at startup

### DIFF
--- a/src/WalkingTec.Mvvm.Core/ConfigOptions/JwtOptions.cs
+++ b/src/WalkingTec.Mvvm.Core/ConfigOptions/JwtOptions.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Text;
 
 namespace WalkingTec.Mvvm.Core
@@ -8,24 +9,48 @@ namespace WalkingTec.Mvvm.Core
         public string Issuer { get; set; } = "http://localhost";
         public string Audience { get; set; } = "http://localhost";
         public int Expires { get; set; } = 3600;
-        private string _securiteKey= "wtmwtmwtmwtmwtmwtm";
-        public string SecurityKey { get
+
+        /// <summary>
+        /// Well-known default shipped in source — publicly readable on GitHub.
+        /// Any deployment still using this value is exploitable.
+        /// </summary>
+        internal const string WellKnownDefaultKey = "wtmwtmwtmwtmwtmwtm";
+
+        private string _securiteKey = WellKnownDefaultKey;
+
+        public string SecurityKey
+        {
+            get => _securiteKey;
+            set
             {
-                return _securiteKey;
-            }
-            set {
                 _securiteKey = value;
                 if (_securiteKey.Length < 32)
                 {
                     var count = 32 - _securiteKey.Length;
                     for (int i = 0; i < count; i++)
-                    {
                         _securiteKey += "x";
-                    }
                 }
-
             }
         }
+
         public string? LoginPath { get; set; }
+
+        /// <summary>
+        /// Returns <c>true</c> when <see cref="SecurityKey"/> is still the well-known
+        /// default value (or the default padded with 'x'). Either form is publicly known
+        /// and must be rejected at startup.
+        /// </summary>
+        public bool IsDefaultOrWeakKey()
+        {
+            // Backing field == default (never set via config)
+            if (_securiteKey == WellKnownDefaultKey) return true;
+
+            // Key was explicitly set to the well-known default, which pads it with 'x':
+            // "wtmwtmwtmwtmwtmwtm" + "xxxxxxxxxxxxxx" (14 x's) = 32 chars
+            var paddedDefault = WellKnownDefaultKey.PadRight(32, 'x');
+            if (_securiteKey == paddedDefault) return true;
+
+            return false;
+        }
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -691,6 +691,15 @@ namespace WalkingTec.Mvvm.Mvc
 
             var jwtOptions = conf.JwtOptions;
 
+            if (jwtOptions.IsDefaultOrWeakKey())
+            {
+                throw new InvalidOperationException(
+                    "[WTM Security] JWT SecurityKey is still the well-known default value shipped in source code. " +
+                    "Anyone who can read the WTM repository can forge tokens for any user. " +
+                    "Set a strong random key (≥32 chars) in your configuration (e.g. JwtOptions:SecurityKey). " +
+                    "Generate one with: openssl rand -base64 32");
+            }
+
             var cookieOptions = conf.CookieOptions;
 
             JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();

--- a/test/WalkingTec.Mvvm.Core.Test/JwtOptionTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/JwtOptionTests.cs
@@ -1,0 +1,73 @@
+#nullable enable
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Core.Test;
+
+/// <summary>
+/// Unit tests for JwtOption.IsDefaultOrWeakKey() — Issue #552.
+/// Verifies that the well-known default key (and its padded variant) are
+/// detected as weak so that AddWtmAuthentication() can refuse to start.
+/// </summary>
+[TestClass]
+public class JwtOptionTests
+{
+    // ─── IsDefaultOrWeakKey ────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void IsDefaultOrWeakKey_unset_key_returns_true()
+    {
+        // Key was never set — backing field holds the well-known default
+        var opt = new JwtOption();
+        Assert.IsTrue(opt.IsDefaultOrWeakKey());
+    }
+
+    [TestMethod]
+    public void IsDefaultOrWeakKey_default_value_set_explicitly_returns_true()
+    {
+        // Operator copied the default into config — padded with 'x' to 32 chars
+        var opt = new JwtOption { SecurityKey = JwtOption.WellKnownDefaultKey };
+        Assert.IsTrue(opt.IsDefaultOrWeakKey(),
+            "Explicitly setting the well-known default key (which gets padded) must still be rejected");
+    }
+
+    [TestMethod]
+    public void IsDefaultOrWeakKey_strong_custom_key_returns_false()
+    {
+        var opt = new JwtOption { SecurityKey = "MyR@ndomStr0ngK3y_NotTheDefault!!" };
+        Assert.IsFalse(opt.IsDefaultOrWeakKey());
+    }
+
+    [TestMethod]
+    public void IsDefaultOrWeakKey_strong_key_shorter_than_32_returns_false()
+    {
+        // Short key gets padded with 'x', but the base is not the well-known default
+        var opt = new JwtOption { SecurityKey = "CustomKey12345" };
+        Assert.IsFalse(opt.IsDefaultOrWeakKey(),
+            "A short custom key that isn't the default should NOT be flagged as weak");
+    }
+
+    [TestMethod]
+    public void IsDefaultOrWeakKey_key_exactly_32_chars_strong_returns_false()
+    {
+        var opt = new JwtOption { SecurityKey = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345" };
+        Assert.IsFalse(opt.IsDefaultOrWeakKey());
+    }
+
+    // ─── SecurityKey padding behaviour (pre-existing, regression guard) ────────
+
+    [TestMethod]
+    public void SecurityKey_short_value_is_padded_to_32()
+    {
+        var opt = new JwtOption { SecurityKey = "short" };
+        Assert.AreEqual(32, opt.SecurityKey.Length);
+    }
+
+    [TestMethod]
+    public void SecurityKey_already_32_chars_is_not_changed()
+    {
+        const string key = "ExactlyThirtyTwoCharactersHere!!";
+        var opt = new JwtOption { SecurityKey = key };
+        Assert.AreEqual(key, opt.SecurityKey);
+    }
+}


### PR DESCRIPTION
## 問題

`JwtOption._securiteKey` 預設值 `"wtmwtmwtmwtmwtmwtm"` 公開在 GitHub 原始碼。攻擊者可離線使用此已知密鑰偽造任意使用者的 JWT token，取得完整系統存取權。

## 修改內容

- **`JwtOption.WellKnownDefaultKey`** — `internal const`，讓弱密鑰檢查不依賴魔法字串
- **`JwtOption.IsDefaultOrWeakKey()`** — 偵測兩種危險情境：
  1. 未設定（backing field 從未被覆寫）
  2. 明確設定為預設值（設定後 setter 補齊 'x' 至 32 字元，仍可預測）
- **`AddWtmAuthentication()`** — 呼叫前述方法；若為弱密鑰，拋出 `InvalidOperationException`（含具體修復說明），應用程式無法啟動

## 測試

- 7 個 MSTest 覆蓋 `IsDefaultOrWeakKey()` 所有路徑及 `SecurityKey` padding 回歸
- Core.Test 全套 936 tests 通過，0 失敗
- 無現有測試呼叫 `AddWtmAuthentication()`，無回歸風險

## 遷移

現有使用預設密鑰的部署在升級後**將無法啟動**（這是有意設計的 fail-fast 行為）。操作者需在設定中提供強密鑰：

```bash
# 生成強密鑰
openssl rand -base64 32
```

```json
// appsettings.json
{
  "JwtOptions": {
    "SecurityKey": "<your-strong-random-key>"
  }
}
```

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)