### PR TITLE
feat(ops): add AddWtmHealthChecks / UseWtmHealthChecks for /healthz support

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -1127,6 +1127,56 @@ namespace WalkingTec.Mvvm.Mvc
             return app;
         }
 
+        /// <summary>
+        /// Registers WTM health check services. Call this in <c>ConfigureServices</c> / <c>builder.Services</c>.
+        /// <para>
+        /// A built-in "self" liveness check is registered automatically.
+        /// Use the <paramref name="configure"/> callback to add database, cache, or custom checks:
+        /// </para>
+        /// <code>
+        /// services.AddWtmHealthChecks(checks =>
+        ///     checks.AddDbContextCheck&lt;MyDataContext&gt;("database", tags: new[] { "ready" }));
+        /// </code>
+        /// </summary>
+        public static IServiceCollection AddWtmHealthChecks(
+            this IServiceCollection services,
+            Action<IHealthChecksBuilder>? configure = null)
+        {
+            var builder = services
+                .AddHealthChecks()
+                .AddCheck("self",
+                    () => Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult.Healthy(),
+                    tags: new[] { "live" });
+
+            configure?.Invoke(builder);
+            return services;
+        }
+
+        /// <summary>
+        /// Maps WTM health check endpoints. Call this in <c>Configure</c> / after <c>app.UseRouting()</c>.
+        /// <list type="bullet">
+        ///   <item><term><paramref name="livePath"/></term><description>Liveness probe — returns 200 if the process is alive (default: <c>/healthz</c>).</description></item>
+        ///   <item><term><paramref name="readyPath"/></term><description>Readiness probe — runs all registered checks (default: <c>/healthz/ready</c>).</description></item>
+        /// </list>
+        /// </summary>
+        public static IApplicationBuilder UseWtmHealthChecks(
+            this IApplicationBuilder app,
+            string livePath = "/healthz",
+            string readyPath = "/healthz/ready")
+        {
+            app.UseHealthChecks(livePath, new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+
+            app.UseHealthChecks(readyPath, new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+            {
+                Predicate = _ => true
+            });
+
+            return app;
+        }
+
     }
 
 

--- a/test/WalkingTec.Mvvm.Core.Test/HealthCheckTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/HealthCheckTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Mvc;
+
+namespace WalkingTec.Mvvm.Core.Test
+{
+    [TestClass]
+    public class HealthCheckTests
+    {
+        private static IHost BuildHost(
+            string livePath = "/healthz",
+            string readyPath = "/healthz/ready",
+            System.Action<IHealthChecksBuilder>? configure = null)
+        {
+            return new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder.UseTestServer();
+                    webBuilder.ConfigureServices(services =>
+                        services.AddWtmHealthChecks(configure));
+                    webBuilder.Configure(app =>
+                        app.UseWtmHealthChecks(livePath, readyPath));
+                })
+                .Build();
+        }
+
+        [TestMethod]
+        public async Task LivePath_returns_200_when_service_is_healthy()
+        {
+            using var host = BuildHost();
+            await host.StartAsync();
+            var client = host.GetTestClient();
+
+            var response = await client.GetAsync("/healthz");
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
+                "/healthz (liveness) 應在服務存活時回傳 200");
+        }
+
+        [TestMethod]
+        public async Task ReadyPath_returns_200_when_all_checks_pass()
+        {
+            using var host = BuildHost();
+            await host.StartAsync();
+            var client = host.GetTestClient();
+
+            var response = await client.GetAsync("/healthz/ready");
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
+                "/healthz/ready (readiness) 預設只有 self 檢查，應回傳 200");
+        }
+
+        [TestMethod]
+        public async Task Custom_path_is_honoured()
+        {
+            using var host = BuildHost(livePath: "/health", readyPath: "/health/ready");
+            await host.StartAsync();
+            var client = host.GetTestClient();
+
+            var live  = await client.GetAsync("/health");
+            var ready = await client.GetAsync("/health/ready");
+
+            Assert.AreEqual(HttpStatusCode.OK, live.StatusCode,  "自訂 livePath /health 應回傳 200");
+            Assert.AreEqual(HttpStatusCode.OK, ready.StatusCode, "自訂 readyPath /health/ready 應回傳 200");
+        }
+
+        [TestMethod]
+        public async Task Default_paths_return_404_for_non_health_requests()
+        {
+            using var host = BuildHost();
+            await host.StartAsync();
+            var client = host.GetTestClient();
+
+            var response = await client.GetAsync("/some-other-path");
+
+            Assert.AreNotEqual(HttpStatusCode.OK, response.StatusCode,
+                "/some-other-path 不應被健康檢查 middleware 攔截並回傳 200");
+        }
+
+        [TestMethod]
+        public async Task Configure_callback_allows_adding_custom_checks()
+        {
+            var callbackInvoked = false;
+            using var host = BuildHost(configure: checks =>
+            {
+                callbackInvoked = true;
+                checks.AddCheck("custom",
+                    () => Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult.Healthy());
+            });
+            await host.StartAsync();
+            var client = host.GetTestClient();
+
+            var response = await client.GetAsync("/healthz/ready");
+
+            Assert.IsTrue(callbackInvoked, "configure 回呼應被呼叫");
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
+                "加入自訂 healthy check 後 /healthz/ready 仍應回傳 200");
+        }
+
+        [TestMethod]
+        public async Task ReadyPath_returns_503_when_custom_check_is_unhealthy()
+        {
+            using var host = BuildHost(configure: checks =>
+                checks.AddCheck("always-fail",
+                    () => Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult.Unhealthy("intentional")));
+            await host.StartAsync();
+            var client = host.GetTestClient();
+
+            var ready = await client.GetAsync("/healthz/ready");
+            var live  = await client.GetAsync("/healthz");
+
+            Assert.AreEqual(HttpStatusCode.ServiceUnavailable, ready.StatusCode,
+                "有 unhealthy check 時 /healthz/ready 應回傳 503");
+            Assert.AreEqual(HttpStatusCode.OK, live.StatusCode,
+                "liveness 端點只跑 'live' tagged check，custom unhealthy check 不影響它");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `services.AddWtmHealthChecks()` and `app.UseWtmHealthChecks()` to `FrameworkServiceExtension`
- No extra NuGet packages — uses ASP.NET Core 8 shared framework built-ins
- Exposes two endpoints following Kubernetes conventions:
  - `/healthz` — liveness probe (only `"live"`-tagged checks, default: process self-check)
  - `/healthz/ready` — readiness probe (all registered checks)
- Optional `configure` callback lets apps add DB, cache, or custom checks

**Typical usage:**
```csharp
// Program.cs
builder.Services.AddWtmHealthChecks(checks =>
    checks.AddDbContextCheck<MyDataContext>("database", tags: new[] { "ready" }));

app.UseWtmHealthChecks();   // /healthz + /healthz/ready
// or custom paths:
app.UseWtmHealthChecks("/health", "/health/ready");
```

## Design decisions

- Liveness (`/healthz`) only runs `"live"`-tagged checks → custom unhealthy DB check never brings down liveness
- Readiness (`/healthz/ready`) runs all checks → K8s stops sending traffic until DB is healthy
- `self` check (always healthy, tag: `"live"`) registered automatically — no config required

## Test plan

- [x] 6 integration tests via `TestServer` (same pattern as `RateLimitingTests`)
- [x] Full suite: 935 + 141 + 75 = 1151 tests, 0 failures

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)