### PR TITLE
feat(rbac): add search filter to role permission tree

### DIFF
--- a/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Views/FrameworkRole/PageFunction.cshtml
+++ b/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Views/FrameworkRole/PageFunction.cshtml
@@ -5,6 +5,9 @@
     <wt:display field="Entity.RoleCode" />
     <wt:display field="Entity.RoleName" />
   </wt:row>
+  <div style="margin-bottom:6px;">
+    <input id="wtm-pf-search" class="layui-input" type="text" placeholder="Search..." autocomplete="off" style="width:260px;" />
+  </div>
   <wt:grid vm="ListVM" height=500 hidden-checkbox="true" hidden-grid-index="true" hidden-panel="true" multi-line="true" use-local-data="true" />
   <wt:hidden field="Entity.ID" />
   <wt:hidden field="Entity.RoleCode" />
@@ -32,6 +35,19 @@
       else {
         $el.nextAll('div.layui-form-checked').click();
       }
+    });
+
+    // Permission tree search filter — debounced, shows ancestors of matches.
+    var _pfTimer;
+    $('#wtm-pf-search').on('input', function () {
+      var val = $(this).val();
+      clearTimeout(_pfTimer);
+      _pfTimer = setTimeout(function () {
+        var $view = $('#wtm-pf-search').closest('.layui-form').find('.layui-table-view');
+        if ($view.length) {
+          wtmPermFilter.apply($view, val);
+        }
+      }, 200);
     });
   });
 </script>

--- a/src/WalkingTec.Mvvm.Mvc/framework_layui.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_layui.js
@@ -1529,6 +1529,78 @@ var wtmHeaderFilter = (function () {
 }());
 window.wtmHeaderFilter = wtmHeaderFilter;
 
+/**
+ * wtmPermFilter — client-side search filter for the role-permission tree table.
+ *
+ * The permission tree is rendered as a flat LayUI table where each row's
+ * PageName cell carries leading &nbsp; entities to indicate depth
+ * (4 &nbsp; per level).  filterTree() is a pure function so it can be
+ * unit-tested without a DOM; apply() wires it to a rendered LayUI table.
+ */
+var wtmPermFilter = (function () {
+
+    /**
+     * Compute row visibility for a permission-tree table.
+     *
+     * @param {Array<{text: string, depth: number}>} rows
+     *   Parallel to the rendered table rows.  text is the stripped page name
+     *   (no &nbsp;, no HTML tags, trimmed).  depth is the tree level (0 = root).
+     * @param {string} query  Case-insensitive substring to match.
+     * @returns {boolean[]}  Parallel to rows — true means the row should show.
+     */
+    function filterTree(rows, query) {
+        if (!query) {
+            return rows.map(function () { return true; });
+        }
+        var q = query.toLowerCase();
+
+        // Step 1: mark rows whose own text matches the query.
+        var vis = rows.map(function (r) {
+            return r.text.toLowerCase().indexOf(q) !== -1;
+        });
+
+        // Step 2: for every matching row, walk backwards and show each ancestor
+        // (a row with strictly smaller depth that appears before it in the list).
+        for (var i = 0; i < rows.length; i++) {
+            if (!vis[i]) { continue; }
+            var depth = rows[i].depth;
+            for (var j = i - 1; j >= 0 && depth > 0; j--) {
+                if (rows[j].depth < depth) {
+                    vis[j] = true;
+                    depth = rows[j].depth;
+                }
+            }
+        }
+
+        return vis;
+    }
+
+    /**
+     * Apply a search filter to a rendered LayUI permission-tree table.
+     *
+     * @param {jQuery} $container  The .layui-table-view element wrapping the grid.
+     * @param {string} query       Search string (empty string clears the filter).
+     */
+    function apply($container, query) {
+        var $rows = $container.find('.layui-table-main tbody tr');
+        var rowData = [];
+        $rows.each(function () {
+            var html = $(this).find('td').first().find('.layui-table-cell').html() || '';
+            // &nbsp; entities in innerHTML — 4 per depth level.
+            var nbspCount = (html.match(/&nbsp;/g) || []).length;
+            var depth = Math.floor(nbspCount / 4);
+            var text = html.replace(/&nbsp;/g, ' ').replace(/<[^>]*>/g, '').trim();
+            rowData.push({ text: text, depth: depth });
+        });
+
+        var visible = filterTree(rowData, (query || '').trim());
+        $rows.each(function (i) { $(this).toggle(visible[i]); });
+    }
+
+    return { filterTree: filterTree, apply: apply };
+}());
+window.wtmPermFilter = wtmPermFilter;
+
 $.ajax({
     url: '/_framework/GetScriptLanguage',
     type: 'GET',

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_permission_filter.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_permission_filter.test.js
@@ -1,0 +1,184 @@
+/**
+ * Tests for wtmPermFilter.filterTree — the pure permission-tree row-visibility
+ * function added to framework_layui.js for issue #610.
+ *
+ * filterTree(rows, query) takes:
+ *   rows  – [{ text: string, depth: number }]  (parallel to rendered table rows)
+ *   query – case-insensitive substring to match (empty = show all)
+ * and returns a boolean[] parallel to rows.
+ *
+ * Ancestor rows of any match are also shown so the tree hierarchy stays readable.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const vm   = require('vm');
+
+const SRC = fs.readFileSync(
+    path.resolve(__dirname, '../../../src/WalkingTec.Mvvm.Mvc/framework_layui.js'),
+    'utf8'
+);
+
+/** Minimal context sufficient to run framework_layui.js and expose wtmPermFilter. */
+function makeCtx() {
+    var ctx = {
+        window: {},
+        global: {},
+        $: Object.assign(function () { return {}; }, { cookie: function () {}, ajax: function () {} }),
+        console: console,
+        setTimeout: global.setTimeout.bind(global),
+        clearTimeout: global.clearTimeout.bind(global),
+        DONOTUSE_TABLAYID: undefined,
+        DONOTUSE_COOKIEPRE: '',
+        DONOTUSE_WINDOWGUID: '',
+        layui: {
+            use:     function () {},
+            table:   { reload: function () {} },
+            layer:   { msg: function () {}, alert: function () {} },
+            form:    { render: function () {} },
+            element: { tabChange: function () {} },
+        },
+    };
+    ctx.window = ctx;   // window self-reference used by the file
+    vm.createContext(ctx);
+    new vm.Script(SRC).runInContext(ctx);
+    return ctx;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Shorthand: build a row descriptor. */
+function r(text, depth) { return { text: text, depth: depth }; }
+
+/** Run filterTree from a fresh VM context. */
+function ft(rows, query) {
+    return makeCtx().wtmPermFilter.filterTree(rows, query);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('wtmPermFilter.filterTree', () => {
+
+    test('wtmPermFilter is exposed on window', () => {
+        var ctx = makeCtx();
+        expect(typeof ctx.wtmPermFilter).toBe('object');
+        expect(typeof ctx.wtmPermFilter.filterTree).toBe('function');
+        expect(typeof ctx.wtmPermFilter.apply).toBe('function');
+    });
+
+    test('empty query shows all rows', () => {
+        var rows = [r('System', 0), r('Users', 1), r('Roles', 1)];
+        expect(ft(rows, '')).toEqual([true, true, true]);
+    });
+
+    test('null / undefined query shows all rows', () => {
+        var rows = [r('System', 0), r('Users', 1)];
+        expect(ft(rows, null)).toEqual([true, true]);
+        expect(ft(rows, undefined)).toEqual([true, true]);
+    });
+
+    test('query with no matches hides all rows', () => {
+        var rows = [r('System', 0), r('Users', 1), r('Roles', 1)];
+        expect(ft(rows, 'zzz')).toEqual([false, false, false]);
+    });
+
+    test('single root-level match shows only that row', () => {
+        var rows = [r('System', 0), r('Reports', 0), r('Users', 0)];
+        expect(ft(rows, 'Reports')).toEqual([false, true, false]);
+    });
+
+    test('leaf match shows leaf and all ancestors', () => {
+        // Tree:
+        //   System (0)
+        //     User Mgmt (1)
+        //       Add User (2)   ← match
+        //       Edit User (2)
+        var rows = [r('System', 0), r('User Mgmt', 1), r('Add User', 2), r('Edit User', 2)];
+        expect(ft(rows, 'Add User')).toEqual([true, true, true, false]);
+    });
+
+    test('depth-2 match traces ancestors through depth-1 then depth-0', () => {
+        var rows = [
+            r('Root A', 0),
+            r('Root B', 0),
+            r('Sub B1', 1),
+            r('Leaf B1a', 2),  // ← match
+        ];
+        expect(ft(rows, 'Leaf B1a')).toEqual([false, true, true, true]);
+    });
+
+    test('multiple matches at different levels show all matched + ancestors', () => {
+        // Tree:
+        //   Admin (0)
+        //     Roles (1)       ← match "role"
+        //       Add Role (2)  ← match "role"
+        //     Users (1)
+        //   Reports (0)
+        var rows = [
+            r('Admin', 0),
+            r('Roles', 1),
+            r('Add Role', 2),
+            r('Users', 1),
+            r('Reports', 0),
+        ];
+        var result = ft(rows, 'role');
+        // Admin (ancestor of Roles and Add Role), Roles, Add Role visible; Users and Reports hidden
+        expect(result).toEqual([true, true, true, false, false]);
+    });
+
+    test('match in second subtree does not show ancestors from first subtree', () => {
+        var rows = [
+            r('Section A', 0),
+            r('Page A1', 1),
+            r('Section B', 0),
+            r('Page B1', 1),  // ← match
+        ];
+        expect(ft(rows, 'B1')).toEqual([false, false, true, true]);
+    });
+
+    test('case-insensitive matching', () => {
+        var rows = [r('System Settings', 0), r('User Management', 1)];
+        expect(ft(rows, 'SYSTEM')).toEqual([true, false]);
+        expect(ft(rows, 'system settings')).toEqual([true, false]);
+        expect(ft(rows, 'MANAGEMENT')).toEqual([true, true]);
+    });
+
+    test('partial substring match', () => {
+        var rows = [r('User Management', 0), r('Role Administration', 0)];
+        expect(ft(rows, 'manage')).toEqual([true, false]);
+        expect(ft(rows, 'admin')).toEqual([false, true]);
+    });
+
+    test('empty rows array returns empty result', () => {
+        expect(ft([], 'anything')).toEqual([]);
+    });
+
+    test('single row match', () => {
+        expect(ft([r('Only Row', 0)], 'Only')).toEqual([true]);
+        expect(ft([r('Only Row', 0)], 'Missing')).toEqual([false]);
+    });
+
+    test('ancestor shown only once even if multiple descendants match', () => {
+        var rows = [
+            r('Parent', 0),
+            r('Child A', 1),  // ← match
+            r('Child B', 1),  // ← match
+        ];
+        // Parent should be visible (ancestor of both matches) — no duplication issue
+        expect(ft(rows, 'Child')).toEqual([true, true, true]);
+    });
+
+    test('depth-0 rows are never hidden because of ancestor logic (no parent to show)', () => {
+        var rows = [r('Root', 0)];
+        expect(ft(rows, 'Root')).toEqual([true]);
+    });
+
+    test('whitespace-only query treated as empty (no trim needed by caller)', () => {
+        // filterTree itself does NOT trim — the apply() wrapper trims before calling.
+        // Verify that a space does not incorrectly match all rows.
+        var rows = [r('System', 0), r('Users', 1)];
+        // ' ' is not empty string so it does an indexOf check; 'system'.indexOf(' ') = -1
+        expect(ft(rows, ' ')).toEqual([false, false]);
+    });
+
+});


### PR DESCRIPTION
## Summary

- Adds a debounced (200 ms) text search field above the permission tree table in `PageFunction.cshtml` (role privilege assignment dialog)
- Matching is **case-insensitive substring**; ancestor rows of any match are revealed automatically so the hierarchy stays readable
- New `wtmPermFilter` module in `framework_layui.js` exposes a pure `filterTree()` function (easily unit-tested) and a DOM `apply()` function

## Files changed

| File | Change |
|------|--------|
| `src/WalkingTec.Mvvm.Mvc/framework_layui.js` | New `wtmPermFilter` IIFE: `filterTree(rows, query)` pure fn + `apply($container, query)` DOM fn |
| `demo/.../Views/FrameworkRole/PageFunction.cshtml` | Search `<input>` + 200 ms debounced filter wiring |
| `test/.../framework_permission_filter.test.js` | 16 Jest tests (empty query, no match, leaf→ancestor, multi-match, cross-subtree, case-insensitive, edge cases) |

## Test plan

- [x] 16/16 new Jest tests pass (`npm test -- --testPathPattern=framework_permission_filter`)
- [x] Full JS suite: 470/470 pass
- [x] .NET build: 0 errors

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)