### PR TITLE
fix(logging): connection string sanitizer regex stops at whitespace (Closes #580)

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmConnectionStringSanitizer.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmConnectionStringSanitizer.cs
@@ -14,7 +14,7 @@ public static class WtmConnectionStringSanitizer
     /// 格式：key=value，value 以 ; " ' 或字串結尾作為終止符。
     /// </summary>
     private static readonly Regex _sensitiveKeyPattern = new(
-        @"(?i)(password|pwd|user\s+id|uid|user)\s*=\s*[^;""'\s][^;""']*",
+        @"(?i)(password|pwd|user\s+id|uid|user)\s*=\s*[^;""'\s][^;""'\s]*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>

--- a/test/WalkingTec.Mvvm.Core.Test/Security/WtmConnectionStringSanitizerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Security/WtmConnectionStringSanitizerTests.cs
@@ -107,4 +107,29 @@ public class WtmConnectionStringSanitizerTests
         Assert.IsFalse(result.Contains("User Id=sa"), "User Id must be redacted");
         StringAssert.Contains(result, "myserver"); // non-sensitive parts preserved
     }
+
+    // ─── Regression: false-positive on log messages containing user=… (#580) ────
+
+    [TestMethod]
+    public void Sanitize_does_not_garble_exception_message_with_user_text()
+    {
+        // Regression for #580: [^;"'\s]* was greedy and consumed whitespace,
+        // causing "user=john was not found" to be mangled.
+        var input = "Error: user=john was not found";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+
+        StringAssert.Contains(result, "user=[redacted]");
+        StringAssert.Contains(result, "was not found", "Text after the value must be preserved");
+    }
+
+    [TestMethod]
+    public void Sanitize_password_stops_at_whitespace()
+    {
+        // Regression for #580: value must stop at first whitespace
+        var input = "password=secret more text";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+
+        Assert.IsFalse(result.Contains("secret"), "Password value must be redacted");
+        StringAssert.Contains(result, "more text", "Text after value must be preserved");
+    }
 }


### PR DESCRIPTION
## Summary

The second character class in `_sensitiveKeyPattern` was `[^;"'\s][^;"']*`, allowing whitespace in the matched value tail. This caused log messages like `"Error: user=john was not found"` to be mangled — the entire trailing text was swallowed into the redacted value.

**Fix**: add `\s` to the second character class → `[^;"'\s][^;"'\s]*`

Both character classes now consistently stop at whitespace/semicolons/quotes, so the value terminates at the first word boundary.

## Changes

- `WtmConnectionStringSanitizer.cs`: 1-char fix in `_sensitiveKeyPattern`
- `WtmConnectionStringSanitizerTests`: 2 regression tests added (12 total)

## Test plan

- [x] `dotnet test --filter WtmConnectionStringSanitizerTests` → 12 passed (was 10, added 2 regression)

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)