### PR TITLE
fix(sanitizer): stop regex value match at whitespace to prevent log mangling (#580)

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmConnectionStringSanitizer.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmConnectionStringSanitizer.cs
@@ -11,11 +11,12 @@ public static class WtmConnectionStringSanitizer
 {
     /// <summary>
     /// 匹配常見連線字串敏感鍵：Password、Pwd、User Id、UID、User。
-    /// 格式：key=value，value 以 ; " ' 或字串結尾作為終止符。
+    /// 格式：key=value，value 以 ; " ' 空白 或字串結尾作為終止符。
+    /// 兩段 char class 均排除空白，避免貪婪 match 至散文句子末尾（#580）。
     /// </summary>
     private static readonly Regex _sensitiveKeyPattern = new(
-        @"(?i)(password|pwd|user\s+id|uid|user)\s*=\s*[^;""'\s][^;""']*",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        @"(?i)(password|pwd|user\s+id|uid|user)\s*=\s*[^;""'\s]+",
+        RegexOptions.Compiled);
 
     /// <summary>
     /// 若輸入字串符合連線字串模式（含 '=' 且含敏感關鍵字），則以 [redacted] 遮蔽敏感值並回傳；

--- a/test/WalkingTec.Mvvm.Core.Test/Security/WtmConnectionStringSanitizerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Security/WtmConnectionStringSanitizerTests.cs
@@ -93,6 +93,33 @@ public class WtmConnectionStringSanitizerTests
         Assert.AreEqual("   ", WtmConnectionStringSanitizer.Sanitize("   "));
     }
 
+    // ─── Regression: greedy value match (#580) ───────────────────────────
+
+    [TestMethod]
+    public void Sanitize_does_not_mangle_log_message_containing_user_equals()
+    {
+        // Regression #580: value pattern must stop at whitespace so natural-language
+        // log messages containing "user=xxx" are not silently truncated.
+        var input = "Error: user=john was not found in the database";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+
+        // Only the credential value "john" should be redacted; the rest of the sentence must survive.
+        StringAssert.Contains(result, "was not found in the database",
+            "Text after the value must not be swallowed (#580)");
+        Assert.IsFalse(result.Contains("john"), "Credential value must still be redacted");
+    }
+
+    [TestMethod]
+    public void Sanitize_password_with_semicolon_terminator_still_redacted()
+    {
+        // Confirm standard semicolon-terminated value still works after the fix.
+        var input = "Server=x;Password=s3cr3t;Database=db";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+
+        Assert.IsFalse(result.Contains("s3cr3t"), "Password value must be redacted");
+        StringAssert.Contains(result, "Database=db", "Non-sensitive tail must be preserved");
+    }
+
     // ─── Exception-message scenario ──────────────────────────────────────
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- **Root cause**: `_sensitiveKeyPattern` second char class `[^;""']*` permitted whitespace, so `user=john was not found` matched the entire sentence tail and was replaced with `user=[redacted]`, mangling log messages.
- **Fix**: Simplify to `[^;""'\s]+` — value terminates at the first whitespace, semicolon, or quote. Standard connection-string values never contain unquoted spaces, so the change is fully backward-compatible.
- **Bonus**: Remove redundant `RegexOptions.IgnoreCase` (the `(?i)` inline flag already handles case-insensitivity).

## Changes

| File | Change |
|------|--------|
| `WtmConnectionStringSanitizer.cs` | `[^;""'\s][^;""']*` → `[^;""'\s]+`; drop `RegexOptions.IgnoreCase` |
| `WtmConnectionStringSanitizerTests.cs` | +2 regression tests |

## Test plan

- [x] `Sanitize_does_not_mangle_log_message_containing_user_equals` — verifies text after value is preserved
- [x] `Sanitize_password_with_semicolon_terminator_still_redacted` — confirms existing happy path unaffected
- [x] All 12 sanitizer tests pass (`dotnet test --filter WtmConnectionStringSanitizerTests`)

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)