### PR TITLE
fix(analysis): Resolve() returns 400 for null/empty VM name, not 404 (#596)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
@@ -54,7 +54,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
         public Type Resolve(string fullName)
         {
             if (string.IsNullOrWhiteSpace(fullName))
-                throw new AnalysisVmNotFoundException(fullName ?? "");
+                throw new InvalidOperationException("VM type name is required.");
             if (_whitelist.TryGetValue(fullName, out var t))
                 return t;
             throw new AnalysisVmNotFoundException(fullName);

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisVmRegistryTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisVmRegistryTests.cs
@@ -65,11 +65,27 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
         [TestMethod]
-        public void Throws_for_empty_type_name()
+        public void Throws_InvalidOperationException_for_empty_type_name()
         {
             var registry = BuildRegistry();
-            Assert.ThrowsException<AnalysisVmNotFoundException>(
+            Assert.ThrowsException<InvalidOperationException>(
                 () => registry.Resolve(string.Empty));
+        }
+
+        [TestMethod]
+        public void Throws_InvalidOperationException_for_null_type_name()
+        {
+            var registry = BuildRegistry();
+            Assert.ThrowsException<InvalidOperationException>(
+                () => registry.Resolve(null));
+        }
+
+        [TestMethod]
+        public void Throws_InvalidOperationException_for_whitespace_type_name()
+        {
+            var registry = BuildRegistry();
+            Assert.ThrowsException<InvalidOperationException>(
+                () => registry.Resolve("   "));
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #596

`AnalysisVmRegistry.Resolve()` was introduced in `43d13319` with a null/empty guard that throws `AnalysisVmNotFoundException` — which the controller maps to **HTTP 404**. Null/empty input is a bad request (client omitted a required field), so the correct response is **HTTP 400**.

**Root cause:** the typed-exception refactor changed a `InvalidOperationException` guard to `AnalysisVmNotFoundException` so the controller's catch ladder routes it to 404 instead of 400.

**Fix:** one-line restore of `throw new InvalidOperationException("VM type name is required.")` for the null/empty guard. The `AnalysisVmNotFoundException` path remains for legitimate "name provided but not in whitelist" cases.

## Changes

- `AnalysisVmRegistry.cs`: restore `InvalidOperationException` for null/empty `fullName`
- `AnalysisVmRegistryTests.cs`: rename existing test + add null and whitespace regression tests (6 tests total, all pass)

## Test plan

- [x] `Throws_InvalidOperationException_for_empty_type_name`
- [x] `Throws_InvalidOperationException_for_null_type_name`
- [x] `Throws_InvalidOperationException_for_whitespace_type_name`
- [x] Existing tests: `Resolves_annotated_vm`, `Throws_for_unannotated_vm`, `Throws_for_unknown_type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)