### PR TITLE
fix(dashboard): replace hardcoded "Admin" role with configurable AdminRoles

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Dashboard/DashboardOptions.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/DashboardOptions.cs
@@ -10,4 +10,12 @@ public class DashboardOptions
     public bool EnableEditing { get; set; } = true;
     public int DefaultRefreshInterval { get; set; } = 60;
     public bool AllowIframeSameOrigin { get; set; } = false;
+
+    /// <summary>
+    /// Role names that are treated as administrators for Dashboard access.
+    /// Administrators can view and edit all dashboards regardless of ownership or sharing settings.
+    /// Defaults to ["Admin"] for backward compatibility.
+    /// Configure this if your deployment uses a different admin role name (e.g. "SystemAdmin", "超級管理員").
+    /// </summary>
+    public string[] AdminRoles { get; set; } = ["Admin"];
 }

--- a/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
@@ -138,7 +138,7 @@ public class JsonFileDashboardService : IDashboardService
         await EnsureInitializedAsync();
 
         var result = new List<DashboardSummary>();
-        var isAdmin = userRoles != null && userRoles.Contains("Admin", StringComparer.OrdinalIgnoreCase);
+        var isAdmin = userRoles != null && _options.AdminRoles.Any(r => userRoles.Contains(r, StringComparer.OrdinalIgnoreCase));
 
         foreach (var summary in _index.Values)
         {
@@ -328,7 +328,7 @@ public class JsonFileDashboardService : IDashboardService
 
     public bool CanAccess(DashboardDefinition dashboard, string userId, string[] userRoles)
     {
-        if (userRoles != null && userRoles.Contains("Admin", StringComparer.OrdinalIgnoreCase)) return true;
+        if (userRoles != null && _options.AdminRoles.Any(r => userRoles.Contains(r, StringComparer.OrdinalIgnoreCase))) return true;
         if (string.Equals(dashboard.Owner, userId, StringComparison.OrdinalIgnoreCase)) return true;
         if (string.Equals(dashboard.Sharing?.Mode, "public", StringComparison.OrdinalIgnoreCase)) return true;
         
@@ -345,7 +345,7 @@ public class JsonFileDashboardService : IDashboardService
 
     public bool CanEdit(DashboardDefinition dashboard, string userId, string[] userRoles)
     {
-        if (userRoles != null && userRoles.Contains("Admin", StringComparer.OrdinalIgnoreCase)) return true;
+        if (userRoles != null && _options.AdminRoles.Any(r => userRoles.Contains(r, StringComparer.OrdinalIgnoreCase))) return true;
         if (string.Equals(dashboard.Owner, userId, StringComparison.OrdinalIgnoreCase)) return true;
         return false;
     }

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/JsonFileDashboardServiceTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/JsonFileDashboardServiceTests.cs
@@ -452,5 +452,88 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
             };
             _service.CanAccess(def, "user2", new[] { "Analyst" }).Should().BeFalse();
         }
+
+        // ─── AdminRoles 配置化測試（#555） ─────────────────────────────────────
+
+        private JsonFileDashboardService CreateServiceWithAdminRoles(params string[] adminRoles)
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var options = Options.Create(new DashboardOptions
+            {
+                DashboardDirectory = dir,
+                AdminRoles = adminRoles
+            });
+            return new JsonFileDashboardService(options, Array.Empty<IWidgetDataSource>());
+        }
+
+        [TestMethod]
+        public void CanAccess_custom_admin_role_grants_access()
+        {
+            var svc = CreateServiceWithAdminRoles("SystemAdmin");
+            var def = new DashboardDefinition { Owner = "user1" };
+
+            svc.CanAccess(def, "user2", new[] { "SystemAdmin" }).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void CanAccess_default_Admin_role_no_longer_grants_when_not_in_AdminRoles()
+        {
+            var svc = CreateServiceWithAdminRoles("SystemAdmin");
+            var def = new DashboardDefinition { Owner = "user1" };
+
+            // "Admin" is not in AdminRoles anymore — should be denied
+            svc.CanAccess(def, "user2", new[] { "Admin" }).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void CanEdit_custom_admin_role_grants_edit()
+        {
+            var svc = CreateServiceWithAdminRoles("SuperAdmin");
+            var def = new DashboardDefinition { Owner = "user1" };
+
+            svc.CanEdit(def, "user2", new[] { "SuperAdmin" }).Should().BeTrue();
+            svc.CanEdit(def, "user2", new[] { "Admin" }).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void CanAccess_multiple_admin_roles_all_grant_access()
+        {
+            var svc = CreateServiceWithAdminRoles("Admin", "SystemAdmin", "超級管理員");
+            var def = new DashboardDefinition { Owner = "user1" };
+
+            svc.CanAccess(def, "user2", new[] { "Admin" }).Should().BeTrue();
+            svc.CanAccess(def, "user2", new[] { "SystemAdmin" }).Should().BeTrue();
+            svc.CanAccess(def, "user2", new[] { "超級管理員" }).Should().BeTrue();
+            svc.CanAccess(def, "user2", new[] { "Viewer" }).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public async Task ListAsync_custom_admin_role_sees_all_dashboards()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            try
+            {
+                var options = Options.Create(new DashboardOptions
+                {
+                    DashboardDirectory = dir,
+                    AdminRoles = ["SuperAdmin"]
+                });
+                var svc = new JsonFileDashboardService(options, Array.Empty<IWidgetDataSource>());
+
+                await svc.CreateAsync(new DashboardDefinition { Owner = "alice", Title = "Private" });
+                await svc.CreateAsync(new DashboardDefinition { Owner = "bob", Title = "Also Private" });
+
+                var list = await svc.ListAsync("carol", new[] { "SuperAdmin" });
+                list.Should().HaveCount(2);
+
+                // "Admin" role should NOT see all dashboards when not in AdminRoles
+                var listAdmin = await svc.ListAsync("carol", new[] { "Admin" });
+                listAdmin.Should().BeEmpty();
+            }
+            finally
+            {
+                if (Directory.Exists(dir)) Directory.Delete(dir, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `AdminRoles string[]` property to `DashboardOptions` (default `["Admin"]`) 
- Replace 3 hardcoded `"Admin"` string comparisons in `JsonFileDashboardService` (`ListAsync`, `CanAccess`, `CanEdit`) with `_options.AdminRoles.Any(r => userRoles.Contains(r, ...))`
- Deployments with custom admin role names (e.g. `SystemAdmin`, `超級管理員`, `Administrator`) can now configure Dashboard admin access via `appsettings.json`:
  ```json
  "DashboardOptions": { "AdminRoles": ["SystemAdmin", "超級管理員"] }
  ```
- Default `["Admin"]` preserves full backward compatibility

## Test plan

- [x] 5 new tests covering custom admin roles in `CanAccess`, `CanEdit`, and `ListAsync`
- [x] All 35 `DashboardService` tests pass
- [x] `dotnet build` clean

Closes #555