### PR TITLE
feat(import): add ValidateOnly dry-run mode to BaseImportVM

### DIFF
--- a/src/WalkingTec.Mvvm.Core/BaseImportVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BaseImportVM.cs
@@ -68,6 +68,16 @@ namespace WalkingTec.Mvvm.Core
         public bool ValidityTemplateType { get; set; }
 
         /// <summary>
+        /// When <c>true</c>, runs all validation and business-rule checks but skips
+        /// persisting data. <see cref="ErrorListVM"/> is populated as usual; the caller
+        /// can inspect <see cref="EntityList"/> to see which rows would be imported.
+        /// The uploaded file is NOT deleted so the user can re-submit for the real import.
+        /// Default: <c>false</c>.
+        /// </summary>
+        [JsonIgnore]
+        public bool ValidateOnly { get; set; }
+
+        /// <summary>
         /// 下载模版页面的参数
         /// </summary>
         [JsonIgnore]
@@ -1041,7 +1051,7 @@ namespace WalkingTec.Mvvm.Core
             }
 
             //如果没有错误，更新数据库
-            if (EntityList.Count > 0)
+            if (EntityList.Count > 0 && !ValidateOnly)
             {
                 try
                 {
@@ -1059,7 +1069,7 @@ namespace WalkingTec.Mvvm.Core
                     return false;
                 }
             }
-            if (string.IsNullOrEmpty(UploadFileId) == false && Wtm!.ServiceProvider != null)
+            if (!ValidateOnly && string.IsNullOrEmpty(UploadFileId) == false && Wtm!.ServiceProvider != null)
             {
                 var fp = Wtm!.ServiceProvider.GetRequiredService<WtmFileProvider>();
                 fp.DeleteFile(UploadFileId, Wtm!.CreateDC(false, "default"));

--- a/test/WalkingTec.Mvvm.Core.Test/VM/ValidateOnlyImportTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/VM/ValidateOnlyImportTests.cs
@@ -1,0 +1,138 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Test.Mock;
+
+namespace WalkingTec.Mvvm.Core.Test.VM;
+
+/// <summary>
+/// Tests for <see cref="BaseImportVM{T,P}.ValidateOnly"/> dry-run mode.
+/// </summary>
+[TestClass]
+public class ValidateOnlyImportTests
+{
+    private string _seed = null!;
+
+    [TestInitialize]
+    public void Init() => _seed = System.Guid.NewGuid().ToString();
+
+    private IDataContext CreateDb() => new ImportTestDataContext(_seed, DBTypeEnum.Memory);
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private TestImportVM MakeVm(List<ImportTestItem> entities, bool validateOnly = false)
+    {
+        var vm = new TestImportVM(entities) { ValidateOnly = validateOnly };
+        vm.Wtm = MockWtmContext.CreateWtmContext(CreateDb(), "testuser");
+        return vm;
+    }
+
+    // ── ValidateOnly = false (normal path unchanged) ─────────────────────────
+
+    [TestMethod]
+    public void ValidateOnly_False_ByDefault()
+    {
+        var vm = new TestImportVM();
+        Assert.IsFalse(vm.ValidateOnly);
+    }
+
+    [TestMethod]
+    public void ValidateOnly_False_PersistsData()
+    {
+        var entities = new List<ImportTestItem>
+        {
+            new ImportTestItem { Name = "Alpha", Value = 1 }
+        };
+        var vm = MakeVm(entities, validateOnly: false);
+
+        var result = vm.BatchSaveData();
+
+        Assert.IsTrue(result);
+        using var db = CreateDb();
+        Assert.AreEqual(1, db.Set<ImportTestItem>().Count(), "Row should be persisted");
+    }
+
+    // ── ValidateOnly = true, no errors ───────────────────────────────────────
+
+    [TestMethod]
+    public void ValidateOnly_True_ValidEntities_ReturnsTrue()
+    {
+        var entities = new List<ImportTestItem>
+        {
+            new ImportTestItem { Name = "Preview1", Value = 10 },
+            new ImportTestItem { Name = "Preview2", Value = 20 }
+        };
+        var vm = MakeVm(entities, validateOnly: true);
+
+        var result = vm.BatchSaveData();
+
+        Assert.IsTrue(result, "ValidateOnly should return true when validation passes");
+    }
+
+    [TestMethod]
+    public void ValidateOnly_True_ValidEntities_DoesNotPersist()
+    {
+        var entities = new List<ImportTestItem>
+        {
+            new ImportTestItem { Name = "DryRun", Value = 99 }
+        };
+        var vm = MakeVm(entities, validateOnly: true);
+        vm.BatchSaveData();
+
+        using var db = CreateDb();
+        Assert.AreEqual(0, db.Set<ImportTestItem>().Count(), "ValidateOnly must not write to DB");
+    }
+
+    [TestMethod]
+    public void ValidateOnly_True_EntityListPopulated_ForPreview()
+    {
+        var entities = new List<ImportTestItem>
+        {
+            new ImportTestItem { Name = "Row1", Value = 1 },
+            new ImportTestItem { Name = "Row2", Value = 2 },
+            new ImportTestItem { Name = "Row3", Value = 3 }
+        };
+        var vm = MakeVm(entities, validateOnly: true);
+
+        vm.BatchSaveData();
+
+        Assert.AreEqual(3, vm.EntityList.Count, "EntityList exposes rows for preview");
+        Assert.AreEqual(0, vm.ErrorListVM.EntityList.Count, "No validation errors expected");
+    }
+
+    // ── ValidateOnly = true, with validation errors ───────────────────────────
+
+    [TestMethod]
+    public void ValidateOnly_True_ValidationErrors_ReturnsFalse()
+    {
+        // Name exceeds StringLength(50)
+        var entities = new List<ImportTestItem>
+        {
+            new ImportTestItem { Name = new string('X', 60), Value = 1 }
+        };
+        var vm = MakeVm(entities, validateOnly: true);
+
+        var result = vm.BatchSaveData();
+
+        Assert.IsFalse(result, "ValidateOnly should return false when validation fails");
+        Assert.IsTrue(vm.ErrorListVM.EntityList.Count > 0, "Errors should be reported");
+    }
+
+    [TestMethod]
+    public void ValidateOnly_True_ValidationErrors_DoesNotPersist()
+    {
+        var entities = new List<ImportTestItem>
+        {
+            new ImportTestItem { Name = "GoodRow", Value = 1 },
+            new ImportTestItem { Name = new string('Y', 60), Value = 2 }  // invalid
+        };
+        var vm = MakeVm(entities, validateOnly: true);
+        vm.BatchSaveData();
+
+        using var db = CreateDb();
+        Assert.AreEqual(0, db.Set<ImportTestItem>().Count(),
+            "Nothing should be persisted even when some rows are valid");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ValidateOnly` property (`bool`, default `false`) to `BaseImportVM<T,P>`
- When `true`: runs DataAnnotations validation, `SetValidateCheck()`, and duplicate detection — but skips `SaveChanges()` and file cleanup
- Callers inspect `ErrorListVM.EntityList` for errors and `EntityList.Count` for the preview row count
- Backward-compatible: existing imports unaffected (`ValidateOnly` defaults to `false`)
- 7 new MSTests covering all branches of the dry-run path

## Usage

```csharp
var vm = CreateVM<MyImportVM>();
vm.ValidateOnly = true;  // dry-run

bool ok = vm.BatchSaveData();
// ok == true  → validation passed; EntityList.Count = rows that would be imported
// ok == false → ErrorListVM.EntityList has errors; nothing was written
```

## Out of scope (separate follow-up issues)

- Progress reporting (SignalR / SSE) — complex real-time infrastructure
- Error-annotated Excel download (EPPlus) — new dependency, separate PR

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 1190 passed, 0 failed across all test projects
- [x] 7 dedicated `ValidateOnlyImportTests` MSTests

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)