### PR TITLE
fix(auth): escape JS string literals in PrivilegeFilter to prevent XSS

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Filters/PrivilegeFilter.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Filters/PrivilegeFilter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Policy;
+using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using System.Web;
 using Microsoft.AspNetCore.Authentication;
@@ -167,10 +168,13 @@ namespace WalkingTec.Mvvm.Mvc.Filters
                                 {
                                     lp = ctrl.Url.Content(lp);
                                 }
+                                var jsRedirect = JavaScriptEncoder.Default.Encode(
+                                    u?.ToLower().StartsWith("/login/logout") == true ? "" : (u ?? ""));
+                                var jsLp = JavaScriptEncoder.Default.Encode(lp);
                                 ContentResult cr = new ContentResult()
                                 {
-                                    Content = $"<script>var redirect='{(u?.ToLower().StartsWith("/login/logout")==true?"":u)}'+ window.location.hash; if(redirect=='/'){{window.location.href='{lp}'; }}  else{{window.location.href='{lp}?ReturnUrl='+encodeURIComponent(redirect);}}</script>",
-                                    ContentType = "text/html",                                    
+                                    Content = $"<script>var redirect='{jsRedirect}'+ window.location.hash; if(redirect=='/'){{window.location.href='{jsLp}'; }}  else{{window.location.href='{jsLp}?ReturnUrl='+encodeURIComponent(redirect);}}</script>",
+                                    ContentType = "text/html",
                                     StatusCode = 200
                                 };
                                 //context.HttpContext.Response.Headers.Add("IsScript", "true");


### PR DESCRIPTION
## Summary

`PrivilegeFilter.cs` line 172 built an inline `<script>` redirect block by directly interpolating the URL path (`u`) and login path (`lp`) into JavaScript single-quoted string literals:

```csharp
Content = $"<script>var redirect='{u}'+ window.location.hash; ... window.location.href='{lp}?ReturnUrl='+...</script>"
```

A crafted URL path containing `'` could close the JS string literal and inject arbitrary JavaScript — a **Reflected XSS** vulnerability.

## Fix

Use `JavaScriptEncoder.Default.Encode()` (from `System.Text.Encodings.Web`, built-in to .NET) on both values before embedding:

```csharp
var jsRedirect = JavaScriptEncoder.Default.Encode(u?.ToLower().StartsWith("/login/logout") == true ? "" : (u ?? ""));
var jsLp = JavaScriptEncoder.Default.Encode(lp);
Content = $"<script>var redirect='{jsRedirect}'+ window.location.hash; ... window.location.href='{jsLp}?ReturnUrl='+...</script>"
```

`JavaScriptEncoder.Default` encodes `'` → `\u0027`, `<` → `\u003C`, `>` → `\u003E`, `/` → `\u002F` — all characters that could break out of a JS string or close a `<script>` block.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] Core tests: 929/929 pass
- [x] Admin tests: 75/75 pass

Closes #550