### PR TITLE
fix(analysis): null/empty VM name returns 400 not 404 (Closes #596)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
@@ -54,7 +54,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
         public Type Resolve(string fullName)
         {
             if (string.IsNullOrWhiteSpace(fullName))
-                throw new AnalysisVmNotFoundException(fullName ?? "");
+                throw new InvalidOperationException("VM type name is required.");
             if (_whitelist.TryGetValue(fullName, out var t))
                 return t;
             throw new AnalysisVmNotFoundException(fullName);

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisVmRegistryTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisVmRegistryTests.cs
@@ -64,12 +64,40 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.AreEqual("Some.Unknown.Type", ex.VmTypeName);
         }
 
+        /// <summary>
+        /// Resolve with empty string throws InvalidOperationException (bad request, not not-found).
+        /// </summary>
         [TestMethod]
-        public void Throws_for_empty_type_name()
+        public void Throws_InvalidOperation_for_empty_type_name()
         {
             var registry = BuildRegistry();
-            Assert.ThrowsException<AnalysisVmNotFoundException>(
+            var ex = Assert.ThrowsException<InvalidOperationException>(
                 () => registry.Resolve(string.Empty));
+            Assert.AreEqual("VM type name is required.", ex.Message);
+        }
+
+        /// <summary>
+        /// Resolve with null throws InvalidOperationException (bad request, not not-found).
+        /// </summary>
+        [TestMethod]
+        public void Throws_InvalidOperation_for_null_type_name()
+        {
+            var registry = BuildRegistry();
+            var ex = Assert.ThrowsException<InvalidOperationException>(
+                () => registry.Resolve(null));
+            Assert.AreEqual("VM type name is required.", ex.Message);
+        }
+
+        /// <summary>
+        /// Resolve with whitespace throws InvalidOperationException (bad request, not not-found).
+        /// </summary>
+        [TestMethod]
+        public void Throws_InvalidOperation_for_whitespace_type_name()
+        {
+            var registry = BuildRegistry();
+            var ex = Assert.ThrowsException<InvalidOperationException>(
+                () => registry.Resolve("   "));
+            Assert.AreEqual("VM type name is required.", ex.Message);
         }
     }
 }


### PR DESCRIPTION
## Summary

- `AnalysisVmRegistry.Resolve()` was throwing `AnalysisVmNotFoundException` for `null`/empty/whitespace input — the controller caught this as HTTP 404
- Null/empty input is a **bad request** (client sent no VM type), not "not found", so the guard now throws `InvalidOperationException("VM type name is required.")` → HTTP 400

## Changes

- `AnalysisVmRegistry.Resolve()`: 1-line fix — `throw new InvalidOperationException(...)` for null/whitespace input
- `AnalysisVmRegistryTests`: update existing `Throws_for_empty_type_name` + add null and whitespace regression tests (6 total)

## Test plan

- [x] `dotnet test --filter AnalysisVmRegistryTests` → 6 passed

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)