### PR TITLE
fix(etl): reset ConsecutiveFailureCount on success; increment on graceful failure

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlQuartzJob.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlQuartzJob.cs
@@ -143,6 +143,7 @@ public class EtlQuartzJob : WtmJob
                 jobDef.LastRunAt = DateTime.UtcNow;
                 jobDef.LastError = null;
                 jobDef.Status = EtlJobStatus.Enabled;
+                jobDef.ConsecutiveFailureCount = 0;  // reset on success
             }
             else
             {
@@ -150,6 +151,8 @@ public class EtlQuartzJob : WtmJob
                     ? result.ErrorMessage[..2000]
                     : result.ErrorMessage;
                 jobDef.Status = result.Aborted ? EtlJobStatus.Enabled : EtlJobStatus.Failed;
+                if (!result.Aborted)
+                    jobDef.ConsecutiveFailureCount++;
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

- **Bug 1**: `EtlQuartzJob` success path had comment "重置連續失敗計數" but never set `ConsecutiveFailureCount = 0` — fixed by adding the reset
- **Bug 2**: Graceful pipeline failure (`EtlExecutionResult.Success == false`) never incremented `ConsecutiveFailureCount`, so `IEtlAlertService` alerts would never fire for non-exception failures (SQL errors, connection failures, etc.) — fixed by incrementing in the `else` branch (skipped when `Aborted`)

## Test plan

- [x] All 170 ETL tests pass (`dotnet test WalkingTec.Mvvm.Etl.Test`)
- [x] New behavior: success resets count; graceful failure increments count; unhandled exception (retry exhausted) increments count; aborted jobs do not increment count

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)