### PR TITLE
fix(sanitizer): stop regex consuming whitespace in value tail (#580)

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmConnectionStringSanitizer.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmConnectionStringSanitizer.cs
@@ -14,7 +14,7 @@ public static class WtmConnectionStringSanitizer
     /// 格式：key=value，value 以 ; " ' 或字串結尾作為終止符。
     /// </summary>
     private static readonly Regex _sensitiveKeyPattern = new(
-        @"(?i)(password|pwd|user\s+id|uid|user)\s*=\s*[^;""'\s][^;""']*",
+        @"(?i)(password|pwd|user\s+id|uid|user)\s*=\s*[^;""'\s][^;""'\s]*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>

--- a/test/WalkingTec.Mvvm.Core.Test/Security/WtmConnectionStringSanitizerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Security/WtmConnectionStringSanitizerTests.cs
@@ -95,6 +95,21 @@ public class WtmConnectionStringSanitizerTests
 
     // ─── Exception-message scenario ──────────────────────────────────────
 
+    // ─── Regression: greedy-regex false positive (#580) ─────────────────
+
+    [TestMethod]
+    public void Sanitize_error_message_with_user_word_not_garbled()
+    {
+        // Regression for #580 — second char class previously allowed whitespace,
+        // causing "user=john was not found" to consume the entire tail.
+        var input = "Error: user=john was not found in directory";
+        var result = WtmConnectionStringSanitizer.Sanitize(input);
+
+        StringAssert.Contains(result, "user=[redacted]");
+        StringAssert.Contains(result, "was not found in directory",
+            "Text after the value boundary must not be consumed by the greedy match");
+    }
+
     [TestMethod]
     public void Sanitize_scrubs_connection_string_embedded_in_exception_message()
     {


### PR DESCRIPTION
## Summary

- Add `\s` to the second character class in `WtmConnectionStringSanitizer._sensitiveKeyPattern`
- Prevents greedy match from consuming text after the value boundary (e.g. `user=john was not found` used to swallow the entire tail)
- Regression test added (`Sanitize_error_message_with_user_word_not_garbled`)

## Root Cause

The pattern `[^;""']*` (second char class) allowed whitespace, so any log message containing `user=<word> more words` would have everything after `user=` consumed and redacted. Connection-string values never contain unquoted spaces, so `\s` belongs in the exclusion set.

## Test plan
- [x] `WtmConnectionStringSanitizerTests` — 11/11 passed locally
- [ ] CI `build-and-test`, `js-test`, `release-tooling-test`, `security-scan`

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)