### PR TITLE
fix(auth): return HTTP 403 instead of 200 for unauthorized MVC responses

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Filters/PrivilegeFilter.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Filters/PrivilegeFilter.cs
@@ -204,7 +204,7 @@ namespace WalkingTec.Mvvm.Mvc.Filters
                             {
                                 Content = MvcProgram._localizer["_Admin.TenantNotAllowed"],
                                 ContentType = "text/html",
-                                StatusCode = 200
+                                StatusCode = 403
                             };
                             context.Result = cr;
                         }
@@ -248,7 +248,7 @@ namespace WalkingTec.Mvvm.Mvc.Filters
                                     {
                                         Content = MvcProgram._localizer["Sys.NoPrivilege"],
                                         ContentType = "text/html",
-                                        StatusCode = 200
+                                        StatusCode = 403
                                     };
                                     context.Result = cr;
 


### PR DESCRIPTION
## Summary

`PrivilegeFilter` returned HTTP **200** for two forbidden-access scenarios in MVC page requests, making authorization failures invisible to security tooling:

| Case | Before | After |
|------|--------|-------|
| `TenantNotAllowed` (MVC page) | 200 | **403** |
| `NoPrivilege` (MVC page) | 200 | **403** |

**Intentionally unchanged (backward compat):**
- `layuisearch` AJAX requests remain HTTP 200 — LayUI grid protocol uses `Code:401/403` in the response body; the grid component cannot handle non-200 HTTP responses
- MVC login redirect (JavaScript `window.location` with hash preservation) remains HTTP 200 — this is a deliberate SPA pattern for preserving the URL hash fragment across redirects

## Impact

With proper 403 responses:
- WAF / CDN can now detect and rate-limit forbidden access attempts
- Security monitoring tools (Datadog, Prometheus 4xx alerts) will trigger on authorization failures
- `fetch()`-based SPA clients can check `response.ok` to detect auth errors

## Test plan

- [x] `dotnet build` — 0 errors
- [x] Admin tests: 75/75 pass

Closes #551