### PR TITLE
fix(core): remove deprecated System.Data.SqlClient using from BaseImportVM

### DIFF
--- a/src/WalkingTec.Mvvm.Core/BaseImportVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BaseImportVM.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data;
-using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;


### PR DESCRIPTION
## Summary

- Remove `using System.Data.SqlClient;` from `BaseImportVM.cs` (line 8)
- The only usage was a fully commented-out `SqlBulkCopy` block that has never been active
- `System.Data.SqlClient` is the legacy namespace superseded by `Microsoft.Data.SqlClient`; keeping the using creates an implicit dependency on a deprecated package

## Test plan

- [x] `dotnet build WalkingTec.Mvvm.sln -c Release` passes (0 errors)
- [x] `dotnet test test/WalkingTec.Mvvm.Core.Test/` — 929/929 tests pass

Closes #553