### PR TITLE
fix(demo): add [Display] to CitySearcher.selectedparent (#643)

### DIFF
--- a/demo/WalkingTec.Mvvm.Demo/ViewModels/CityVMs/CitySearcher.cs
+++ b/demo/WalkingTec.Mvvm.Demo/ViewModels/CityVMs/CitySearcher.cs
@@ -14,6 +14,7 @@ namespace WalkingTec.Mvvm.Demo.ViewModels.CityVMs
     {
         [Display(Name = "名称")]
         public String Name { get; set; }
+        [Display(Name = "父级城市")]
         public Guid selectedparent { get; set; }
         public List<TreeSelectListItem> Items { get; set; }
         protected override void InitVM()


### PR DESCRIPTION
## Summary

- Adds `[Display(Name = "父级城市")]` to `CitySearcher.selectedparent` in the demo project
- Without this attribute, `wt:tree` TagHelper falls back to the raw property name, rendering the label as `*selectedparent:` instead of `父级城市:`
- One-line fix; no logic changes

## Test plan

- [ ] Build passes (0 errors — verified locally)
- [ ] Load `/City/Index` → search bar second field now shows `父级城市:` label

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)