### PR TITLE
fix(analysis): Resolve() returns 400 for null/empty VM name (#596)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
@@ -54,7 +54,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
         public Type Resolve(string fullName)
         {
             if (string.IsNullOrWhiteSpace(fullName))
-                throw new AnalysisVmNotFoundException(fullName ?? "");
+                throw new InvalidOperationException("VM type name is required.");
             if (_whitelist.TryGetValue(fullName, out var t))
                 return t;
             throw new AnalysisVmNotFoundException(fullName);

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -213,6 +213,28 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
             Assert.IsNotNull(result, "未註冊 VM 應回傳 404");
         }
 
+        // Regression tests for #596 — null/empty VM name must be 400, not 404
+        [TestMethod]
+        public void GetMeta_returns_400_for_null_vm_type()
+        {
+            var result = CreateController().GetMeta(null) as BadRequestObjectResult;
+            Assert.IsNotNull(result, "null VM type 應回傳 400 BadRequest，而非 404");
+        }
+
+        [TestMethod]
+        public void GetMeta_returns_400_for_empty_vm_type()
+        {
+            var result = CreateController().GetMeta("") as BadRequestObjectResult;
+            Assert.IsNotNull(result, "空字串 VM type 應回傳 400 BadRequest，而非 404");
+        }
+
+        [TestMethod]
+        public void GetMeta_returns_400_for_whitespace_vm_type()
+        {
+            var result = CreateController().GetMeta("   ") as BadRequestObjectResult;
+            Assert.IsNotNull(result, "空白 VM type 應回傳 400 BadRequest，而非 404");
+        }
+
         // ─── Query 路由守衛 ───────────────────────────────────────────────────
 
         [TestMethod]


### PR DESCRIPTION
## Summary

- `AnalysisVmRegistry.Resolve()` was throwing `AnalysisVmNotFoundException` for null/empty input → controller mapped it to HTTP **404**
- Null/empty `listVmType` is a **client error** (missing required field) → should be HTTP **400**
- Fix: throw `InvalidOperationException("VM type name is required.")` for the null/whitespace guard; the existing `catch(InvalidOperationException)` branch in `_AnalysisController` already returns `BadRequest`

## Change

One line in `AnalysisVmRegistry.Resolve()`:
```csharp
// Before
throw new AnalysisVmNotFoundException(fullName ?? "");

// After
throw new InvalidOperationException("VM type name is required.");
```

## Test plan
- [x] 3 new regression tests: `GetMeta` with `null`, `""`, `"   "` all return `BadRequestObjectResult`
- [x] `AnalysisControllerTests` — 106/106 passed locally
- [ ] CI `build-and-test`, `js-test`, `release-tooling-test`, `security-scan`

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)