### PR TITLE
fix(dashboard): surface partial Analysis Mode registration as startup error

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/DashboardServiceCollectionExtensions.cs
@@ -23,12 +23,24 @@ namespace WalkingTec.Mvvm.Core.Dashboard
                 services.AddSingleton(GroupByStrategyResolver.Default);
             }
 
-            // Auto-register AnalysisWidgetDataSource when Analysis Mode dependencies are available
+            // Auto-register AnalysisWidgetDataSource when Analysis Mode dependencies are available.
+            // IMPORTANT: AddWtmContext() must be called BEFORE AddWtmDashboard() for this check to
+            // succeed. If called in the wrong order, AnalysisWidgetDataSource is silently skipped and
+            // widget data requests for the "analysis" source will fail with "Data source not found".
             var hasRegistry = services.Any(d => d.ServiceType == typeof(AnalysisVmRegistry));
             var hasEngine = services.Any(d => d.ServiceType == typeof(AnalysisQueryEngine));
             if (hasRegistry && hasEngine)
             {
                 services.AddTransient<IWidgetDataSource, AnalysisWidgetDataSource>();
+            }
+            else if (hasRegistry || hasEngine)
+            {
+                // Partial registration — one dep present without the other is unexpected.
+                // Surface this at startup rather than silently producing a misconfigured container.
+                throw new InvalidOperationException(
+                    "Partial Analysis Mode registration detected. " +
+                    "Both AnalysisVmRegistry and AnalysisQueryEngine must be registered. " +
+                    "Ensure services.AddWtmContext() is called before services.AddWtmDashboard().");
             }
 
             return services;


### PR DESCRIPTION
## Summary

`AddWtmDashboard()` checks for `AnalysisVmRegistry` + `AnalysisQueryEngine` at registration time to auto-wire `AnalysisWidgetDataSource`. When only one dependency is present (partial setup), the old code silently skipped registration, producing a confusing `"Data source 'analysis' not found"` error at runtime with no hint of the root cause.

This PR changes the behavior for the partial-registration case:

- **Both absent** (Analysis Mode not used): unchanged — no registration, no error
- **Both present** (correct order): unchanged — `AnalysisWidgetDataSource` auto-registered
- **One present, one absent** (wrong call order / misconfiguration): **now throws `InvalidOperationException`** at startup with a clear message pointing to the `AddWtmContext()` ordering requirement

## Test plan

- [x] All 3 existing `DashboardServiceCollectionExtensionsTests` pass (no-deps, both-deps, explicit registration)
- [x] `dotnet build` 0 errors

Closes #591