### PR TITLE
feat(observability): add OpenTelemetry integration

### DIFF
--- a/src/WalkingTec.Mvvm.Core/WtmActivitySources.cs
+++ b/src/WalkingTec.Mvvm.Core/WtmActivitySources.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Diagnostics;
+
+namespace WalkingTec.Mvvm.Core;
+
+/// <summary>
+/// Named <see cref="ActivitySource"/> instances for WTM framework telemetry.
+/// Register these source names via <c>AddWtmOpenTelemetry()</c> so the OTel SDK
+/// can collect spans emitted by the Core, Analysis, and ETL subsystems.
+/// </summary>
+public static class WtmActivitySources
+{
+    public const string CoreName = "WalkingTec.Mvvm.Core";
+    public const string AnalysisName = "WalkingTec.Mvvm.Analysis";
+    public const string EtlName = "WalkingTec.Mvvm.Etl";
+
+    /// <summary>Core framework spans (VM lifecycle, controller operations).</summary>
+    public static readonly ActivitySource Core = new(CoreName);
+
+    /// <summary>Analysis engine spans (ad-hoc query, export).</summary>
+    public static readonly ActivitySource Analysis = new(AnalysisName);
+
+    /// <summary>ETL pipeline spans (extract, load, merge).</summary>
+    public static readonly ActivitySource Etl = new(EtlName);
+}

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmOpenTelemetryExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmOpenTelemetryExtension.cs
@@ -1,0 +1,121 @@
+#nullable enable
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Mvc;
+
+/// <summary>
+/// Configuration options for <see cref="WtmOpenTelemetryExtension.AddWtmOpenTelemetry"/>.
+/// </summary>
+public class WtmOpenTelemetryOptions
+{
+    /// <summary>OTel service name reported to the backend (default: <c>WtmApp</c>).</summary>
+    public string ServiceName { get; set; } = "WtmApp";
+
+    /// <summary>Optional service version string injected into the OTel resource.</summary>
+    public string? ServiceVersion { get; set; }
+
+    /// <summary>Instrument ASP.NET Core HTTP requests (traces + metrics). Default: <c>true</c>.</summary>
+    public bool EnableAspNetCoreInstrumentation { get; set; } = true;
+
+    /// <summary>Instrument outgoing <see cref="System.Net.Http.HttpClient"/> calls. Default: <c>true</c>.</summary>
+    public bool EnableHttpClientInstrumentation { get; set; } = true;
+
+    /// <summary>
+    /// Collect spans emitted by <see cref="WtmActivitySources"/> (Core, Analysis, ETL).
+    /// Default: <c>true</c>.
+    /// </summary>
+    public bool EnableWtmActivitySources { get; set; } = true;
+
+    /// <summary>
+    /// OTLP exporter endpoint (e.g. <c>http://localhost:4317</c> for Jaeger / Grafana Tempo).
+    /// When <c>null</c> no OTLP exporter is registered.
+    /// </summary>
+    public string? OtlpEndpoint { get; set; }
+
+    /// <summary>
+    /// Additional tracing configuration applied after all built-in sources are added.
+    /// Use this to register extra <see cref="ActivitySource"/> names or custom exporters.
+    /// </summary>
+    public Action<TracerProviderBuilder>? CustomTracing { get; set; }
+
+    /// <summary>
+    /// Additional metrics configuration applied after all built-in instruments are added.
+    /// </summary>
+    public Action<MeterProviderBuilder>? CustomMetrics { get; set; }
+}
+
+/// <summary>
+/// <see cref="IServiceCollection"/> extensions for WTM OpenTelemetry integration.
+/// </summary>
+public static class WtmOpenTelemetryExtension
+{
+    /// <summary>
+    /// Registers OpenTelemetry tracing and metrics with WTM-specific defaults.
+    /// </summary>
+    /// <remarks>
+    /// Minimal usage (OTLP to local Jaeger/Tempo):
+    /// <code>
+    /// services.AddWtmOpenTelemetry(o =>
+    /// {
+    ///     o.ServiceName    = "MyWtmApp";
+    ///     o.OtlpEndpoint   = "http://localhost:4317";
+    /// });
+    /// </code>
+    /// </remarks>
+    public static IServiceCollection AddWtmOpenTelemetry(
+        this IServiceCollection services,
+        Action<WtmOpenTelemetryOptions>? configure = null)
+    {
+        var options = new WtmOpenTelemetryOptions();
+        configure?.Invoke(options);
+
+        services
+            .AddOpenTelemetry()
+            .ConfigureResource(resource =>
+            {
+                resource.AddService(
+                    serviceName: options.ServiceName,
+                    serviceVersion: options.ServiceVersion);
+            })
+            .WithTracing(tracing =>
+            {
+                if (options.EnableAspNetCoreInstrumentation)
+                    tracing.AddAspNetCoreInstrumentation();
+
+                if (options.EnableHttpClientInstrumentation)
+                    tracing.AddHttpClientInstrumentation();
+
+                if (options.EnableWtmActivitySources)
+                {
+                    tracing.AddSource(WtmActivitySources.CoreName);
+                    tracing.AddSource(WtmActivitySources.AnalysisName);
+                    tracing.AddSource(WtmActivitySources.EtlName);
+                }
+
+                if (options.OtlpEndpoint != null)
+                    tracing.AddOtlpExporter(o => o.Endpoint = new Uri(options.OtlpEndpoint));
+
+                options.CustomTracing?.Invoke(tracing);
+            })
+            .WithMetrics(metrics =>
+            {
+                if (options.EnableAspNetCoreInstrumentation)
+                    metrics.AddAspNetCoreInstrumentation();
+
+                if (options.EnableHttpClientInstrumentation)
+                    metrics.AddHttpClientInstrumentation();
+
+                if (options.OtlpEndpoint != null)
+                    metrics.AddOtlpExporter(o => o.Endpoint = new Uri(options.OtlpEndpoint));
+
+                options.CustomMetrics?.Invoke(metrics);
+            });
+
+        return services;
+    }
+}

--- a/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
+++ b/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
@@ -89,6 +89,10 @@
 
   <ItemGroup>
     <PackageReference Include="DUWENINK.Captcha" Version="0.8.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.22" />

--- a/test/WalkingTec.Mvvm.Core.Test/OpenTelemetry/WtmOpenTelemetryTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/OpenTelemetry/WtmOpenTelemetryTests.cs
@@ -1,0 +1,161 @@
+#nullable enable
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Mvc;
+
+namespace WalkingTec.Mvvm.Core.Test.OpenTelemetry;
+
+[TestClass]
+public class WtmActivitySourcesTests
+{
+    [TestMethod]
+    public void SourceNames_HaveExpectedValues()
+    {
+        Assert.AreEqual("WalkingTec.Mvvm.Core", WtmActivitySources.CoreName);
+        Assert.AreEqual("WalkingTec.Mvvm.Analysis", WtmActivitySources.AnalysisName);
+        Assert.AreEqual("WalkingTec.Mvvm.Etl", WtmActivitySources.EtlName);
+    }
+
+    [TestMethod]
+    public void StaticSources_AreNotNull()
+    {
+        Assert.IsNotNull(WtmActivitySources.Core);
+        Assert.IsNotNull(WtmActivitySources.Analysis);
+        Assert.IsNotNull(WtmActivitySources.Etl);
+    }
+
+    [TestMethod]
+    public void StaticSources_NamesMatchConstants()
+    {
+        Assert.AreEqual(WtmActivitySources.CoreName, WtmActivitySources.Core.Name);
+        Assert.AreEqual(WtmActivitySources.AnalysisName, WtmActivitySources.Analysis.Name);
+        Assert.AreEqual(WtmActivitySources.EtlName, WtmActivitySources.Etl.Name);
+    }
+}
+
+[TestClass]
+public class WtmOpenTelemetryExtensionTests
+{
+    [TestMethod]
+    public void AddWtmOpenTelemetry_NoOptions_DoesNotThrow()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddWtmOpenTelemetry();
+
+        // BuildServiceProvider verifies DI registration is consistent
+        using var sp = services.BuildServiceProvider();
+        Assert.IsNotNull(sp);
+    }
+
+    [TestMethod]
+    public void AddWtmOpenTelemetry_WithOptions_DoesNotThrow()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddWtmOpenTelemetry(o =>
+        {
+            o.ServiceName = "TestService";
+            o.ServiceVersion = "1.0.0";
+            o.EnableAspNetCoreInstrumentation = false; // requires HTTP context pipeline
+            o.EnableHttpClientInstrumentation = true;
+            o.EnableWtmActivitySources = true;
+        });
+
+        using var sp = services.BuildServiceProvider();
+        Assert.IsNotNull(sp);
+    }
+
+    [TestMethod]
+    public void AddWtmOpenTelemetry_WithOtlpEndpoint_DoesNotThrow()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddWtmOpenTelemetry(o =>
+        {
+            o.OtlpEndpoint = "http://localhost:4317";
+            o.EnableAspNetCoreInstrumentation = false;
+        });
+
+        using var sp = services.BuildServiceProvider();
+        Assert.IsNotNull(sp);
+    }
+
+    [TestMethod]
+    public void AddWtmOpenTelemetry_RegistersOpenTelemetryServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        int countBefore = services.Count;
+
+        services.AddWtmOpenTelemetry(o =>
+        {
+            o.EnableAspNetCoreInstrumentation = false;
+        });
+
+        Assert.IsTrue(services.Count > countBefore,
+            "AddWtmOpenTelemetry should register at least one service");
+    }
+
+    [TestMethod]
+    public void AddWtmOpenTelemetry_RegistersOtelHostedService()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddWtmOpenTelemetry(o =>
+        {
+            o.EnableAspNetCoreInstrumentation = false;
+        });
+
+        // The OTel SDK registers an IHostedService for lifecycle management
+        bool hasOtelService = services.Any(sd =>
+            sd.ServiceType.FullName?.Contains("OpenTelemetry") == true ||
+            sd.ImplementationType?.FullName?.Contains("OpenTelemetry") == true ||
+            sd.ImplementationFactory != null &&
+                sd.ServiceType.Assembly.GetName().Name?.Contains("OpenTelemetry") == true);
+
+        Assert.IsTrue(hasOtelService, "Expected at least one OpenTelemetry service to be registered");
+    }
+
+    [TestMethod]
+    public void WtmOpenTelemetryOptions_Defaults_AreCorrect()
+    {
+        var opts = new WtmOpenTelemetryOptions();
+
+        Assert.AreEqual("WtmApp", opts.ServiceName);
+        Assert.IsNull(opts.ServiceVersion);
+        Assert.IsTrue(opts.EnableAspNetCoreInstrumentation);
+        Assert.IsTrue(opts.EnableHttpClientInstrumentation);
+        Assert.IsTrue(opts.EnableWtmActivitySources);
+        Assert.IsNull(opts.OtlpEndpoint);
+        Assert.IsNull(opts.CustomTracing);
+        Assert.IsNull(opts.CustomMetrics);
+    }
+
+    [TestMethod]
+    public void AddWtmOpenTelemetry_CustomTracing_IsCalled()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        bool customTracingCalled = false;
+
+        services.AddWtmOpenTelemetry(o =>
+        {
+            o.EnableAspNetCoreInstrumentation = false;
+            o.CustomTracing = _ => customTracingCalled = true;
+        });
+
+        using var sp = services.BuildServiceProvider();
+        // Resolve TracerProvider to trigger the builder
+        var tracerProvider = sp.GetService<global::OpenTelemetry.Trace.TracerProvider>();
+
+        Assert.IsTrue(customTracingCalled, "CustomTracing delegate should have been invoked");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `WtmActivitySources` to `WalkingTec.Mvvm.Core` — named `ActivitySource` statics for Core, Analysis, and ETL subsystems
- Adds `AddWtmOpenTelemetry()` opt-in DI extension to `WalkingTec.Mvvm.Mvc` following the existing `AddWtmSerilog()` pattern
- Adds 4 stable OTel NuGet packages (v1.15.x): `Extensions.Hosting`, `Instrumentation.AspNetCore`, `Instrumentation.Http`, `Exporter.OpenTelemetryProtocol`
- 7 new MSTests (all passing)

## Usage

```csharp
// Program.cs / Startup.cs
services.AddWtmOpenTelemetry(o =>
{
    o.ServiceName  = "MyWtmApp";
    o.OtlpEndpoint = "http://localhost:4317"; // Jaeger / Grafana Tempo
});
```

Custom spans in ETL / Analysis:
```csharp
using var activity = WtmActivitySources.Etl.StartActivity("pipeline.execute");
```

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 1201 passed, 0 failed
- [x] 7 OTel-specific MSTests covering: source name constants, static source instances, DI registration, option defaults, OTLP config, custom tracing delegate

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)