### PR TITLE
security(analysis): write ActionLog for query/export/pivot endpoints (#561)

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WalkingTec.Mvvm.Core;
@@ -41,6 +42,7 @@ namespace WalkingTec.Mvvm.Mvc
         private readonly IAnalysisCache? _cache;
         private readonly IAnalysisFieldPolicy? _fieldPolicy;
         private readonly ILogger<_AnalysisController> _logger;
+        private readonly ILogger<ActionLog>? _actionLogger;
         private readonly TimeSpan? _cacheTtl;
 
         public _AnalysisController(
@@ -48,13 +50,15 @@ namespace WalkingTec.Mvvm.Mvc
             ILogger<_AnalysisController> logger,
             IAnalysisCache? cache = null,
             IAnalysisFieldPolicy? fieldPolicy = null,
-            IOptions<Configs>? configs = null)
+            IOptions<Configs>? configs = null,
+            ILogger<ActionLog>? actionLogger = null)
         {
             _registry = registry;
             _logger = logger;
             _cache = cache;
             _fieldPolicy = fieldPolicy;
             _cacheTtl = configs?.Value.AnalysisCacheTtl;
+            _actionLogger = actionLogger;
         }
 
         /// <summary>
@@ -114,6 +118,7 @@ namespace WalkingTec.Mvvm.Mvc
                 sw.Stop();
                 _logger.LogInformation("Analysis query completed ListVm={ListVmType} Dims={DimCount} Msrs={MsrCount} ElapsedMs={Elapsed} Truncated={Truncated}",
                     req.ListVmType, req.Dimensions.Count, req.Measures.Count, sw.ElapsedMilliseconds, result.Truncated);
+                WriteAnalysisActionLog("Query", req.ListVmType, req.Dimensions, req.Measures, result.TotalCount, sw.ElapsedMilliseconds / 1000.0, result.Truncated);
                 return new JsonResult(result, _camelCase);
             }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
@@ -139,6 +144,7 @@ namespace WalkingTec.Mvvm.Mvc
                 sw.Stop();
                 _logger.LogInformation("Analysis pivot completed ListVm={ListVmType} Dims={DimCount} Msrs={MsrCount} Pivot={PivotDim} ElapsedMs={Elapsed}",
                     req.ListVmType, req.Dimensions.Count, req.Measures.Count, req.PivotDimension, sw.ElapsedMilliseconds);
+                WriteAnalysisActionLog("Pivot", req.ListVmType, req.Dimensions, req.Measures, result.Rows.Count, sw.ElapsedMilliseconds / 1000.0, result.Truncated);
                 return new JsonResult(result, _camelCase);
             }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
@@ -172,6 +178,7 @@ namespace WalkingTec.Mvvm.Mvc
                 sw.Stop();
                 _logger.LogInformation("Analysis export completed ListVm={ListVmType} Format={Format} ElapsedMs={Elapsed}",
                     req.ListVmType, format, sw.ElapsedMilliseconds);
+                WriteAnalysisActionLog($"Export({format})", req.ListVmType, req.Dimensions, req.Measures, result.TotalCount, sw.ElapsedMilliseconds / 1000.0, result.Truncated);
             }
             catch (InvalidOperationException ex)
             {
@@ -224,6 +231,7 @@ namespace WalkingTec.Mvvm.Mvc
                 sw.Stop();
                 _logger.LogInformation("Analysis pivot export completed ListVm={ListVmType} Format={Format} ElapsedMs={Elapsed}",
                     req.ListVmType, format, sw.ElapsedMilliseconds);
+                WriteAnalysisActionLog($"PivotExport({format})", req.ListVmType, req.Dimensions, req.Measures, result.Rows.Count, sw.ElapsedMilliseconds / 1000.0, result.Truncated);
             }
             catch (InvalidOperationException ex)
             {
@@ -258,6 +266,43 @@ namespace WalkingTec.Mvvm.Mvc
         }
 
         // ─── Helpers ───────────────────────────────────────────────────────
+
+        /// <summary>
+        /// 寫入 ActionLog，記錄 Analysis 查詢/匯出的稽核軌跡（#561）。
+        /// 若 _actionLogger 未注入且 HttpContext 不可用（如單元測試），則靜默略過。
+        /// </summary>
+        private void WriteAnalysisActionLog(
+            string actionName,
+            string listVmType,
+            List<string> dimensions,
+            List<MeasureRequest> measures,
+            int rowCount,
+            double durationSec,
+            bool truncated)
+        {
+            var logger = _actionLogger
+                ?? HttpContext?.RequestServices?.GetService<ILogger<ActionLog>>();
+            if (logger == null) return;
+
+            var dims = string.Join(",", dimensions);
+            var msrs = string.Join(",", measures.Select(m => $"{m.Field}_{m.Func}"));
+            var log = new ActionLog
+            {
+                LogType    = ActionLogTypesEnum.Normal,
+                ActionTime = DateTime.Now,
+                ITCode     = Wtm?.LoginUserInfo?.ITCode ?? string.Empty,
+                ModuleName = "Analysis",
+                ActionName = actionName,
+                ActionUrl  = HttpContext?.Request?.Path.Value,
+                Duration   = durationSec,
+                Remark     = $"ListVm={listVmType} Dims=[{dims}] Msrs=[{msrs}] Rows={rowCount} Truncated={truncated}",
+                IP         = HttpContext?.Connection?.RemoteIpAddress?.ToString(),
+                TenantCode = Wtm?.LoginUserInfo?.CurrentTenant
+            };
+
+            logger.Log<ActionLog>(LogLevel.Information, new EventId(), log, null,
+                (a, _) => a.GetLogString());
+        }
 
         /// <summary>
         /// 封裝四個 action 共用的準備結果：VM 解析、存取驗證、欄位掃描、基底查詢、identityKey。

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using NPOI.SS.UserModel;
 using NPOI.XSSF.UserModel;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Analysis;
@@ -2204,6 +2205,133 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             var meta = wb.GetSheet("Metadata");
             Assert.IsNotNull(meta, "應有 Metadata 工作表");
             Assert.AreEqual("匯出時間", meta.GetRow(0).GetCell(0).StringCellValue);
+        }
+
+        // ─── ActionLog 稽核測試（#561）────────────────────────────────────────
+
+        /// <summary>
+        /// 簡單的捕捉型 ILogger 實作，記錄所有 Log 呼叫供測試斷言。
+        /// </summary>
+        private class CapturingLogger<T> : ILogger<T>
+        {
+            public readonly List<string> Messages = new();
+
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception exception, Func<TState, Exception, string> formatter)
+            {
+                Messages.Add(formatter(state, exception));
+            }
+
+            private class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+                public void Dispose() { }
+            }
+        }
+
+        private _AnalysisController CreateControllerWithActionLogger(
+            CapturingLogger<ActionLog> actionLogger,
+            IAnalysisFieldPolicy policy = null)
+        {
+            var controller = new _AnalysisController(
+                _registry,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<_AnalysisController>.Instance,
+                cache: null,
+                fieldPolicy: policy,
+                configs: null,
+                actionLogger: actionLogger);
+            controller.Wtm = MockWtmContext.CreateWtmContext();
+            return controller;
+        }
+
+        [TestMethod]
+        public void Query_happy_path_writes_ActionLog()
+        {
+            // Arrange
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華東", Category = "A", Amount = 100m },
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華東", Category = "A", Amount = 200m },
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華南", Category = "B", Amount = 300m },
+            };
+
+            var actionLogger = new CapturingLogger<ActionLog>();
+            var controller = CreateControllerWithActionLogger(actionLogger);
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            // Act
+            var result = controller.Query(req);
+
+            // Assert: 200 OK
+            Assert.IsInstanceOfType(result, typeof(JsonResult));
+
+            // Assert: ActionLog was written exactly once
+            Assert.AreEqual(1, actionLogger.Messages.Count,
+                "Query 成功後應寫入恰好 1 筆 ActionLog");
+
+            var logMsg = actionLogger.Messages[0];
+            StringAssert.Contains(logMsg, "Analysis",      "ActionLog 應記錄 ModuleName=Analysis");
+            StringAssert.Contains(logMsg, "Query",         "ActionLog 應記錄 ActionName=Query");
+            StringAssert.Contains(logMsg, "Region",        "ActionLog Remark 應包含維度名稱");
+            StringAssert.Contains(logMsg, "Amount_Sum",    "ActionLog Remark 應包含度量指標");
+        }
+
+        [TestMethod]
+        public void Export_happy_path_writes_ActionLog()
+        {
+            // Arrange
+            _testData = new List<SaleRecord>
+            {
+                new SaleRecord { ID = Guid.NewGuid(), Region = "華東", Category = "A", Amount = 150m },
+            };
+
+            var actionLogger = new CapturingLogger<ActionLog>();
+            var controller = CreateControllerWithActionLogger(actionLogger);
+            var req = Req(
+                dims: new[] { "Region" },
+                msrs: new[] { ("Amount", AggregateFunc.Sum) });
+
+            // Act
+            var result = controller.Export(req, "csv");
+
+            // Assert: file returned
+            Assert.IsInstanceOfType(result, typeof(FileContentResult));
+
+            // Assert: ActionLog was written exactly once
+            Assert.AreEqual(1, actionLogger.Messages.Count,
+                "Export 成功後應寫入恰好 1 筆 ActionLog");
+
+            var logMsg = actionLogger.Messages[0];
+            StringAssert.Contains(logMsg, "Analysis",         "ActionLog 應記錄 ModuleName=Analysis");
+            StringAssert.Contains(logMsg, "Export",           "ActionLog 應記錄 ActionName 包含 Export");
+        }
+
+        [TestMethod]
+        public void Query_validation_failure_does_not_write_ActionLog()
+        {
+            // Arrange: request with no dimensions triggers 400 before engine runs
+            var actionLogger = new CapturingLogger<ActionLog>();
+            var controller = CreateControllerWithActionLogger(actionLogger);
+            var req = new AnalysisQueryRequest
+            {
+                ListVmType = typeof(SaleRecordListVM).FullName,
+                Dimensions = new List<string>(),   // invalid
+                Measures   = new List<MeasureRequest> { new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum } },
+                Filters    = new List<FilterCondition>()
+            };
+
+            // Act
+            var result = controller.Query(req);
+
+            // Assert: 400 returned, no ActionLog written
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult));
+            Assert.AreEqual(0, actionLogger.Messages.Count,
+                "驗證失敗時不應寫入 ActionLog");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `ILogger<ActionLog>` injection to `_AnalysisController` (optional ctor param, backwards-compatible)
- Add `WriteAnalysisActionLog()` private helper called after each successful data-access endpoint: `Query`, `Pivot`, `Export`, `PivotExport`
- Each log entry records: `ModuleName=Analysis`, `ActionName`, `ListVmType`, `Dims`, `Msrs`, `RowCount`, `Duration`, `IP`, `TenantCode`
- Follows the same `ILogger<ActionLog>` pattern used by `FrameworkFilter` and `_FrameworkController`
- 3 new MSTests: Query writes log, Export writes log, validation failure does not write log (99/99 pass)

Closes #561

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~AnalysisControllerTests` — 99/99 passed
- [x] `dotnet build src/WalkingTec.Mvvm.Mvc` — 0 errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)