### PR TITLE
security(core): redact connection string secrets from Serilog structured logs

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmConnectionStringSanitizer.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmConnectionStringSanitizer.cs
@@ -1,0 +1,37 @@
+#nullable enable
+using System.Text.RegularExpressions;
+
+namespace WalkingTec.Mvvm.Mvc;
+
+/// <summary>
+/// 遮蔽字串中常見的連線字串敏感欄位，防止帳密出現在 Serilog 日誌（#559）。
+/// 適用於 Serilog Destructure.ByTransforming 及 ILogEventEnricher。
+/// </summary>
+public static class WtmConnectionStringSanitizer
+{
+    /// <summary>
+    /// 匹配常見連線字串敏感鍵：Password、Pwd、User Id、UID、User。
+    /// 格式：key=value，value 以 ; " ' 或字串結尾作為終止符。
+    /// </summary>
+    private static readonly Regex _sensitiveKeyPattern = new(
+        @"(?i)(password|pwd|user\s+id|uid|user)\s*=\s*[^;""'\s][^;""']*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// 若輸入字串符合連線字串模式（含 '=' 且含敏感關鍵字），則以 [redacted] 遮蔽敏感值並回傳；
+    /// 否則回傳原始字串，避免不必要的正規表達式執行。
+    /// </summary>
+    public static string Sanitize(string input)
+    {
+        // 快速篩選：不含 '=' 的字串絕不是連線字串
+        if (!input.Contains('='))
+            return input;
+
+        return _sensitiveKeyPattern.Replace(input, m =>
+        {
+            // 保留 key= 部分，只遮蔽 value
+            var eq = m.Value.IndexOf('=');
+            return eq < 0 ? m.Value : m.Value[..(eq + 1)] + "[redacted]";
+        });
+    }
+}

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmSerilogExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmSerilogExtension.cs
@@ -52,7 +52,10 @@ namespace WalkingTec.Mvvm.Mvc
                 .MinimumLevel.Is(levelMap)
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
-                .Enrich.FromLogContext();
+                .Enrich.FromLogContext()
+                // Redact connection string secrets from structured string properties (#559).
+                // Covers destructured values logged via {@obj} or explicit string properties.
+                .Destructure.ByTransforming<string>(WtmConnectionStringSanitizer.Sanitize);
 
             if (options.EnableConsole)
             {

--- a/test/WalkingTec.Mvvm.Core.Test/Security/WtmConnectionStringSanitizerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Security/WtmConnectionStringSanitizerTests.cs
@@ -1,0 +1,110 @@
+#nullable enable
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Mvc;
+
+namespace WalkingTec.Mvvm.Core.Test.Security;
+
+/// <summary>
+/// Unit tests for WtmConnectionStringSanitizer (#559).
+/// Verifies sensitive connection string fields are redacted before appearing in logs.
+/// </summary>
+[TestClass]
+public class WtmConnectionStringSanitizerTests
+{
+    // ─── Redaction tests ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Sanitize_Password_is_redacted()
+    {
+        var input = "Server=myserver;Database=mydb;Password=s3cr3t!;";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+
+        StringAssert.Contains(result, "Password=[redacted]");
+        Assert.IsFalse(result.Contains("s3cr3t!"), "Raw password must not survive sanitization");
+    }
+
+    [TestMethod]
+    public void Sanitize_Pwd_is_redacted()
+    {
+        var input = "Server=myserver;Pwd=abc123;";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+
+        StringAssert.Contains(result, "Pwd=[redacted]");
+        Assert.IsFalse(result.Contains("abc123"));
+    }
+
+    [TestMethod]
+    public void Sanitize_UserId_is_redacted()
+    {
+        var input = "Data Source=oracle;User Id=admin;Password=pwd;";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+
+        Assert.IsFalse(result.Contains("admin"), "UserId value must be redacted");
+        Assert.IsFalse(result.Contains("pwd"), "Password value must be redacted");
+    }
+
+    [TestMethod]
+    public void Sanitize_case_insensitive()
+    {
+        var input = "SERVER=x;PASSWORD=secret;DATABASE=db";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+
+        Assert.IsFalse(result.Contains("secret"), "Case-insensitive match required for PASSWORD");
+    }
+
+    [TestMethod]
+    public void Sanitize_preserves_non_sensitive_segments()
+    {
+        var input = "Server=myserver;Database=mydb;Password=s3cr3t;Port=1433";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+
+        StringAssert.Contains(result, "Server=myserver");
+        StringAssert.Contains(result, "Database=mydb");
+        StringAssert.Contains(result, "Port=1433");
+    }
+
+    // ─── No-op tests (no redaction needed) ──────────────────────────────
+
+    [TestMethod]
+    public void Sanitize_plain_string_without_equals_is_unchanged()
+    {
+        var input = "Hello World — no connection string here";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+        Assert.AreEqual(input, result);
+    }
+
+    [TestMethod]
+    public void Sanitize_innocent_key_value_pair_unchanged()
+    {
+        var input = "Status=OK;Code=200;Reason=NotFound";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+        Assert.AreEqual(input, result);
+    }
+
+    [TestMethod]
+    public void Sanitize_empty_string_unchanged()
+    {
+        Assert.AreEqual("", WtmConnectionStringSanitizer.Sanitize(""));
+    }
+
+    [TestMethod]
+    public void Sanitize_whitespace_only_unchanged()
+    {
+        Assert.AreEqual("   ", WtmConnectionStringSanitizer.Sanitize("   "));
+    }
+
+    // ─── Exception-message scenario ──────────────────────────────────────
+
+    [TestMethod]
+    public void Sanitize_scrubs_connection_string_embedded_in_exception_message()
+    {
+        // Simulates ex.Message from SqlException when connection fails
+        var exMessage = "Cannot open server 'myserver' requested by the login. " +
+                        "Connection string: Server=myserver;User Id=sa;Password=P@ssw0rd;Database=prod";
+        var result = WtmConnectionStringSanitizer.Sanitize(exMessage);
+
+        Assert.IsFalse(result.Contains("P@ssw0rd"), "Password must be redacted from exception message");
+        Assert.IsFalse(result.Contains("User Id=sa"), "User Id must be redacted");
+        StringAssert.Contains(result, "myserver"); // non-sensitive parts preserved
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `WtmConnectionStringSanitizer.Sanitize()` — a compiled-regex helper that replaces `Password`/`Pwd`/`User Id`/`Uid`/`User` key=value pairs in strings with `[redacted]`; fast-path skips strings with no `=` at all
- Wires the sanitizer into `WtmSerilogExtension` via `.Destructure.ByTransforming<string>()`, so **every structured string property** logged through Serilog (via `{@obj}` or named parameters) is automatically scrubbed before reaching any sink (file, console, Seq, Elastic, etc.)
- No new NuGet dependencies — uses only built-in `System.Text.RegularExpressions`

## Coverage

| Scenario | Covered? |
|----------|----------|
| `{@obj}` destructuring of objects with string fields | ✅ via `ByTransforming<string>` |
| Named string properties (`{ConnectionString}`) | ✅ |
| `ex.Message` embedded in structured properties | ✅ |
| Raw `{Exception}` rendering (`ex.ToString()`) | Partial — ETL layer already sanitizes RunLog (#518); Serilog `{Exception}` rendering bypasses destructuring |

## Test plan

- [x] `Sanitize_Password_is_redacted`
- [x] `Sanitize_Pwd_is_redacted`
- [x] `Sanitize_UserId_is_redacted`
- [x] `Sanitize_case_insensitive`
- [x] `Sanitize_preserves_non_sensitive_segments`
- [x] `Sanitize_plain_string_without_equals_is_unchanged`
- [x] `Sanitize_innocent_key_value_pair_unchanged`
- [x] `Sanitize_empty_string_unchanged`
- [x] `Sanitize_whitespace_only_unchanged`
- [x] `Sanitize_scrubs_connection_string_embedded_in_exception_message`

All 10 pass. `dotnet build` clean.

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)