### PR TITLE
feat(api): add [ProducesResponseType] to _AnalysisController and _DashboardController (#568)

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -62,6 +63,10 @@ namespace WalkingTec.Mvvm.Mvc
         /// 回傳指定 ListVM 上標記 [Dimension]/[Measure] 的欄位清單。
         /// </summary>
         [HttpGet("meta")]
+        [ProducesResponseType(typeof(IEnumerable<object>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public IActionResult GetMeta([FromQuery] string listVmType)
         {
             Type vmType;
@@ -96,6 +101,10 @@ namespace WalkingTec.Mvvm.Mvc
         /// 執行分析查詢。
         /// </summary>
         [HttpPost("query")]
+        [ProducesResponseType(typeof(AnalysisQueryResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public IActionResult Query([FromBody] AnalysisQueryRequest? req)
         {
             if (req == null) return BadRequest("Request body is required.");
@@ -120,6 +129,10 @@ namespace WalkingTec.Mvvm.Mvc
         }
 
         [HttpPost("pivot")]
+        [ProducesResponseType(typeof(AnalysisPivotResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public IActionResult Pivot([FromBody] AnalysisPivotRequest? req)
         {
             if (req == null) return BadRequest("Request body is required.");
@@ -149,6 +162,10 @@ namespace WalkingTec.Mvvm.Mvc
         /// 匯出分析結果為 Excel 或 CSV。
         /// </summary>
         [HttpPost("export")]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public IActionResult Export([FromBody] AnalysisQueryRequest? req,
             [FromQuery] string format = "xlsx",
             [FromQuery] bool includeChart = false,
@@ -201,6 +218,10 @@ namespace WalkingTec.Mvvm.Mvc
         /// 匯出 Pivot 分析結果為 Excel 或 CSV。
         /// </summary>
         [HttpPost("pivot/export")]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public IActionResult PivotExport([FromBody] AnalysisPivotRequest? req,
             [FromQuery] string format = "xlsx",
             [FromQuery] bool includeChart = false,

--- a/src/WalkingTec.Mvvm.Mvc/_DashboardController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_DashboardController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using WalkingTec.Mvvm.Core;
@@ -46,6 +47,8 @@ namespace WalkingTec.Mvvm.Mvc
         }
 
         [HttpGet("list")]
+        [ProducesResponseType(typeof(IReadOnlyList<DashboardSummary>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> List()
         {
             var (userId, roles) = GetUserInfo();
@@ -55,6 +58,10 @@ namespace WalkingTec.Mvvm.Mvc
         }
 
         [HttpGet("{id}")]
+        [ProducesResponseType(typeof(DashboardDefinition), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get(string id)
         {
             var tenantId = GetTenantId();
@@ -71,6 +78,9 @@ namespace WalkingTec.Mvvm.Mvc
         }
 
         [HttpPost("")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> Create([FromBody] DashboardDefinition dashboard)
         {
             if (dashboard == null) return BadRequest();
@@ -87,6 +97,11 @@ namespace WalkingTec.Mvvm.Mvc
         }
 
         [HttpPut("{id}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Update(string id, [FromBody] DashboardDefinition dashboard)
         {
             if (dashboard == null || dashboard.Id != id) return BadRequest();
@@ -112,6 +127,10 @@ namespace WalkingTec.Mvvm.Mvc
         }
 
         [HttpDelete("{id}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Delete(string id)
         {
             var tenantId = GetTenantId();
@@ -129,6 +148,10 @@ namespace WalkingTec.Mvvm.Mvc
         }
 
         [HttpGet("{id}/widget/{wid}/data")]
+        [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetWidgetData(string id, string wid, CancellationToken ct)
         {
             var tenantId = GetTenantId();
@@ -160,6 +183,10 @@ namespace WalkingTec.Mvvm.Mvc
         }
 
         [HttpPost("{id}/widget/{wid}/data")]
+        [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> PostWidgetData(string id, string wid, [FromBody] Dictionary<string, string> filters, CancellationToken ct)
         {
             var tenantId = GetTenantId();
@@ -189,6 +216,8 @@ namespace WalkingTec.Mvvm.Mvc
         }
 
         [HttpGet("datasources")]
+        [ProducesResponseType(typeof(IEnumerable<object>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public IActionResult GetDataSources()
         {
             var result = new List<object>();


### PR DESCRIPTION
## Summary

Adds `[ProducesResponseType]` attributes to all framework API controller actions so Swagger/OpenAPI spec correctly documents all possible HTTP status codes.

### `_AnalysisController` (5 actions)

| Action | Status codes |
|--------|-------------|
| `GET /meta` | 200 `IEnumerable<object>`, 400, 401, 403 |
| `POST /query` | 200 `AnalysisQueryResponse`, 400, 401, 403 |
| `POST /pivot` | 200 `AnalysisPivotResponse`, 400, 401, 403 |
| `POST /export` | 200 `FileContentResult`, 400, 401, 403 |
| `POST /pivot/export` | 200 `FileContentResult`, 400, 401, 403 |

### `_DashboardController` (8 actions)

| Action | Status codes |
|--------|-------------|
| `GET /list` | 200 `IReadOnlyList<DashboardSummary>`, 401 |
| `GET /{id}` | 200 `DashboardDefinition`, 401, 403, 404 |
| `POST /` | 200 `string`, 400, 401 |
| `PUT /{id}` | 200, 400, 401, 403, 404 |
| `DELETE /{id}` | 200, 401, 403, 404 |
| `GET /{id}/widget/{wid}/data` | 200 `object`, 401, 403, 404 |
| `POST /{id}/widget/{wid}/data` | 200 `object`, 401, 403, 404 |
| `GET /datasources` | 200 `IEnumerable<object>`, 401 |

### Out of scope

`_FrameworkController` returns HTML views (not JSON), so `[ProducesResponseType]` is less useful there — tracked separately if needed.

## Test plan

- [x] `dotnet build` passes with 0 errors
- [x] No test changes required (metadata-only attribute, no runtime behavior change)
- CI run will confirm full suite

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)