### PR TITLE
feat(analysis): dynamic Excel number format per measure column (#614)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisExcelExporter.cs
@@ -39,10 +39,21 @@ namespace WalkingTec.Mvvm.Core.Analysis
             headerStyle.FillForegroundColor = IndexedColors.Grey25Percent.Index;
             headerStyle.FillPattern = FillPattern.SolidForeground;
 
-            // Numeric data: thousand-separator format (e.g. 1,234,567.89)
-            var numericStyle = workbook.CreateCellStyle();
+            // Numeric data: one ICellStyle per MeasureFormat value
             var numericFormat = workbook.CreateDataFormat();
-            numericStyle.DataFormat = numericFormat.GetFormat("#,##0.00");
+            ICellStyle MakeNumericStyle(string fmt)
+            {
+                var s = workbook.CreateCellStyle();
+                s.DataFormat = numericFormat.GetFormat(fmt);
+                return s;
+            }
+            var formatStyles = new System.Collections.Generic.Dictionary<MeasureFormat, ICellStyle>
+            {
+                [MeasureFormat.Auto]     = MakeNumericStyle("#,##0.00"),
+                [MeasureFormat.Integer]  = MakeNumericStyle("#,##0"),
+                [MeasureFormat.Currency] = MakeNumericStyle("¥#,##0.00"),
+                [MeasureFormat.Percent]  = MakeNumericStyle("0.00%"),
+            };
 
             // ── Header row — use display names when available ─────────────────────
             var header = sheet.CreateRow(0);
@@ -55,15 +66,24 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 cell.CellStyle = headerStyle;
             }
 
-            // ── Detect numeric (measure) columns from first data row ──────────────
-            var numericColIndices = new HashSet<int>();
-            if (result.Rows.Count > 0)
+            // ── Resolve per-column ICellStyle ────────────────────────────────────
+            // ColumnFormats carries explicit format from [Measure(Format=...)] attribute.
+            // Fall back to numeric auto-detection (Auto style) for legacy responses.
+            var colStyles = new ICellStyle?[result.Columns.Count];
+            for (int i = 0; i < result.Columns.Count; i++)
             {
+                var colKey = result.Columns[i];
+                if (result.ColumnFormats.TryGetValue(colKey, out var fmt))
+                    colStyles[i] = formatStyles[fmt];
+            }
+            if (result.ColumnFormats.Count == 0 && result.Rows.Count > 0)
+            {
+                // Legacy path: no format metadata — detect numeric columns by CLR type.
                 for (int c = 0; c < result.Columns.Count; c++)
                 {
                     result.Rows[0].TryGetValue(result.Columns[c], out var firstVal);
                     if (firstVal is decimal or double or float or int or long)
-                        numericColIndices.Add(c);
+                        colStyles[c] = formatStyles[MeasureFormat.Auto];
                 }
             }
 
@@ -88,8 +108,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
                     else
                         cell.SetCellValue(val?.ToString() ?? "");
 
-                    if (numericColIndices.Contains(c))
-                        cell.CellStyle = numericStyle;
+                    if (colStyles[c] != null)
+                        cell.CellStyle = colStyles[c];
                 }
             }
 

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldMeta.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldMeta.cs
@@ -45,5 +45,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
         /// 前端用於渲染 &lt;select&gt; 控件，避免使用者猜測枚舉值。
         /// </summary>
         public IReadOnlyList<string>? AllowedValues { get; init; }
+
+        /// <summary>Excel 匯出格式（來自 [Measure] attribute）</summary>
+        public MeasureFormat Format { get; set; } = MeasureFormat.Auto;
     }
 }

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldScanner.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisFieldScanner.cs
@@ -59,7 +59,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
                         Kind = AnalysisFieldKind.Measure,
                         AllowedFuncs = msr.AllowedFuncs,
                         ClrType = prop.PropertyType,
-                        AllowedRoles = msr.AllowedRoles
+                        AllowedRoles = msr.AllowedRoles,
+                        Format = msr.Format
                     };
                 }
             }

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -92,6 +92,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
             }
 
             var displayNames = BuildColumnDisplayNames(req, wl);
+            var columnFormats = BuildColumnFormats(req, wl);
 
             var response = new AnalysisQueryResponse
             {
@@ -104,7 +105,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
                     ? "聚合結果僅基於前 50,000 筆原始資料，可能不代表完整數據。建議縮小篩選條件或聯繫管理員啟用 ServerSide 策略。"
                     : null,
                 QueryHash = queryHash,
-                ColumnDisplayNames = displayNames
+                ColumnDisplayNames = displayNames,
+                ColumnFormats = columnFormats
             };
 
             _cache?.Set(queryHash, response, _defaultTtl);
@@ -170,6 +172,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
             }
 
             var displayNames = BuildColumnDisplayNames(req, wl);
+            var columnFormats = BuildColumnFormats(req, wl);
 
             var response = new AnalysisQueryResponse
             {
@@ -182,7 +185,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
                     ? "聚合結果僅基於前 50,000 筆原始資料，可能不代表完整數據。建議縮小篩選條件或聯繫管理員啟用 ServerSide 策略。"
                     : null,
                 QueryHash = queryHash,
-                ColumnDisplayNames = displayNames
+                ColumnDisplayNames = displayNames,
+                ColumnFormats = columnFormats
             };
 
             _cache?.Set(queryHash, response, _defaultTtl);
@@ -686,6 +690,19 @@ namespace WalkingTec.Mvvm.Core.Analysis
         /// <summary>
         /// 建立欄位 key → 使用者友善顯示名稱的對照表。
         /// </summary>
+        private static Dictionary<string, MeasureFormat> BuildColumnFormats(
+            AnalysisQueryRequest req,
+            Dictionary<string, AnalysisFieldMeta> wl)
+        {
+            var map = new Dictionary<string, MeasureFormat>();
+            foreach (var m in req.Measures)
+            {
+                var key = $"{m.Field}_{m.Func}";
+                map[key] = wl.TryGetValue(m.Field, out var meta) ? meta.Format : MeasureFormat.Auto;
+            }
+            return map;
+        }
+
         private static Dictionary<string, string> BuildColumnDisplayNames(
             AnalysisQueryRequest req,
             Dictionary<string, AnalysisFieldMeta> wl)

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryResponse.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryResponse.cs
@@ -36,6 +36,12 @@ namespace WalkingTec.Mvvm.Core.Analysis
         public string QueryHash { get; set; } = string.Empty;
 
         /// <summary>
+        /// 量值欄位 key（如 "Amount_Sum"）→ MeasureFormat 的對照表。
+        /// 匯出時依此套用數字格式；不在此表中的欄位以 Auto 處理。
+        /// </summary>
+        public Dictionary<string, MeasureFormat> ColumnFormats { get; set; } = new Dictionary<string, MeasureFormat>();
+
+        /// <summary>
         /// 欄位 key（Columns 中的值）到使用者友善顯示名稱的對照表。
         /// 維度：key = 欄位名稱，value = DisplayName（如 "地區"）。
         /// 量值：key = "Field_Func"（如 "Amount_Sum"），value = "DisplayName 合計"（如 "金額 合計"）。

--- a/src/WalkingTec.Mvvm.Core/Analysis/MeasureAttribute.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/MeasureAttribute.cs
@@ -17,5 +17,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
         /// <summary>允許存取此度量的角色列表（逗號分隔）</summary>
         public string? AllowedRoles { get; set; }
+
+        /// <summary>Excel 匯出時的數字格式（預設 Auto）</summary>
+        public MeasureFormat Format { get; set; } = MeasureFormat.Auto;
     }
 }

--- a/src/WalkingTec.Mvvm.Core/Analysis/MeasureFormat.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/MeasureFormat.cs
@@ -1,0 +1,21 @@
+#nullable enable
+namespace WalkingTec.Mvvm.Core.Analysis
+{
+    /// <summary>
+    /// Analysis Mode Excel 匯出時，量值欄位的數字顯示格式。
+    /// </summary>
+    public enum MeasureFormat
+    {
+        /// <summary>自動：千分位 + 兩位小數（#,##0.00），與舊版行為相同。</summary>
+        Auto = 0,
+
+        /// <summary>整數：千分位，無小數（#,##0）。適合數量、筆數等整數量值。</summary>
+        Integer = 1,
+
+        /// <summary>貨幣：人民幣符號 + 千分位 + 兩位小數（¥#,##0.00）。</summary>
+        Currency = 2,
+
+        /// <summary>百分比：兩位小數百分比（0.00%）。值應以小數形式儲存（如 0.75 = 75%）。</summary>
+        Percent = 3,
+    }
+}

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/MeasureFormatTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/MeasureFormatTests.cs
@@ -1,0 +1,203 @@
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
+using WalkingTec.Mvvm.Core.Analysis;
+
+namespace WalkingTec.Mvvm.Core.Test.Analysis;
+
+/// <summary>
+/// Tests for issue #614 — Excel export dynamic number formatting via MeasureFormat.
+/// Covers: attribute → scanner → response → exporter pipeline.
+/// </summary>
+[TestClass]
+public class MeasureFormatTests
+{
+    // ── Attribute & Scanner ───────────────────────────────────────────────────
+
+    private class SalesModel
+    {
+        [Dimension] public string? Region { get; set; }
+
+        [Measure(AllowedFuncs = AggregateFunc.Sum)]
+        public decimal Revenue { get; set; }
+
+        [Measure(AllowedFuncs = AggregateFunc.Sum, Format = MeasureFormat.Currency)]
+        public decimal Cost { get; set; }
+
+        [Measure(AllowedFuncs = AggregateFunc.Sum, Format = MeasureFormat.Integer)]
+        public int Quantity { get; set; }
+
+        [Measure(AllowedFuncs = AggregateFunc.Avg, Format = MeasureFormat.Percent)]
+        public double Margin { get; set; }
+    }
+
+    [TestMethod]
+    public void Scanner_defaults_to_Auto_when_Format_not_specified()
+    {
+        var metas = AnalysisFieldScanner.ScanModel(typeof(SalesModel)).ToList();
+        var revenue = metas.Single(m => m.FieldName == "Revenue");
+        Assert.AreEqual(MeasureFormat.Auto, revenue.Format);
+    }
+
+    [TestMethod]
+    public void Scanner_propagates_Currency_format()
+    {
+        var metas = AnalysisFieldScanner.ScanModel(typeof(SalesModel)).ToList();
+        var cost = metas.Single(m => m.FieldName == "Cost");
+        Assert.AreEqual(MeasureFormat.Currency, cost.Format);
+    }
+
+    [TestMethod]
+    public void Scanner_propagates_Integer_format()
+    {
+        var metas = AnalysisFieldScanner.ScanModel(typeof(SalesModel)).ToList();
+        var qty = metas.Single(m => m.FieldName == "Quantity");
+        Assert.AreEqual(MeasureFormat.Integer, qty.Format);
+    }
+
+    [TestMethod]
+    public void Scanner_propagates_Percent_format()
+    {
+        var metas = AnalysisFieldScanner.ScanModel(typeof(SalesModel)).ToList();
+        var margin = metas.Single(m => m.FieldName == "Margin");
+        Assert.AreEqual(MeasureFormat.Percent, margin.Format);
+    }
+
+    // ── AnalysisQueryResponse.ColumnFormats ───────────────────────────────────
+
+    [TestMethod]
+    public void ColumnFormats_defaults_to_empty_dict()
+    {
+        var r = new AnalysisQueryResponse();
+        Assert.IsNotNull(r.ColumnFormats);
+        Assert.AreEqual(0, r.ColumnFormats.Count);
+    }
+
+    // ── AnalysisExcelExporter — per-column number format ─────────────────────
+
+    private static AnalysisQueryResponse BuildResponse(params (string col, MeasureFormat fmt, object val)[] cols)
+    {
+        var resp = new AnalysisQueryResponse();
+        foreach (var (col, fmt, _) in cols)
+        {
+            resp.Columns.Add(col);
+            resp.ColumnFormats[col] = fmt;
+        }
+        var row = new Dictionary<string, object?>();
+        foreach (var (col, _, val) in cols) row[col] = val;
+        resp.Rows.Add(row);
+        return resp;
+    }
+
+    private static string GetDataFormatString(IWorkbook wb, ICell cell)
+    {
+        var styleIdx = cell.CellStyle.DataFormat;
+        return wb.CreateDataFormat().GetFormat(styleIdx);
+    }
+
+    private static (IWorkbook wb, ISheet sheet) LoadExcel(byte[] bytes)
+    {
+        var ms = new MemoryStream(bytes);
+        var wb = new XSSFWorkbook(ms);
+        return (wb, wb.GetSheetAt(0));
+    }
+
+    [TestMethod]
+    public void Export_Auto_format_applies_comma_decimal()
+    {
+        var resp = BuildResponse(("Amount_Sum", MeasureFormat.Auto, 1234.56m));
+        var bytes = AnalysisExcelExporter.Export(resp);
+        var (_, sheet) = LoadExcel(bytes);
+        var cell = sheet.GetRow(1).GetCell(0);
+        Assert.IsNotNull(cell.CellStyle, "Data cell should have a style");
+        // Auto = #,##0.00; format index 4 in built-in OR a custom format string
+        var fmtStr = cell.CellStyle.GetDataFormatString();
+        Assert.IsTrue(fmtStr.Contains("0.00"), $"Expected '0.00' in format, got: {fmtStr}");
+        Assert.IsTrue(fmtStr.Contains(",") || fmtStr.Contains("#,##"), $"Expected thousand separator, got: {fmtStr}");
+    }
+
+    [TestMethod]
+    public void Export_Integer_format_has_no_decimal()
+    {
+        var resp = BuildResponse(("Qty_Sum", MeasureFormat.Integer, 42));
+        var bytes = AnalysisExcelExporter.Export(resp);
+        var (_, sheet) = LoadExcel(bytes);
+        var cell = sheet.GetRow(1).GetCell(0);
+        Assert.IsNotNull(cell.CellStyle);
+        var fmtStr = cell.CellStyle.GetDataFormatString();
+        StringAssert.Contains(fmtStr, "#,##0");
+        Assert.IsFalse(fmtStr.Contains(".00"), $"Integer format must not contain '.00', got: {fmtStr}");
+    }
+
+    [TestMethod]
+    public void Export_Currency_format_contains_yen_symbol()
+    {
+        var resp = BuildResponse(("Cost_Sum", MeasureFormat.Currency, 9999.99m));
+        var bytes = AnalysisExcelExporter.Export(resp);
+        var (_, sheet) = LoadExcel(bytes);
+        var cell = sheet.GetRow(1).GetCell(0);
+        Assert.IsNotNull(cell.CellStyle);
+        var fmtStr = cell.CellStyle.GetDataFormatString();
+        StringAssert.Contains(fmtStr, "¥");
+        StringAssert.Contains(fmtStr, "0.00");
+    }
+
+    [TestMethod]
+    public void Export_Percent_format_contains_percent_sign()
+    {
+        var resp = BuildResponse(("Margin_Avg", MeasureFormat.Percent, 0.75));
+        var bytes = AnalysisExcelExporter.Export(resp);
+        var (_, sheet) = LoadExcel(bytes);
+        var cell = sheet.GetRow(1).GetCell(0);
+        Assert.IsNotNull(cell.CellStyle);
+        var fmtStr = cell.CellStyle.GetDataFormatString();
+        StringAssert.Contains(fmtStr, "%");
+    }
+
+    [TestMethod]
+    public void Export_mixed_formats_apply_independently_per_column()
+    {
+        var resp = new AnalysisQueryResponse();
+        resp.Columns.AddRange(new[] { "Revenue_Sum", "Qty_Sum", "Margin_Avg" });
+        resp.ColumnFormats["Revenue_Sum"] = MeasureFormat.Currency;
+        resp.ColumnFormats["Qty_Sum"] = MeasureFormat.Integer;
+        resp.ColumnFormats["Margin_Avg"] = MeasureFormat.Percent;
+        resp.Rows.Add(new Dictionary<string, object?>
+        {
+            ["Revenue_Sum"] = 12345.67m,
+            ["Qty_Sum"] = 100,
+            ["Margin_Avg"] = 0.42,
+        });
+
+        var bytes = AnalysisExcelExporter.Export(resp);
+        var (_, sheet) = LoadExcel(bytes);
+        var dataRow = sheet.GetRow(1);
+
+        StringAssert.Contains(dataRow.GetCell(0).CellStyle.GetDataFormatString(), "¥");
+        Assert.IsFalse(dataRow.GetCell(1).CellStyle.GetDataFormatString().Contains(".00"),
+            "Integer column must not have .00");
+        StringAssert.Contains(dataRow.GetCell(2).CellStyle.GetDataFormatString(), "%");
+    }
+
+    [TestMethod]
+    public void Export_legacy_response_without_ColumnFormats_still_applies_numeric_style()
+    {
+        // Simulate old response with empty ColumnFormats (backward compat)
+        var resp = new AnalysisQueryResponse();
+        resp.Columns.Add("Value_Sum");
+        // ColumnFormats is empty — legacy path
+        resp.Rows.Add(new Dictionary<string, object?> { ["Value_Sum"] = 100m });
+
+        var bytes = AnalysisExcelExporter.Export(resp);
+        var (_, sheet) = LoadExcel(bytes);
+        var cell = sheet.GetRow(1).GetCell(0);
+        // Legacy auto-detection should still apply numeric style
+        Assert.IsNotNull(cell.CellStyle);
+        var fmt = cell.CellStyle.GetDataFormatString();
+        Assert.IsFalse(string.IsNullOrEmpty(fmt), "Legacy numeric cell should have a format string");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `MeasureFormat` enum (`Auto` / `Integer` / `Currency` / `Percent`) in `WalkingTec.Mvvm.Core.Analysis`
- `[Measure]` attribute gains a `Format` property (default `Auto`, fully backward compatible)
- Format flows through the pipeline: attribute → `AnalysisFieldMeta` → `AnalysisQueryResponse.ColumnFormats` → `AnalysisExcelExporter` per-column `ICellStyle`
- Excel format strings: `Auto` = `#,##0.00`, `Integer` = `#,##0`, `Currency` = `¥#,##0.00`, `Percent` = `0.00%`
- Legacy responses with empty `ColumnFormats` fall back to existing numeric auto-detection (zero breaking changes)

## Files changed

| File | Change |
|------|--------|
| `Analysis/MeasureFormat.cs` | New enum |
| `Analysis/MeasureAttribute.cs` | Add `Format` property |
| `Analysis/AnalysisFieldMeta.cs` | Add `Format` field |
| `Analysis/AnalysisFieldScanner.cs` | Propagate `msr.Format` |
| `Analysis/AnalysisQueryResponse.cs` | Add `ColumnFormats` dict |
| `Analysis/AnalysisQueryEngine.cs` | Build `ColumnFormats` in `Execute` + `ExecuteAsync` |
| `Analysis/AnalysisExcelExporter.cs` | Per-column style lookup; legacy fallback |
| `MeasureFormatTests.cs` | 11 new MSTest cases |

## Test plan

- [x] `dotnet test` — 1048/1048 pass (0 failures)
- [x] All 4 `MeasureFormat` values tested end-to-end through the exporter
- [x] Mixed-format multi-column test
- [x] Legacy backward-compat test (empty `ColumnFormats`)

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)