### PR TITLE
fix(etl): respect IsQuickDebug in OnActionExecuting role gate

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
@@ -29,6 +29,13 @@ public class _EtlJobController : BaseController
 
     public override void OnActionExecuting(ActionExecutingContext context)
     {
+        // IsQuickDebug bypasses all RBAC (framework-wide convention).
+        if (Wtm?.ConfigInfo?.IsQuickDebug == true)
+        {
+            base.OnActionExecuting(context);
+            return;
+        }
+
         var roles = Wtm?.LoginUserInfo?.Roles?.Select(r => r.RoleCode).ToArray() ?? Array.Empty<string>();
         var isAdmin = roles.Any(r =>
             string.Equals(r, "Admin", StringComparison.OrdinalIgnoreCase) ||

--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlRbacTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlRbacTests.cs
@@ -252,4 +252,38 @@ public class EtlRbacTests
             "無角色使用者應回傳 ForbidResult");
     }
 
+    // ─── 7. IsQuickDebug bypass — 對應 Issue #638 ───────────────────────────────
+
+    [TestMethod]
+    public void OnActionExecuting_IsQuickDebug_true_bypasses_role_check()
+    {
+        // Arrange: non-Admin user (would normally be forbidden)
+        var controller = CreateEtlControllerWithRoles("001");   // default demo admin code
+        controller.Wtm!.ConfigInfo!.IsQuickDebug = true;
+        var context = MakeActionContext(controller);
+
+        // Act
+        controller.OnActionExecuting(context);
+
+        // Assert: IsQuickDebug must bypass the custom role gate, matching WTM convention
+        Assert.IsNull(context.Result,
+            "IsQuickDebug=true 時應繞過 ETL 角色守衛，context.Result 應為 null");
+    }
+
+    [TestMethod]
+    public void OnActionExecuting_IsQuickDebug_false_still_enforces_role_check()
+    {
+        // Arrange: non-Admin user with IsQuickDebug explicitly false
+        var controller = CreateEtlControllerWithRoles("001");
+        controller.Wtm!.ConfigInfo!.IsQuickDebug = false;
+        var context = MakeActionContext(controller);
+
+        // Act
+        controller.OnActionExecuting(context);
+
+        // Assert: role check still runs, non-Admin is forbidden
+        Assert.IsInstanceOfType(context.Result, typeof(ForbidResult),
+            "IsQuickDebug=false 時仍應執行角色檢查");
+    }
+
 }


### PR DESCRIPTION
## Summary

- `_EtlJobController.OnActionExecuting()` had a hardcoded role check (`"Admin"` / `"ETLAdmin"`) that ran unconditionally, ignoring the WTM-wide `IsQuickDebug` convention
- Any deployment using non-standard role codes (e.g. demo app default RoleCode `"001"`) received **HTTP 403** even in debug mode
- Fix: add `IsQuickDebug` early-return at the top of `OnActionExecuting`, identical to the pattern in `MenuExtension` and `PrivilegeFilter`

## Root cause

```csharp
// Before — no IsQuickDebug check
public override void OnActionExecuting(ActionExecutingContext context)
{
    var roles = ...;
    var isAdmin = roles.Any(r => ...);
    if (!isAdmin) { context.Result = Forbid(); return; }  // always ran
    base.OnActionExecuting(context);
}
```

```csharp
// After — IsQuickDebug bypass added
public override void OnActionExecuting(ActionExecutingContext context)
{
    if (Wtm?.ConfigInfo?.IsQuickDebug == true)
    {
        base.OnActionExecuting(context);
        return;
    }
    var roles = ...;
    ...
}
```

## Test plan

- [x] 2 regression tests added to `EtlRbacTests`: `IsQuickDebug=true` bypasses; `IsQuickDebug=false` still enforces
- [x] All 14 `EtlRbacTests` pass
- [x] .NET build: 0 errors

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)