### PR TITLE
chore(workflow): deprecate built-in Elsa workflow API stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Deprecated
+- **Workflow API**：內建 Elsa workflow 整合（`IWorkflow`、`FrameworkWorkflow`、`ApproveTimeLine`、`ApproveInfo`、`FlowInfoTagHelper`、`IBaseCRUDVM` 工作流程方法、`DataContext.FrameworkWorkflows`）標記為 `[Obsolete]`，將於下一個主版本移除（#586）。
+  - **遷移指引**：若仍需工作流程功能，請直接引用 Elsa 或改用其他工作流程引擎；移除 `IWorkflow` 介面實作及相關 TagHelper。
+
 ## [8.6.1] - 2026-03-17
 
 ### Added

--- a/src/WalkingTec.Mvvm.Core/BaseCRUDVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BaseCRUDVM.cs
@@ -65,9 +65,13 @@ namespace WalkingTec.Mvvm.Core
         void DoDelete();
         Task DoDeleteAsync();
 
+        [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
         Task<object?> StartWorkflowAsync(string? flowName=null);
+        [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
         Task<object?> ContinueWorkflowAsync(string actionName, string remark, string? flowName=null, string? tag = null);
+        [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
         Task<List<ApproveTimeLine>> GetWorkflowTimeLineAsync(string? flowName = null);
+        [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
         Task<object?> GetWorkflowInstanceAsync(string? flowName = null);
         /// <summary>
         /// 彻底删除，对PersistPoco进行物理删除
@@ -1343,24 +1347,28 @@ namespace WalkingTec.Mvvm.Core
         }
 
         // [Elsa removed] StartWorkflowAsync — stubbed, returns null
+        [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
         public virtual Task<object?> StartWorkflowAsync(string? flowName=null)
         {
             return Task.FromResult<object?>(null);
         }
 
         // [Elsa removed] ContinueWorkflowAsync — stubbed, returns null
+        [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
         public virtual Task<object?> ContinueWorkflowAsync(string actionName, string remark, string? flowName=null, string? tag = null)
         {
             return Task.FromResult<object?>(null);
         }
 
         // [Elsa removed] GetWorkflowTimeLineAsync — returns empty list
+        [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
         public virtual Task<List<ApproveTimeLine>> GetWorkflowTimeLineAsync(string? flowName = null)
         {
             return Task.FromResult(new List<ApproveTimeLine>());
         }
 
         // [Elsa removed] GetWorkflowInstanceAsync — returns null
+        [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
         public virtual Task<object?> GetWorkflowInstanceAsync(string? flowName = null)
         {
             return Task.FromResult<object?>(null);

--- a/src/WalkingTec.Mvvm.Core/DataContext.cs
+++ b/src/WalkingTec.Mvvm.Core/DataContext.cs
@@ -41,6 +41,7 @@ namespace WalkingTec.Mvvm.Core
         public DbSet<FrameworkRole> BaseFrameworkRoles { get; set; } = null!;
         public DbSet<FrameworkUserRole> BaseFrameworkUserRoles { get; set; } = null!;
         public DbSet<FrameworkUserGroup> BaseFrameworkUserGroups { get; set; } = null!;
+        [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
         public DbSet<FrameworkWorkflow> FrameworkWorkflows { get; set; } = null!;
         public DbSet<ActionLog> BaseActionLogs { get; set; } = null!;
         public DbSet<FrameworkTenant> FrameworkTenants { get; set; } = null!;

--- a/src/WalkingTec.Mvvm.Core/Models/FrameworkWorkflow.cs
+++ b/src/WalkingTec.Mvvm.Core/Models/FrameworkWorkflow.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace WalkingTec.Mvvm.Core
 {
     [Table("FrameworkWorkflows")]
+    [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
     public class FrameworkWorkflow : TopBasePoco, ITenant
     {
         [Required]

--- a/src/WalkingTec.Mvvm.Core/Models/IWorkflow.cs
+++ b/src/WalkingTec.Mvvm.Core/Models/IWorkflow.cs
@@ -1,8 +1,10 @@
 #nullable enable
+using System;
 
 namespace WalkingTec.Mvvm.Core
 {
 
+    [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
     public interface IWorkflow
     {
     }

--- a/src/WalkingTec.Mvvm.Core/WorkFlow/ApproveInfo.cs
+++ b/src/WalkingTec.Mvvm.Core/WorkFlow/ApproveInfo.cs
@@ -5,6 +5,7 @@ using WalkingTec.Mvvm.Core.Support.Json;
 
 namespace WalkingTec.Mvvm.Core.WorkFlow
 {
+    [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
     public class ApproveInfo
     {
         public string? FlowName{get;set;}

--- a/src/WalkingTec.Mvvm.Core/WorkFlow/ApproveTimeLine.cs
+++ b/src/WalkingTec.Mvvm.Core/WorkFlow/ApproveTimeLine.cs
@@ -1,6 +1,8 @@
 #nullable enable
+using System;
 namespace WalkingTec.Mvvm.Core.WorkFlow
 {
+    [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
     public class ApproveTimeLine
     {
         public string? Id { get; set; }

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/FlowInfoTagHelper.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/FlowInfoTagHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -10,6 +11,7 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
 
 
     [HtmlTargetElement("wt:flowinfo",TagStructure = TagStructure.WithoutEndTag)]
+    [Obsolete("WTM's built-in Elsa workflow integration has been removed. This member will be deleted in the next major version. See CHANGELOG.md for migration guidance.")]
     public class FlowInfoTagHelper : BaseElementTag
     {
         public ModelExpression Vm { get; set; }


### PR DESCRIPTION
## Summary

- Marks all remnant Elsa workflow symbols with `[Obsolete]` — they will be removed in the next major version
- Adds `using System;` to files that were missing it (`IWorkflow.cs`, `ApproveTimeLine.cs`, `FlowInfoTagHelper.cs`)
- Updates `CHANGELOG.md` with deprecation notice and migration guidance

**Affected symbols:**
- `IWorkflow` interface
- `FrameworkWorkflow` model + `DataContext.FrameworkWorkflows` DbSet
- `ApproveTimeLine` / `ApproveInfo` value objects
- `IBaseCRUDVM` workflow method stubs (4) + `BaseCRUDVM` implementations
- `FlowInfoTagHelper` TagHelper

**Migration:** Users relying on these stubs should migrate to Elsa directly or adopt another workflow engine before the next major version.

## Test plan

- [x] `dotnet build -c Release` — Build succeeded, no new errors
- [x] `dotnet test -c Release` — 929 + 141 + 75 + 38 tests passed, 0 failures

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)