### PR TITLE
refactor(analysis): replace string-matching with typed exceptions

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisException.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisException.cs
@@ -1,0 +1,44 @@
+#nullable enable
+using System;
+
+namespace WalkingTec.Mvvm.Core.Analysis;
+
+/// <summary>
+/// Base exception for Analysis Mode errors.
+/// Subtypes are used to distinguish HTTP response codes in the controller.
+/// </summary>
+public class AnalysisException : InvalidOperationException
+{
+    public AnalysisException(string message) : base(message) { }
+    public AnalysisException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown when a VM type name is not found in the Analysis whitelist.
+/// The controller maps this to HTTP 404.
+/// </summary>
+public class AnalysisVmNotFoundException : AnalysisException
+{
+    public string VmTypeName { get; }
+
+    public AnalysisVmNotFoundException(string vmTypeName)
+        : base($"VM type not registered for analysis: {vmTypeName}")
+    {
+        VmTypeName = vmTypeName;
+    }
+}
+
+/// <summary>
+/// Thrown when a requested dimension or measure field is not enabled for analysis.
+/// The controller maps this to HTTP 400.
+/// </summary>
+public class AnalysisFieldNotFoundException : AnalysisException
+{
+    public string FieldName { get; }
+
+    public AnalysisFieldNotFoundException(string fieldName, string kind)
+        : base($"{kind} field '{fieldName}' is not enabled for analysis.")
+    {
+        FieldName = fieldName;
+    }
+}

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -242,12 +242,12 @@ namespace WalkingTec.Mvvm.Core.Analysis
             foreach (var d in req.Dimensions)
             {
                 if (!whitelist.TryGetValue(d, out var meta) || meta.Kind != AnalysisFieldKind.Dimension)
-                    throw new InvalidOperationException($"Dimension field '{d}' is not enabled for analysis.");
+                    throw new AnalysisFieldNotFoundException(d, "Dimension");
             }
             foreach (var m in req.Measures)
             {
                 if (!whitelist.TryGetValue(m.Field, out var meta) || meta.Kind != AnalysisFieldKind.Measure)
-                    throw new InvalidOperationException($"Measure field '{m.Field}' is not enabled for analysis.");
+                    throw new AnalysisFieldNotFoundException(m.Field, "Measure");
                 if ((meta.AllowedFuncs & m.Func) == 0)
                     throw new NotSupportedException($"Function '{m.Func}' is not allowed for field '{m.Field}'.");
             }
@@ -266,7 +266,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
             foreach (var f in filters)
             {
                 if (!whitelist.TryGetValue(f.Field, out var meta))
-                    throw new InvalidOperationException($"Filter field '{f.Field}' is not enabled for analysis.");
+                    throw new AnalysisFieldNotFoundException(f.Field, "Filter");
 
                 var prop = Expression.Property(param, f.Field);
                 var targetType = prop.Type;

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
@@ -49,15 +49,15 @@ namespace WalkingTec.Mvvm.Core.Analysis
         }
 
         /// <summary>
-        /// 依 FullName 查詢白名單，找不到時拋出 InvalidOperationException。
+        /// 依 FullName 查詢白名單，找不到時拋出 <see cref="AnalysisVmNotFoundException"/>。
         /// </summary>
         public Type Resolve(string fullName)
         {
             if (string.IsNullOrWhiteSpace(fullName))
-                throw new InvalidOperationException("VM type name is required.");
+                throw new AnalysisVmNotFoundException(fullName ?? "");
             if (_whitelist.TryGetValue(fullName, out var t))
                 return t;
-            throw new InvalidOperationException($"VM type not registered for analysis: {fullName}");
+            throw new AnalysisVmNotFoundException(fullName);
         }
 
         /// <summary>

--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -66,6 +66,7 @@ namespace WalkingTec.Mvvm.Mvc
         {
             Type vmType;
             try { vmType = _registry.Resolve(listVmType); }
+            catch (AnalysisVmNotFoundException ex) { return NotFound(ex.Message); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
 
             if (!CheckAccess(vmType)) return Forbid();
@@ -279,6 +280,7 @@ namespace WalkingTec.Mvvm.Mvc
 
             Type vmType;
             try { vmType = _registry.Resolve(req.ListVmType); }
+            catch (AnalysisVmNotFoundException ex) { return NotFound(ex.Message); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
 
             if (!CheckAccess(vmType)) return Forbid();

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -202,10 +202,10 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
         [TestMethod]
-        public void GetMeta_returns_400_for_unregistered_vm()
+        public void GetMeta_returns_404_for_unregistered_vm()
         {
-            var result = CreateController().GetMeta("No.Such.Vm") as BadRequestObjectResult;
-            Assert.IsNotNull(result, "未註冊 VM 應回傳 400");
+            var result = CreateController().GetMeta("No.Such.Vm") as NotFoundObjectResult;
+            Assert.IsNotNull(result, "未註冊 VM 應回傳 404");
         }
 
         // ─── Query 路由守衛 ───────────────────────────────────────────────────
@@ -238,7 +238,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
         [TestMethod]
-        public void Query_returns_400_for_unregistered_vm()
+        public void Query_returns_404_for_unregistered_vm()
         {
             var req = new AnalysisQueryRequest
             {
@@ -246,8 +246,8 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 Dimensions = new List<string> { "Region" },
                 Measures   = new List<MeasureRequest> { new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum } }
             };
-            var result = CreateController().Query(req) as BadRequestObjectResult;
-            Assert.IsNotNull(result);
+            var result = CreateController().Query(req) as NotFoundObjectResult;
+            Assert.IsNotNull(result, "未註冊 VM 應回傳 404");
         }
 
         [TestMethod]
@@ -320,7 +320,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
         [TestMethod]
-        public void Export_returns_400_for_unregistered_vm()
+        public void Export_returns_404_for_unregistered_vm()
         {
             var req = new AnalysisQueryRequest
             {
@@ -328,8 +328,8 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 Dimensions = new List<string> { "Region" },
                 Measures   = new List<MeasureRequest> { new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum } }
             };
-            var result = CreateController().Export(req) as BadRequestObjectResult;
-            Assert.IsNotNull(result);
+            var result = CreateController().Export(req) as NotFoundObjectResult;
+            Assert.IsNotNull(result, "未註冊 VM 應回傳 404");
         }
 
         // ─── Export xlsx / csv ────────────────────────────────────────────────
@@ -1299,7 +1299,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
 
         [TestMethod]
         [TestCategory("Analysis")]
-        public void Pivot_returns_400_for_unregistered_vm()
+        public void Pivot_returns_404_for_unregistered_vm()
         {
             var req = new AnalysisPivotRequest
             {
@@ -1312,8 +1312,8 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 PivotDimension = "Category"
             };
 
-            var result = CreateController().Pivot(req) as BadRequestObjectResult;
-            Assert.IsNotNull(result, "Pivot 未註冊 VM 應回傳 400");
+            var result = CreateController().Pivot(req) as NotFoundObjectResult;
+            Assert.IsNotNull(result, "Pivot 未註冊 VM 應回傳 404");
         }
 
         [TestMethod]
@@ -1407,7 +1407,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
 
         [TestMethod]
         [TestCategory("Analysis")]
-        public void PivotExport_returns_400_for_unregistered_vm()
+        public void PivotExport_returns_404_for_unregistered_vm()
         {
             var req = new AnalysisPivotRequest
             {
@@ -1420,8 +1420,8 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 PivotDimension = "Category"
             };
 
-            var result = CreateController().PivotExport(req) as BadRequestObjectResult;
-            Assert.IsNotNull(result, "PivotExport 未註冊 VM 應回傳 400");
+            var result = CreateController().PivotExport(req) as NotFoundObjectResult;
+            Assert.IsNotNull(result, "PivotExport 未註冊 VM 應回傳 404");
         }
 
         [TestMethod]

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisQueryEngineTests.cs
@@ -129,7 +129,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         public void Throws_when_dimension_not_in_whitelist()
         {
             var req = Req(dims: new[] { "Nonexistent" });
-            Assert.ThrowsException<InvalidOperationException>(() => Engine().Execute(Q(), req, _whitelist));
+            Assert.ThrowsException<AnalysisFieldNotFoundException>(() => Engine().Execute(Q(), req, _whitelist));
         }
 
         /// <summary>嘗試將 Measure 欄位用作 Dimension（Kind 不符）→ 拋例外</summary>
@@ -137,7 +137,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         public void Throws_when_measure_field_used_as_dimension()
         {
             var req = Req(dims: new[] { "Amount" }); // Amount is Measure, not Dimension
-            Assert.ThrowsException<InvalidOperationException>(() => Engine().Execute(Q(), req, _whitelist));
+            Assert.ThrowsException<AnalysisFieldNotFoundException>(() => Engine().Execute(Q(), req, _whitelist));
         }
 
         /// <summary>度量欄位不在白名單中 → 拋例外</summary>
@@ -145,7 +145,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         public void Throws_when_measure_field_not_in_whitelist()
         {
             var req = Req(msrs: new[] { ("Nonexistent", AggregateFunc.Sum) });
-            Assert.ThrowsException<InvalidOperationException>(() => Engine().Execute(Q(), req, _whitelist));
+            Assert.ThrowsException<AnalysisFieldNotFoundException>(() => Engine().Execute(Q(), req, _whitelist));
         }
 
         /// <summary>嘗試將 Dimension 欄位用作 Measure（Kind 不符）→ 拋例外</summary>
@@ -153,7 +153,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         public void Throws_when_dimension_field_used_as_measure()
         {
             var req = Req(msrs: new[] { ("Region", AggregateFunc.Sum) }); // Region is Dimension
-            Assert.ThrowsException<InvalidOperationException>(() => Engine().Execute(Q(), req, _whitelist));
+            Assert.ThrowsException<AnalysisFieldNotFoundException>(() => Engine().Execute(Q(), req, _whitelist));
         }
 
         /// <summary>不允許的聚合函式（CountOnly 欄位不支援 Sum）→ 拋例外</summary>
@@ -175,7 +175,7 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
                 dims: new[] { "Region" },
                 msrs: new[] { ("Amount", AggregateFunc.Sum) },
                 filters: new[] { ("Nonexistent", FilterOperator.Eq, "X") });
-            Assert.ThrowsException<InvalidOperationException>(() => Engine().Execute(Q(), req, _whitelist));
+            Assert.ThrowsException<AnalysisFieldNotFoundException>(() => Engine().Execute(Q(), req, _whitelist));
         }
 
         // ─── ApplyFilters 運算子分支 ────────────────────────────────────────────

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisVmRegistryTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisVmRegistryTests.cs
@@ -42,32 +42,33 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
         /// <summary>
-        /// Resolve with the FullName of an unannotated VM throws InvalidOperationException.
+        /// Resolve with the FullName of an unannotated VM throws AnalysisVmNotFoundException.
         /// </summary>
         [TestMethod]
         public void Throws_for_unannotated_vm()
         {
             var registry = BuildRegistry();
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsException<AnalysisVmNotFoundException>(
                 () => registry.Resolve(typeof(NotAnnotatedListVM).FullName));
         }
 
         /// <summary>
-        /// Resolve with an unknown type name throws InvalidOperationException.
+        /// Resolve with an unknown type name throws AnalysisVmNotFoundException.
         /// </summary>
         [TestMethod]
         public void Throws_for_unknown_type()
         {
             var registry = BuildRegistry();
-            Assert.ThrowsException<InvalidOperationException>(
+            var ex = Assert.ThrowsException<AnalysisVmNotFoundException>(
                 () => registry.Resolve("Some.Unknown.Type"));
+            Assert.AreEqual("Some.Unknown.Type", ex.VmTypeName);
         }
 
         [TestMethod]
         public void Throws_for_empty_type_name()
         {
             var registry = BuildRegistry();
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsException<AnalysisVmNotFoundException>(
                 () => registry.Resolve(string.Empty));
         }
     }

--- a/test/WalkingTec.Mvvm.Core.Test/Dashboard/AnalysisWidgetDataSourceTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Dashboard/AnalysisWidgetDataSourceTests.cs
@@ -110,7 +110,7 @@ namespace WalkingTec.Mvvm.Core.Test.Dashboard
                 }
             };
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            await Assert.ThrowsExceptionAsync<AnalysisVmNotFoundException>(
                 () => source.GetDataAsync(request));
         }
 

--- a/test/WalkingTec.Mvvm.Core.Test/Integration/CfoFinancialDashboardIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/CfoFinancialDashboardIntegrationTests.cs
@@ -403,7 +403,7 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
             };
 
             // Act & Assert
-            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            var ex = await Assert.ThrowsExceptionAsync<AnalysisVmNotFoundException>(
                 () => source.GetDataAsync(request));
 
             // 錯誤訊息應清楚說明 VM 未在白名單中，而非模糊的 NullReferenceException
@@ -907,7 +907,7 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
                 because: "未標記 [EnableAnalysis] 的 ListVM 不應在白名單中，防止未授權存取財務資料");
 
             // 嘗試 Resolve 應拋出
-            var ex = Assert.ThrowsException<InvalidOperationException>(
+            var ex = Assert.ThrowsException<AnalysisVmNotFoundException>(
                 () => _registry.Resolve(DeletedVmType));
 
             ex.Message.Should().Contain("not registered for analysis");

--- a/test/WalkingTec.Mvvm.Core.Test/Integration/CfoFinancialDashboardIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/CfoFinancialDashboardIntegrationTests.cs
@@ -412,7 +412,7 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
         }
 
         [TestMethod]
-        [Description("Analysis 引擎拋出欄位驗證失敗（非白名單維度）→ AnalysisWidgetDataSource 應傳播 InvalidOperationException，不吞例外")]
+        [Description("Analysis 引擎拋出欄位驗證失敗（非白名單維度）→ AnalysisWidgetDataSource 應傳播 AnalysisFieldNotFoundException，不吞例外")]
         public async Task CFO_WidgetRequestsNonWhitelistedField_AnalysisEnginePropagatesError()
         {
             var source = CreateAnalysisDataSource();
@@ -430,7 +430,7 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
                 }
             };
 
-            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            var ex = await Assert.ThrowsExceptionAsync<AnalysisFieldNotFoundException>(
                 () => source.GetDataAsync(request));
 
             ex.Message.Should().Contain("ID",

--- a/test/WalkingTec.Mvvm.Core.Test/Integration/SalesDashboardIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/SalesDashboardIntegrationTests.cs
@@ -602,9 +602,9 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
                 }
             };
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            await Assert.ThrowsExceptionAsync<AnalysisVmNotFoundException>(
                 () => source.GetDataAsync(request),
-                "未授權的 ListVM 應拋出 InvalidOperationException");
+                "未授權的 ListVM 應拋出 AnalysisVmNotFoundException");
         }
 
         /// <summary>

--- a/test/WalkingTec.Mvvm.Core.Test/Integration/SupplyChainIntegrationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Integration/SupplyChainIntegrationTests.cs
@@ -833,10 +833,10 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
             var whitelist = AnalysisFieldScanner.ScanModel(typeof(SupplierDelivery));
 
             // 白名單驗證應阻擋不存在的欄位名稱
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsException<AnalysisFieldNotFoundException>(
                 () => _engine.Execute(
                     SupplierDeliveryListVM.TestData.AsQueryable(), maliciousReq, whitelist),
-                "惡意欄位名稱應被白名單阻擋，拋出 InvalidOperationException");
+                "惡意欄位名稱應被白名單阻擋，拋出 AnalysisFieldNotFoundException");
         }
 
         /// <summary>
@@ -859,9 +859,9 @@ namespace WalkingTec.Mvvm.Core.Test.Integration
                 }
             };
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            await Assert.ThrowsExceptionAsync<AnalysisVmNotFoundException>(
                 () => dataSource.GetDataAsync(request),
-                "未在 registry 中的 ListVM 應拋出 InvalidOperationException");
+                "未在 registry 中的 ListVM 應拋出 AnalysisVmNotFoundException");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- Introduce `AnalysisException` hierarchy (`AnalysisVmNotFoundException`, `AnalysisFieldNotFoundException`) so HTTP status codes are determined by exception type, not message-string matching
- `AnalysisVmRegistry.Resolve()` → throws `AnalysisVmNotFoundException` (carries `VmTypeName`)
- `AnalysisQueryEngine.ValidateFields()` → throws `AnalysisFieldNotFoundException` for dimension / measure / filter field not-found cases
- All 5 controller endpoints (`GetMeta`, `Query`, `Pivot`, `Export`, `PivotExport`) now return **404** for unregistered VMs and **400** for field validation errors

## Test plan

- [x] Updated 5 controller tests: `returns_400_for_unregistered_vm` → `returns_404_for_unregistered_vm`
- [x] Updated 3 `AnalysisVmRegistryTests` to assert `AnalysisVmNotFoundException` directly (with `VmTypeName` property check)
- [x] 100/100 tests pass locally

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)