### PR TITLE
fix(etl): remove [ApiController] from _EtlJobController — fixes startup crash (#635)

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
@@ -14,7 +14,6 @@ using WalkingTec.Mvvm.Mvc;
 
 namespace WalkingTec.Mvvm.Mvc;
 
-[ApiController]
 [ActionDescription("ETL Job 管理")]
 public class _EtlJobController : BaseController
 {

--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlControllerAttributeTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlControllerAttributeTests.cs
@@ -1,0 +1,52 @@
+#nullable enable
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Mvc;
+
+namespace WalkingTec.Mvvm.Etl.Test.Controllers;
+
+/// <summary>
+/// Regression tests for issue #635.
+/// ETL controllers inherit BaseController (convention routing) and must NOT carry
+/// [ApiController], which forces attribute-only routing and crashes the host at startup.
+/// </summary>
+[TestClass]
+public class EtlControllerAttributeTests
+{
+    private static readonly Type[] EtlControllerTypes =
+    [
+        typeof(_EtlJobController),
+        typeof(_EtlMonitorController),
+        typeof(_EtlRunLogController),
+    ];
+
+    [TestMethod]
+    public void EtlControllers_inherit_BaseController_not_BaseApiController()
+    {
+        foreach (var t in EtlControllerTypes)
+        {
+            Assert.IsTrue(
+                typeof(BaseController).IsAssignableFrom(t),
+                $"{t.Name} must inherit BaseController");
+            Assert.IsFalse(
+                typeof(BaseApiController).IsAssignableFrom(t),
+                $"{t.Name} must NOT inherit BaseApiController");
+        }
+    }
+
+    [TestMethod]
+    [Description("Regression: #635 — [ApiController] on a convention-routed BaseController crashes the host at startup.")]
+    public void EtlControllers_do_not_carry_ApiControllerAttribute()
+    {
+        foreach (var t in EtlControllerTypes)
+        {
+            var hasApiCtrl = t.GetCustomAttributes(typeof(ApiControllerAttribute), inherit: true).Any();
+            Assert.IsFalse(
+                hasApiCtrl,
+                $"{t.Name} must not have [ApiController]. " +
+                "BaseController uses convention routing; [ApiController] requires attribute routing and crashes the host.");
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

`_EtlJobController` inherits `BaseController` (convention routing) but was tagged with `[ApiController]`. ASP.NET Core validates that all actions on `[ApiController]`-annotated controllers use attribute routes — which they don't — and throws at host startup:

```
System.InvalidOperationException: Action '_EtlJobController.Index'
does not have an attribute route. Action methods on controllers annotated
with ApiControllerAttribute must be attribute routed.
```

`_EtlMonitorController` and `_EtlRunLogController` were not affected (no `[ApiController]`).

## Fix

Remove `[ApiController]` from `_EtlJobController`.

## Tests

Added `EtlControllerAttributeTests` with 2 regression tests:
- All 3 ETL controllers inherit `BaseController`, not `BaseApiController`
- None of the 3 ETL controllers carry `[ApiController]`

## Test plan

- [x] `dotnet test WalkingTec.Mvvm.Etl.Test` — 2/2 new regression tests pass, full suite passes

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)