### PR TITLE
fix(analysis): humanize pivot table/chart column headers (#646)

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -1395,7 +1395,38 @@
 
     // ─── 渲染函式（保留 v1 邏輯）──────────────────────────────────────────────
 
+    // Build a human-friendly label for a pivot column key.
+    // Pivot columns are encoded as "{pivotValue}_{fieldName}_{func}".
+    // Row-dimension columns are plain fieldName strings.
+    function buildPivotColLabel(col, pivotValues, measureNames, fieldByName) {
+        for (var i = 0; i < pivotValues.length; i++) {
+            var pv = pivotValues[i];
+            var prefix = pv + '_';
+            if (col.length > prefix.length && col.indexOf(prefix) === 0) {
+                var msr = col.substring(prefix.length);
+                if (measureNames.indexOf(msr) >= 0) {
+                    var underIdx = msr.lastIndexOf('_');
+                    if (underIdx > 0) {
+                        var fieldPart = msr.substring(0, underIdx);
+                        var funcPart  = msr.substring(underIdx + 1);
+                        var meta = fieldByName[fieldPart];
+                        var dispName = (meta && (meta.displayName || meta.title)) || fieldPart;
+                        return pv + ' (' + dispName + ' ' + getFuncLabel(funcPart) + ')';
+                    }
+                    return pv + ' (' + msr + ')';
+                }
+            }
+        }
+        var dimMeta = fieldByName[col];
+        return (dimMeta && (dimMeta.displayName || dimMeta.title)) || col;
+    }
+
     function renderPivotTable(gridId, result, container, dateDims) {
+        var st = _state[gridId];
+        var fields = (st && st.fields) ? st.fields : [];
+        var fieldByName = {};
+        fields.forEach(function (f) { fieldByName[f.fieldName] = f; });
+
         var wrapper = document.createElement('div');
         wrapper.style.overflowX = 'auto';
         var table = document.createElement('table');
@@ -1406,7 +1437,7 @@
         var headerRow = document.createElement('tr');
         result.columns.forEach(function (col) {
             var th = document.createElement('th');
-            th.textContent = col;
+            th.textContent = buildPivotColLabel(col, result.pivotValues, result.measureNames, fieldByName);
             headerRow.appendChild(th);
         });
         thead.appendChild(headerRow);
@@ -1441,14 +1472,19 @@
         var categories = result.rows.map(function (r) {
             return firstRowDim ? String(r[firstRowDim] || '') : _i18n('result.total');
         });
+        var st = _state[gridId];
+        var fields = (st && st.fields) ? st.fields : [];
+        var fieldByName = {};
+        fields.forEach(function (f) { fieldByName[f.fieldName] = f; });
         var series = [];
         var legendData = [];
         result.pivotValues.forEach(function (pv) {
             result.measureNames.forEach(function (m) {
                 var key = pv + '_' + m;
-                legendData.push(key);
+                var label = buildPivotColLabel(key, result.pivotValues, result.measureNames, fieldByName);
+                legendData.push(label);
                 series.push({
-                    name: key, type: 'bar', stack: m,
+                    name: label, type: 'bar', stack: m,
                     data: result.rows.map(function (r) { return r[key] || 0; })
                 });
             });
@@ -1983,6 +2019,7 @@
         renderChart: renderChart,
         renderPivotTable: renderPivotTable,
         renderPivotChart: renderPivotChart,
+        buildPivotColLabel: buildPivotColLabel,
         renderTable: renderTableExposed,
         formatDateKey: formatDateKey,
         buildDrillFilter: buildDrillFilter,

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -2370,8 +2370,9 @@ describe('wtmAnalysis.renderPivotTable', () => {
         var ths = createdElements.filter(function(e) { return e.tag === 'th'; });
         expect(ths.length).toBe(3);
         expect(ths[0].textContent).toBe('Region');
-        expect(ths[1].textContent).toBe('2026-Q1_Amount_Sum');
-        expect(ths[2].textContent).toBe('2026-Q2_Amount_Sum');
+        // buildPivotColLabel formats pivot columns as "{pivotValue} ({fieldPart} {funcLabel})"
+        expect(ths[1].textContent).toBe('2026-Q1 (Amount 合計)');
+        expect(ths[2].textContent).toBe('2026-Q2 (Amount 合計)');
     });
 
     test('缺值（null）顯示 "-"', () => {
@@ -2480,11 +2481,12 @@ describe('wtmAnalysis.renderPivotChart', () => {
         var opt = capturedOptions[0];
         expect(opt.xAxis.data).toEqual(['華東', '華南']);
         expect(opt.series.length).toBe(2);
-        expect(opt.series[0].name).toBe('Q1_Amount_Sum');
+        // buildPivotColLabel formats pivot chart series names as "{pivotValue} ({fieldPart} {funcLabel})"
+        expect(opt.series[0].name).toBe('Q1 (Amount 合計)');
         expect(opt.series[0].type).toBe('bar');
         expect(opt.series[0].stack).toBe('Amount_Sum');
         expect(opt.series[0].data).toEqual([100, 50]);
-        expect(opt.series[1].name).toBe('Q2_Amount_Sum');
+        expect(opt.series[1].name).toBe('Q2 (Amount 合計)');
         expect(opt.series[1].data).toEqual([200, 150]);
     });
 

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis_pivot_header.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis_pivot_header.test.js
@@ -1,0 +1,165 @@
+/**
+ * Tests for buildPivotColLabel() — issue #646
+ *
+ * Pivot column keys are encoded as "{pivotValue}_{fieldName}_{func}".
+ * buildPivotColLabel() converts them to "{pivotValue} ({displayName} {funcLabel})"
+ * so that table headers and chart legends are human-friendly.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const vm   = require('vm');
+
+const SRC = fs.readFileSync(
+    path.resolve(__dirname, '../../../src/WalkingTec.Mvvm.Mvc/framework_analysis.js'),
+    'utf8'
+);
+
+// ─── Helper: load framework_analysis.js in a minimal context ─────────────────
+
+function loadWa(overrides) {
+    const ctx = vm.createContext(Object.assign({
+        window: {},
+        document: {
+            createElement: () => ({ style: {}, appendChild: jest.fn(), children: [] }),
+            querySelector: () => null,
+            querySelectorAll: () => [],
+        },
+        fetch: jest.fn(),
+        console,
+        setInterval: global.setInterval.bind(global),
+        clearInterval: global.clearInterval.bind(global),
+        AbortController: global.AbortController,
+        URL: { createObjectURL: jest.fn(), revokeObjectURL: jest.fn() },
+        alert: jest.fn(),
+    }, overrides));
+    ctx.window = ctx;
+    new vm.Script(SRC).runInContext(ctx);
+    return ctx.wtmAnalysis;
+}
+
+// ─── Fixture data ─────────────────────────────────────────────────────────────
+
+const PIVOT_VALUES   = ['男', '女'];
+const MEASURE_NAMES  = ['RecordCount_Sum', 'Score_Avg'];
+const FIELD_BY_NAME  = {
+    RecordCount: { fieldName: 'RecordCount', displayName: '學生數', kind: 'Measure' },
+    Score:       { fieldName: 'Score',       displayName: '分數',   kind: 'Measure' },
+    Gender:      { fieldName: 'Gender',      displayName: '性别',   kind: 'Dimension' },
+    Region:      { fieldName: 'Region',      displayName: '地區',   kind: 'Dimension' },
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('buildPivotColLabel — pivot column header formatting (issue #646)', () => {
+    let wa;
+    beforeAll(() => { wa = loadWa(); });
+
+    // ── Basic formatting ─────────────────────────────────────────────────────
+
+    test('formats pivot column as "pivotValue (displayName funcLabel)"', () => {
+        const label = wa.buildPivotColLabel(
+            '男_RecordCount_Sum', PIVOT_VALUES, MEASURE_NAMES, FIELD_BY_NAME
+        );
+        expect(label).toBe('男 (學生數 合計)');
+    });
+
+    test('formats second pivot value correctly', () => {
+        const label = wa.buildPivotColLabel(
+            '女_RecordCount_Sum', PIVOT_VALUES, MEASURE_NAMES, FIELD_BY_NAME
+        );
+        expect(label).toBe('女 (學生數 合計)');
+    });
+
+    test('formats Avg function with correct localized label', () => {
+        const label = wa.buildPivotColLabel(
+            '男_Score_Avg', PIVOT_VALUES, MEASURE_NAMES, FIELD_BY_NAME
+        );
+        expect(label).toBe('男 (分數 平均)');
+    });
+
+    test('formats female pivot + avg measure', () => {
+        const label = wa.buildPivotColLabel(
+            '女_Score_Avg', PIVOT_VALUES, MEASURE_NAMES, FIELD_BY_NAME
+        );
+        expect(label).toBe('女 (分數 平均)');
+    });
+
+    // ── Row dimension columns ────────────────────────────────────────────────
+
+    test('returns displayName for row dimension column', () => {
+        const label = wa.buildPivotColLabel(
+            'Gender', PIVOT_VALUES, MEASURE_NAMES, FIELD_BY_NAME
+        );
+        expect(label).toBe('性别');
+    });
+
+    test('returns displayName for a different dimension column', () => {
+        const label = wa.buildPivotColLabel(
+            'Region', PIVOT_VALUES, MEASURE_NAMES, FIELD_BY_NAME
+        );
+        expect(label).toBe('地區');
+    });
+
+    // ── Fallback behaviour ───────────────────────────────────────────────────
+
+    test('falls back to raw col name when fieldByName has no entry', () => {
+        const label = wa.buildPivotColLabel(
+            'UnknownCol', PIVOT_VALUES, MEASURE_NAMES, {}
+        );
+        expect(label).toBe('UnknownCol');
+    });
+
+    test('falls back to raw fieldPart when meta is missing for measure', () => {
+        // Column matches pivot format but field not in fieldByName
+        const label = wa.buildPivotColLabel(
+            '男_Score_Avg', PIVOT_VALUES, MEASURE_NAMES, {}
+        );
+        expect(label).toBe('男 (Score 平均)');
+    });
+
+    test('uses title as fallback when displayName is absent', () => {
+        const fieldByNameWithTitle = {
+            RecordCount: { fieldName: 'RecordCount', title: '學生人數', kind: 'Measure' },
+        };
+        const label = wa.buildPivotColLabel(
+            '男_RecordCount_Sum', PIVOT_VALUES, MEASURE_NAMES, fieldByNameWithTitle
+        );
+        expect(label).toBe('男 (學生人數 合計)');
+    });
+
+    // ── Edge cases ───────────────────────────────────────────────────────────
+
+    test('does not confuse partial pivot value prefix', () => {
+        // "男性" is NOT in PIVOT_VALUES, so the column should be treated as dimension
+        const label = wa.buildPivotColLabel(
+            '男性', PIVOT_VALUES, MEASURE_NAMES, FIELD_BY_NAME
+        );
+        // Not a pivot column, no dim meta → raw fallback
+        expect(label).toBe('男性');
+    });
+
+    test('handles empty pivotValues list gracefully', () => {
+        const label = wa.buildPivotColLabel(
+            '男_RecordCount_Sum', [], MEASURE_NAMES, FIELD_BY_NAME
+        );
+        // With no pivot values, treated as a dimension column → raw fallback
+        expect(label).toBe('男_RecordCount_Sum');
+    });
+
+    test('handles empty measureNames list gracefully', () => {
+        // Column starts with pivot prefix but no measure match → raw fallback
+        const label = wa.buildPivotColLabel(
+            '男_RecordCount_Sum', PIVOT_VALUES, [], FIELD_BY_NAME
+        );
+        expect(label).toBe('男_RecordCount_Sum');
+    });
+
+    test('returned label does NOT contain raw underscore-encoded key format', () => {
+        const label = wa.buildPivotColLabel(
+            '男_RecordCount_Sum', PIVOT_VALUES, MEASURE_NAMES, FIELD_BY_NAME
+        );
+        // Must not look like "男_RecordCount_Sum"
+        expect(label).not.toMatch(/_RecordCount_Sum/);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `buildPivotColLabel()` helper that converts raw pivot column keys (`男_RecordCount_Sum`) to human-friendly labels (`男 (學生數 合計)`)
- Applied to both `renderPivotTable()` column headers and `renderPivotChart()` legend/series names
- Falls back gracefully to raw field names when metadata is unavailable
- `buildPivotColLabel` exposed in the public `wtmAnalysis` API for testability

## Before / After

| Before | After |
|--------|-------|
| `男_RecordCount_Sum` | `男 (學生數 合計)` |
| `女_Score_Avg` | `女 (分數 平均)` |

## Test plan

- [ ] 13 new Jest tests in `framework_analysis_pivot_header.test.js`
- [ ] 2 existing pivot tests updated to expect new label format
- [ ] Full suite: 483/483 tests pass

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)