### PR TITLE
feat(analysis): add chart type manual selector with active-state highlight

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_analysis.js
@@ -902,10 +902,11 @@
         chartToggleRow.id = 'analysis-chart-toggle-' + gridId;
         chartToggleRow.className = 'analysis-chart-toggle-bar';
         chartToggleRow.style.display = 'none';
-        ['bar', 'line', 'bar-stacked', 'pie', 'card'].forEach(function (ct) {
+        ['bar', 'line', 'bar-stacked', 'pie', 'scatter', 'card'].forEach(function (ct) {
             var btn = document.createElement('button');
             btn.type = 'button';
             btn.className = 'layui-btn layui-btn-xs';
+            btn.dataset.chartType = ct;
             btn.textContent = ct;
             btn.title = _CHART_TITLE_MAP[ct] || ct;
             btn.addEventListener('click', function () {
@@ -1566,6 +1567,24 @@
         container.appendChild(table);
     }
 
+    // Highlights the active chart-type button in the toggle bar (#618).
+    // Called from renderChart so both auto-detect and manual selection stay in sync.
+    function syncChartToggleActive(gridId, chartType) {
+        var row = document.getElementById('analysis-chart-toggle-' + gridId);
+        if (!row) return;
+        var buttons = row.querySelectorAll('button[data-chart-type]');
+        for (var i = 0; i < buttons.length; i++) {
+            var btn = buttons[i];
+            if (btn.dataset.chartType === chartType) {
+                if (btn.className.indexOf('layui-btn-primary') < 0) {
+                    btn.className += ' layui-btn-primary';
+                }
+            } else {
+                btn.className = btn.className.replace(/\s*layui-btn-primary\b/g, '').trim();
+            }
+        }
+    }
+
     function renderChart(gridId, result, req, dimFields, container, forceChartType) {
         if (!result.rows || result.rows.length === 0) {
             var emptyP = document.createElement('p');
@@ -1582,6 +1601,7 @@
         // Persist effective chart type so exportData honours the user's manual selection (#479)
         var st = _state[gridId];
         if (st) st.lastChartType = chartType;
+        syncChartToggleActive(gridId, chartType);
 
         // Build measure key → display label map for human-friendly legends
         var fieldByName = {};
@@ -1981,6 +2001,7 @@
         collectSelection: collectSelection,
         parseFuncs: parseFuncs,
         renderChart: renderChart,
+        syncChartToggleActive: syncChartToggleActive,
         renderPivotTable: renderPivotTable,
         renderPivotChart: renderPivotChart,
         renderTable: renderTableExposed,

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -4877,3 +4877,120 @@ describe('filterPoolPills #609', () => {
         spy.mockRestore();
     });
 });
+
+// ─── [#618] syncChartToggleActive ────────────────────────────────────────────
+describe('[#618] waReq.syncChartToggleActive', () => {
+    function makeToggleRow(gridId, types) {
+        const row = document.createElement('div');
+        row.id = 'analysis-chart-toggle-' + gridId;
+        types.forEach(function (ct) {
+            const btn = document.createElement('button');
+            btn.className = 'layui-btn layui-btn-xs';
+            btn.dataset.chartType = ct;
+            row.appendChild(btn);
+        });
+        return row;
+    }
+
+    test('sets layui-btn-primary on matching button', () => {
+        const gridId = 'sync618a';
+        const row = makeToggleRow(gridId, ['bar', 'line', 'pie']);
+        const spy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-chart-toggle-' + gridId ? row : null
+        );
+        waReq.syncChartToggleActive(gridId, 'bar');
+        const barBtn = row.querySelector('[data-chart-type="bar"]');
+        expect(barBtn.className).toContain('layui-btn-primary');
+        spy.mockRestore();
+    });
+
+    test('removes layui-btn-primary from non-matching buttons', () => {
+        const gridId = 'sync618b';
+        const row = makeToggleRow(gridId, ['bar', 'line', 'pie']);
+        // Pre-mark all as active
+        row.querySelectorAll('button').forEach(b => { b.className += ' layui-btn-primary'; });
+        const spy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-chart-toggle-' + gridId ? row : null
+        );
+        waReq.syncChartToggleActive(gridId, 'line');
+        const barBtn = row.querySelector('[data-chart-type="bar"]');
+        const lineBtn = row.querySelector('[data-chart-type="line"]');
+        const pieBtn = row.querySelector('[data-chart-type="pie"]');
+        expect(barBtn.className).not.toContain('layui-btn-primary');
+        expect(lineBtn.className).toContain('layui-btn-primary');
+        expect(pieBtn.className).not.toContain('layui-btn-primary');
+        spy.mockRestore();
+    });
+
+    test('handles scatter type correctly', () => {
+        const gridId = 'sync618c';
+        const row = makeToggleRow(gridId, ['bar', 'line', 'scatter', 'pie', 'card']);
+        const spy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-chart-toggle-' + gridId ? row : null
+        );
+        waReq.syncChartToggleActive(gridId, 'scatter');
+        const scatterBtn = row.querySelector('[data-chart-type="scatter"]');
+        const barBtn = row.querySelector('[data-chart-type="bar"]');
+        expect(scatterBtn.className).toContain('layui-btn-primary');
+        expect(barBtn.className).not.toContain('layui-btn-primary');
+        spy.mockRestore();
+    });
+
+    test('no matching type — no button gets layui-btn-primary', () => {
+        const gridId = 'sync618d';
+        const row = makeToggleRow(gridId, ['bar', 'line']);
+        const spy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-chart-toggle-' + gridId ? row : null
+        );
+        waReq.syncChartToggleActive(gridId, 'pie');
+        row.querySelectorAll('button').forEach(b => {
+            expect(b.className).not.toContain('layui-btn-primary');
+        });
+        spy.mockRestore();
+    });
+
+    test('missing toggle row — does not throw', () => {
+        const spy = jest.spyOn(document, 'getElementById').mockReturnValue(null);
+        expect(() => waReq.syncChartToggleActive('missing618', 'bar')).not.toThrow();
+        spy.mockRestore();
+    });
+
+    test('duplicate call — layui-btn-primary not duplicated in className', () => {
+        const gridId = 'sync618e';
+        const row = makeToggleRow(gridId, ['bar', 'line']);
+        const spy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-chart-toggle-' + gridId ? row : null
+        );
+        waReq.syncChartToggleActive(gridId, 'bar');
+        waReq.syncChartToggleActive(gridId, 'bar');
+        const barBtn = row.querySelector('[data-chart-type="bar"]');
+        const classes = barBtn.className.split(/\s+/);
+        const count = classes.filter(c => c === 'layui-btn-primary').length;
+        expect(count).toBe(1);
+        spy.mockRestore();
+    });
+
+    test('renderChart persists chartType in state and calls syncChartToggleActive', () => {
+        const gridId = 'sync618f';
+        const row = makeToggleRow(gridId, ['bar', 'line', 'pie', 'scatter', 'card']);
+        const container = document.createElement('div');
+        const mockEcharts = {
+            init: jest.fn(() => ({ setOption: jest.fn(), resize: jest.fn(), on: jest.fn() })),
+            getInstanceByDom: jest.fn(() => null),
+        };
+        const spy = jest.spyOn(document, 'getElementById').mockImplementation(id =>
+            id === 'analysis-chart-toggle-' + gridId ? row : null
+        );
+        const origEcharts = global.window.echarts;
+        global.window.echarts = mockEcharts;
+        // Single dim (non-date) + single measure → detectChartType returns 'bar'
+        const result = { rows: [{ Region: 'East', Amount_Sum: 100 }] };
+        const req = { dimensions: ['Region'], measures: [{ field: 'Amount', func: 'Sum' }] };
+        const dimFields = [{ fieldName: 'Region', isDate: false }];
+        waReq.renderChart(gridId, result, req, dimFields, container);
+        const barBtn = row.querySelector('[data-chart-type="bar"]');
+        expect(barBtn.className).toContain('layui-btn-primary');
+        global.window.echarts = origEcharts;
+        spy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary

- Add `scatter` to the chart toggle button list (was missing from the original 5 types)
- Add `data-chart-type` attribute to each toggle button for reliable DOM selection
- Add `syncChartToggleActive(gridId, chartType)` — highlights active button with `layui-btn-primary`, clears others; called automatically from `renderChart` so auto-detect result is highlighted on first render and manual clicks stay in sync
- Auto-detect remains the default (backward-compatible); user click overrides it

## Test plan

- [x] 7 new Jest tests: active highlight, deactivation of other buttons, scatter type, no-match type, missing DOM row (no throw), duplicate-call idempotency, `renderChart` integration
- [x] Full suite: **477/477 passed**
- [x] No regressions

Closes #618