### PR TITLE
fix(analysis): apply DataPrivilege row-level filter in Analysis Mode

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Extensions/DCExtension.cs
+++ b/src/WalkingTec.Mvvm.Core/Extensions/DCExtension.cs
@@ -284,6 +284,24 @@ namespace WalkingTec.Mvvm.Core.Extensions
         /// <param name="wtmcontext">Wtm context</param>
         /// <param name="dps">数据权限列表</param>
         /// <returns>拼接好where条件的query</returns>
+        private static readonly MethodInfo _appendSelfDPWhereMethod =
+            typeof(DCExtension).GetMethod("AppendSelfDPWhere", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        /// <summary>
+        /// Analysis Mode 防禦性 DataPrivilege 過濾（#554）。
+        /// 對非泛型 IQueryable 套用 AppendSelfDPWhere，確保 Analysis 查詢受同一行級權限保護。
+        /// </summary>
+        public static IQueryable ApplyDataPrivilegeForAnalysis(IQueryable baseQuery, WTMContext? wtmcontext)
+        {
+            if (wtmcontext?.DataPrivilegeSettings == null) return baseQuery;
+            if (wtmcontext.LoginUserInfo == null) return baseQuery;
+            var elementType = baseQuery.ElementType;
+            if (!typeof(TopBasePoco).IsAssignableFrom(elementType)) return baseQuery;
+            var method = _appendSelfDPWhereMethod.MakeGenericMethod(elementType);
+            var dps = wtmcontext.LoginUserInfo.DataPrivileges;
+            return (IQueryable)method.Invoke(null, new object?[] { baseQuery, wtmcontext, dps })!;
+        }
+
         private static IQueryable<T> AppendSelfDPWhere<T>(IQueryable<T> query, WTMContext? wtmcontext, List<SimpleDataPri>? dps) where T : TopBasePoco
         {
             var dpsSetting = wtmcontext?.DataPrivilegeSettings;

--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Analysis;
+using WalkingTec.Mvvm.Core.Extensions;
 
 namespace WalkingTec.Mvvm.Mvc
 {
@@ -298,6 +299,9 @@ namespace WalkingTec.Mvvm.Mvc
 
             var baseQuery = InvokeGetSearchQuery(vm, vmType);
             if (baseQuery == null) return BadRequest("無法取得查詢來源。");
+
+            // Defense-in-depth: apply row-level DataPrivilege filtering (#554)
+            baseQuery = DCExtension.ApplyDataPrivilegeForAnalysis(baseQuery, Wtm);
 
             var hierarchyError = ValidateDimensionHierarchies(req.DimensionHierarchies, fields);
             if (hierarchyError != null) return BadRequest(hierarchyError);

--- a/test/WalkingTec.Mvvm.Core.Test/Extensions/DPWhereInMemoryTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Extensions/DPWhereInMemoryTests.cs
@@ -310,4 +310,169 @@ namespace WalkingTec.Mvvm.Core.Test.Extensions
 
         #endregion
     }
+
+    // ─── ApplyDataPrivilegeForAnalysis tests (#554) ───────────────────────────
+
+    [TestClass]
+    public class ApplyDataPrivilegeForAnalysisTests
+    {
+        private static WTMContext CreateWtmWithDP(string tableName, List<string?> relateIds)
+        {
+            var dpSettings = new List<IDataPrivilege>
+            {
+                new DPTestPrivilegeInfo
+                {
+                    ModelName = tableName,
+                    PrivillegeName = tableName,
+                    ModelType = typeof(TopBasePoco)
+                }
+            };
+            var wtm = new WTMContext(null, new GlobalData(), null, null, dpSettings);
+            wtm.MSD = new BasicMSD();
+            wtm.DC = new EmptyContext(Guid.NewGuid().ToString(), DBTypeEnum.Memory);
+            wtm.LoginUserInfo = new LoginUserInfo
+            {
+                ITCode = "testuser",
+                DataPrivileges = relateIds.Select(id => new SimpleDataPri
+                {
+                    ID = Guid.NewGuid(),
+                    TableName = tableName,
+                    RelateId = id,
+                    UserCode = "testuser"
+                }).ToList()
+            };
+            return wtm;
+        }
+
+        [TestMethod]
+        public void ApplyDataPrivilege_FiltersRowsByAllowedIds()
+        {
+            var id1 = Guid.NewGuid();
+            var id2 = Guid.NewGuid();
+            var id3 = Guid.NewGuid();
+
+            IQueryable baseQuery = new List<DPTestMajor>
+            {
+                new() { ID = id1, MajorName = "Math" },
+                new() { ID = id2, MajorName = "English" },
+                new() { ID = id3, MajorName = "Physics" }
+            }.AsQueryable();
+
+            var wtm = CreateWtmWithDP(nameof(DPTestMajor), new List<string?> { id1.ToString(), id3.ToString() });
+
+            var result = DCExtension.ApplyDataPrivilegeForAnalysis(baseQuery, wtm)
+                .Cast<DPTestMajor>().ToList();
+
+            Assert.AreEqual(2, result.Count);
+            Assert.IsTrue(result.Any(x => x.ID == id1));
+            Assert.IsTrue(result.Any(x => x.ID == id3));
+        }
+
+        [TestMethod]
+        public void ApplyDataPrivilege_DeniesAll_WhenNoPrivilegesConfigured()
+        {
+            IQueryable baseQuery = new List<DPTestMajor>
+            {
+                new() { ID = Guid.NewGuid(), MajorName = "Math" },
+                new() { ID = Guid.NewGuid(), MajorName = "English" }
+            }.AsQueryable();
+
+            // DP setting for DPTestMajor exists, but user has no relateIds → deny all
+            var wtm = CreateWtmWithDP(nameof(DPTestMajor), new List<string?>());
+
+            var result = DCExtension.ApplyDataPrivilegeForAnalysis(baseQuery, wtm)
+                .Cast<DPTestMajor>().ToList();
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void ApplyDataPrivilege_AllowsAll_WhenNullRelateIdPresent()
+        {
+            IQueryable baseQuery = new List<DPTestMajor>
+            {
+                new() { ID = Guid.NewGuid(), MajorName = "Math" },
+                new() { ID = Guid.NewGuid(), MajorName = "English" }
+            }.AsQueryable();
+
+            // null in relateIds list = unrestricted access
+            var wtm = CreateWtmWithDP(nameof(DPTestMajor), new List<string?> { null });
+
+            var result = DCExtension.ApplyDataPrivilegeForAnalysis(baseQuery, wtm)
+                .Cast<DPTestMajor>().ToList();
+
+            Assert.AreEqual(2, result.Count);
+        }
+
+        [TestMethod]
+        public void ApplyDataPrivilege_NoOp_WhenModelNotInDPSettings()
+        {
+            var id1 = Guid.NewGuid();
+            var id2 = Guid.NewGuid();
+
+            IQueryable baseQuery = new List<DPTestMajor>
+            {
+                new() { ID = id1, MajorName = "Math" },
+                new() { ID = id2, MajorName = "English" }
+            }.AsQueryable();
+
+            // DP settings only cover "SomeOtherTable" — DPTestMajor is not restricted
+            var wtm = CreateWtmWithDP("SomeOtherTable", new List<string?> { Guid.NewGuid().ToString() });
+
+            var result = DCExtension.ApplyDataPrivilegeForAnalysis(baseQuery, wtm)
+                .Cast<DPTestMajor>().ToList();
+
+            Assert.AreEqual(2, result.Count);
+        }
+
+        [TestMethod]
+        public void ApplyDataPrivilege_NoOp_WhenElementTypeNotTopBasePoco()
+        {
+            // Non-TopBasePoco type should pass through unchanged
+            IQueryable baseQuery = new List<string> { "a", "b", "c" }.AsQueryable();
+            var wtm = CreateWtmWithDP("String", new List<string?>());
+
+            var result = DCExtension.ApplyDataPrivilegeForAnalysis(baseQuery, wtm)
+                .Cast<string>().ToList();
+
+            Assert.AreEqual(3, result.Count);
+        }
+
+        [TestMethod]
+        public void ApplyDataPrivilege_NoOp_WhenWtmIsNull()
+        {
+            IQueryable baseQuery = new List<DPTestMajor>
+            {
+                new() { ID = Guid.NewGuid(), MajorName = "Math" }
+            }.AsQueryable();
+
+            var result = DCExtension.ApplyDataPrivilegeForAnalysis(baseQuery, null)
+                .Cast<DPTestMajor>().ToList();
+
+            Assert.AreEqual(1, result.Count);
+        }
+
+        [TestMethod]
+        public void ApplyDataPrivilege_NoOp_WhenLoginUserInfoIsNull()
+        {
+            var dpSettings = new List<IDataPrivilege>
+            {
+                new DPTestPrivilegeInfo { ModelName = nameof(DPTestMajor) }
+            };
+            var wtm = new WTMContext(null, new GlobalData(), null, null, dpSettings);
+            wtm.MSD = new BasicMSD();
+            wtm.DC = new EmptyContext(Guid.NewGuid().ToString(), DBTypeEnum.Memory);
+            // LoginUserInfo intentionally left null
+
+            IQueryable baseQuery = new List<DPTestMajor>
+            {
+                new() { ID = Guid.NewGuid(), MajorName = "Math" }
+            }.AsQueryable();
+
+            var result = DCExtension.ApplyDataPrivilegeForAnalysis(baseQuery, wtm)
+                .Cast<DPTestMajor>().ToList();
+
+            Assert.AreEqual(1, result.Count);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `DCExtension.ApplyDataPrivilegeForAnalysis(IQueryable, WTMContext?)` — a public non-generic wrapper around the private `AppendSelfDPWhere<T>`, resolving the element type at runtime via cached `MethodInfo`
- `_AnalysisController.TryPrepareContext` now calls this immediately after `InvokeGetSearchQuery`, acting as defense-in-depth so row-level DP filters apply even if a developer's VM forgets them
- 7 new MSTest cases in `DPWhereInMemoryTests.cs` covering all branches

## Test plan

- [x] `ApplyDataPrivilege_FiltersRowsByAllowedIds` — allowed IDs only
- [x] `ApplyDataPrivilege_DeniesAll_WhenNoPrivilegesConfigured` — empty ID list → deny all
- [x] `ApplyDataPrivilege_AllowsAll_WhenNullRelateIdPresent` — null entry = unrestricted
- [x] `ApplyDataPrivilege_NoOp_WhenModelNotInDPSettings` — table not in DP settings → pass-through
- [x] `ApplyDataPrivilege_NoOp_WhenElementTypeNotTopBasePoco` — non-entity query → pass-through
- [x] `ApplyDataPrivilege_NoOp_WhenWtmIsNull` — null context → pass-through
- [x] `ApplyDataPrivilege_NoOp_WhenLoginUserInfoIsNull` — null login → pass-through

All 7 tests pass. `dotnet test --filter FullyQualifiedName~ApplyDataPrivilegeForAnalysis` → 7/7 ✓

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)