### PR TITLE
feat(dashboard): add frontend management UI views (#528)

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Views/_DashboardPage/Index.cshtml
+++ b/src/WalkingTec.Mvvm.Mvc/Views/_DashboardPage/Index.cshtml
@@ -1,0 +1,222 @@
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <title>Dashboard 管理</title>
+    <link rel="stylesheet" href="/layui/css/layui.css">
+    <link rel="stylesheet" href="/sitecss/wtm.css">
+    <link rel="stylesheet" href="/_js/framework_dashboard.css">
+    <style>
+        body { background: #f2f2f2; padding: 16px; }
+        .wtm-db-cards { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 16px; }
+        .wtm-db-card {
+            background: #fff; border-radius: 4px; border: 1px solid #e6e6e6;
+            padding: 16px; width: 280px; box-shadow: 0 1px 4px rgba(0,0,0,.06);
+        }
+        .wtm-db-card-title { font-size: 16px; font-weight: 600; margin-bottom: 8px; color: #333; }
+        .wtm-db-card-meta { font-size: 12px; color: #999; margin-bottom: 12px; }
+        .wtm-db-card-actions { display: flex; gap: 8px; }
+        .wtm-db-empty { color: #aaa; padding: 40px; text-align: center; }
+    </style>
+</head>
+<body>
+    <div class="layui-layout-body">
+        <div class="layui-card">
+            <div class="layui-card-header" style="display:flex;align-items:center;justify-content:space-between;">
+                <span style="font-size:16px;font-weight:600;">Dashboard 管理</span>
+                <button class="layui-btn layui-btn-sm" id="btn-create">
+                    <i class="layui-icon layui-icon-add-1"></i> 新增 Dashboard
+                </button>
+            </div>
+            <div class="layui-card-body">
+                <div id="dashboard-list-container">
+                    <div class="wtm-db-empty">載入中…</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Create form (hidden template) -->
+    <div id="create-form-tpl" style="display:none;">
+        <form class="layui-form" id="create-form" style="padding:16px 24px;">
+            <div class="layui-form-item">
+                <label class="layui-form-label">標題</label>
+                <div class="layui-input-block">
+                    <input type="text" id="new-title" name="title" required lay-verify="required"
+                           placeholder="請輸入 Dashboard 標題" class="layui-input">
+                </div>
+            </div>
+            <div class="layui-form-item">
+                <label class="layui-form-label">自動刷新（秒）</label>
+                <div class="layui-input-block">
+                    <input type="number" id="new-refresh" name="refreshInterval" value="60" min="0" class="layui-input">
+                </div>
+            </div>
+            <div class="layui-form-item">
+                <label class="layui-form-label">分享模式</label>
+                <div class="layui-input-block">
+                    <select id="new-sharing" name="sharingMode">
+                        <option value="private">私人</option>
+                        <option value="public">公開</option>
+                        <option value="roles">角色限定</option>
+                    </select>
+                </div>
+            </div>
+            <div class="layui-form-item" style="text-align:right;">
+                <button type="button" class="layui-btn" id="btn-create-submit">建立</button>
+                <button type="button" class="layui-btn layui-btn-primary" id="btn-create-cancel">取消</button>
+            </div>
+        </form>
+    </div>
+
+    <script src="/jquery.min.js"></script>
+    <script src="/layui/layui.js"></script>
+    <script src="/_js/framework_dashboard.js"></script>
+    <script>
+    (function () {
+        "use strict";
+
+        // ── DOM helpers ────────────────────────────────────────────────────
+        function el(tag, cls, text) {
+            var node = document.createElement(tag);
+            if (cls) node.className = cls;
+            if (text != null) node.textContent = text;
+            return node;
+        }
+
+        function btn(label, cls, clickFn) {
+            var b = el('button', 'layui-btn layui-btn-sm ' + (cls || ''), label);
+            b.addEventListener('click', clickFn);
+            return b;
+        }
+
+        // ── Load & render list ─────────────────────────────────────────────
+        function loadList() {
+            var container = document.getElementById('dashboard-list-container');
+            container.textContent = '載入中…';
+
+            fetch('/_dashboard/list')
+                .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+                .then(function (items) { renderList(container, items); })
+                .catch(function () {
+                    container.textContent = '載入失敗，請重新整理頁面。';
+                });
+        }
+
+        function renderList(container, items) {
+            container.textContent = '';
+
+            if (!items || items.length === 0) {
+                var empty = el('div', 'wtm-db-empty', '尚無 Dashboard，請點擊「新增 Dashboard」建立第一個。');
+                container.appendChild(empty);
+                return;
+            }
+
+            var cards = el('div', 'wtm-db-cards');
+            items.forEach(function (item) {
+                var sharingLabel = item.sharing && item.sharing.mode === 'public' ? '公開'
+                    : item.sharing && item.sharing.mode === 'roles' ? '角色限定'
+                    : '私人';
+
+                var card   = el('div', 'wtm-db-card');
+                var title  = el('div', 'wtm-db-card-title', item.title || '(無標題)');
+                var meta   = el('div', 'wtm-db-card-meta');
+                meta.textContent = '擁有者：' + (item.owner || '') + '　分享：' + sharingLabel;
+
+                var actions = el('div', 'wtm-db-card-actions');
+                actions.appendChild(btn('預覽', '', function () {
+                    window.location.href = '/_DashboardPage/Render?id=' + encodeURIComponent(item.id);
+                }));
+                actions.appendChild(btn('編輯', 'layui-btn-normal', function () {
+                    window.location.href = '/_DashboardPage/Render?id=' + encodeURIComponent(item.id) + '&edit=1';
+                }));
+                actions.appendChild(btn('刪除', 'layui-btn-danger', function () {
+                    confirmDelete(item.id, item.title || '');
+                }));
+
+                card.appendChild(title);
+                card.appendChild(meta);
+                card.appendChild(actions);
+                cards.appendChild(card);
+            });
+
+            container.appendChild(cards);
+        }
+
+        // ── Delete ─────────────────────────────────────────────────────────
+        function confirmDelete(id, title) {
+            layui.layer.confirm('確定刪除「' + title + '」？此操作不可復原。',
+                { btn: ['刪除', '取消'] },
+                function () {
+                    layui.layer.closeAll();
+                    fetch('/_dashboard/' + encodeURIComponent(id), { method: 'DELETE' })
+                        .then(function (r) {
+                            if (!r.ok) throw new Error(r.status);
+                            layui.layer.msg('已刪除');
+                            loadList();
+                        })
+                        .catch(function () { layui.layer.msg('刪除失敗'); });
+                });
+        }
+
+        // ── Create dialog ──────────────────────────────────────────────────
+        var _createLayerId = null;
+
+        document.getElementById('btn-create').addEventListener('click', function () {
+            _createLayerId = layui.layer.open({
+                type: 1,
+                title: '新增 Dashboard',
+                area: ['480px', 'auto'],
+                content: document.getElementById('create-form-tpl'),
+                end: function () { document.getElementById('create-form-tpl').style.display = 'none'; }
+            });
+            document.getElementById('create-form-tpl').style.display = '';
+            layui.form.render();
+        });
+
+        document.getElementById('btn-create-cancel').addEventListener('click', function () {
+            if (_createLayerId) layui.layer.close(_createLayerId);
+        });
+
+        document.getElementById('btn-create-submit').addEventListener('click', function () {
+            var title    = document.getElementById('new-title').value.trim();
+            var refresh  = parseInt(document.getElementById('new-refresh').value, 10);
+            var sharing  = document.getElementById('new-sharing').value;
+
+            if (!title) { layui.layer.msg('請輸入標題'); return; }
+
+            var body = {
+                id: '',
+                title: title,
+                refreshInterval: isNaN(refresh) ? 60 : refresh,
+                sharing: { mode: sharing },
+                layout: [],
+                widgets: {}
+            };
+
+            fetch('/_dashboard/', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body)
+            }).then(function (r) {
+                return r.ok ? r.json() : r.text().then(function (t) { throw new Error(t); });
+            }).then(function (newId) {
+                if (_createLayerId) layui.layer.close(_createLayerId);
+                layui.layer.msg('建立成功，即將前往編輯頁', { time: 1500 });
+                setTimeout(function () {
+                    window.location.href = '/_DashboardPage/Render?id=' + encodeURIComponent(newId) + '&edit=1';
+                }, 1500);
+            }).catch(function (e) {
+                layui.layer.msg('建立失敗：' + e.message);
+            });
+        });
+
+        loadList();
+    }());
+    </script>
+</body>
+</html>

--- a/src/WalkingTec.Mvvm.Mvc/Views/_DashboardPage/Render.cshtml
+++ b/src/WalkingTec.Mvvm.Mvc/Views/_DashboardPage/Render.cshtml
@@ -1,0 +1,229 @@
+@{
+    Layout = null;
+    var dashboardId = ViewBag.DashboardId as string ?? "";
+}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <title>Dashboard</title>
+    <link rel="stylesheet" href="/layui/css/layui.css">
+    <link rel="stylesheet" href="/sitecss/wtm.css">
+    <link rel="stylesheet" href="/_js/lib/gridstack/gridstack.min.css">
+    <link rel="stylesheet" href="/_js/framework_dashboard.css">
+    <style>
+        body { background: #f2f2f2; margin: 0; }
+        #wtm-db-toolbar {
+            display: flex; align-items: center; gap: 8px;
+            padding: 8px 16px; background: #fff;
+            border-bottom: 1px solid #e6e6e6;
+        }
+        #wtm-db-toolbar .toolbar-title {
+            font-size: 16px; font-weight: 600; margin-right: auto; color: #333;
+        }
+        #wtm-db-content { padding: 16px; }
+        #wtm-dashboard-grid { min-height: 200px; }
+        #wtm-db-loading { padding: 40px; text-align: center; color: #aaa; }
+    </style>
+</head>
+<body>
+    <div id="wtm-db-toolbar">
+        <span class="toolbar-title" id="db-title">載入中…</span>
+        <button class="layui-btn layui-btn-sm layui-btn-primary" id="btn-back">← 返回列表</button>
+        <button class="layui-btn layui-btn-sm layui-btn-normal" id="btn-edit" style="display:none;">編輯佈局</button>
+        <button class="layui-btn layui-btn-sm" id="btn-add-widget" style="display:none;">+ 新增元件</button>
+        <button class="layui-btn layui-btn-sm" id="btn-save" style="display:none;">儲存</button>
+        <button class="layui-btn layui-btn-sm layui-btn-primary" id="btn-cancel-edit" style="display:none;">取消</button>
+        <button class="layui-btn layui-btn-sm layui-btn-danger" id="btn-delete" style="display:none;">刪除 Dashboard</button>
+    </div>
+
+    <div id="wtm-db-content">
+        <div id="wtm-db-loading">載入中…</div>
+        <div id="wtm-dashboard-grid" style="display:none;"></div>
+    </div>
+
+    <!-- Add widget dialog template (hidden) -->
+    <div id="add-widget-tpl" style="display:none;">
+        <form style="padding:16px 24px;">
+            <div class="layui-form-item">
+                <label class="layui-form-label">元件標題</label>
+                <div class="layui-input-block">
+                    <input type="text" id="new-widget-title" placeholder="請輸入元件標題" class="layui-input">
+                </div>
+            </div>
+            <div class="layui-form-item">
+                <label class="layui-form-label">元件類型</label>
+                <div class="layui-input-block">
+                    <select id="new-widget-type">
+                        <option value="kpi">KPI 指標</option>
+                        <option value="chart">圖表</option>
+                        <option value="table">表格</option>
+                        <option value="progress">進度條</option>
+                        <option value="list">清單</option>
+                    </select>
+                </div>
+            </div>
+            <div class="layui-form-item">
+                <label class="layui-form-label">資料來源</label>
+                <div class="layui-input-block">
+                    <select id="new-widget-source">
+                        <option value="">（選填）</option>
+                    </select>
+                </div>
+            </div>
+            <div class="layui-form-item" style="text-align:right;">
+                <button type="button" class="layui-btn" id="btn-widget-confirm">新增</button>
+                <button type="button" class="layui-btn layui-btn-primary" id="btn-widget-cancel">取消</button>
+            </div>
+        </form>
+    </div>
+
+    <script src="/jquery.min.js"></script>
+    <script src="/layui/layui.js"></script>
+    <script src="/_js/lib/gridstack/gridstack-all.min.js"></script>
+    <script src="/_js/framework_dashboard.js"></script>
+    <script>
+    (function () {
+        "use strict";
+
+        var DASHBOARD_ID = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(dashboardId));
+        var _editMode = false;
+        var _addWidgetLayerId = null;
+
+        // Auto-enter edit mode if ?edit=1
+        var _autoEdit = (window.location.search || '').indexOf('edit=1') >= 0;
+
+        function getEl(id) { return document.getElementById(id); }
+
+        // ── Init dashboard ─────────────────────────────────────────────────
+        WtmDashboard.DashboardManager.init('wtm-dashboard-grid', DASHBOARD_ID)
+            .then(function (def) {
+                if (!def) { showError('Dashboard 不存在或無法存取。'); return; }
+                getEl('db-title').textContent = def.title || '(無標題)';
+                getEl('wtm-db-loading').style.display = 'none';
+                getEl('wtm-dashboard-grid').style.display = '';
+                getEl('btn-edit').style.display = '';
+                getEl('btn-delete').style.display = '';
+                if (_autoEdit) enterEditMode();
+            })
+            .catch(function () { showError('載入 Dashboard 失敗，請確認您有存取權限。'); });
+
+        function showError(msg) {
+            getEl('wtm-db-loading').textContent = msg;
+        }
+
+        // ── Back ───────────────────────────────────────────────────────────
+        getEl('btn-back').addEventListener('click', function () {
+            window.location.href = '/_DashboardPage/Index';
+        });
+
+        // ── Edit mode ──────────────────────────────────────────────────────
+        getEl('btn-edit').addEventListener('click', enterEditMode);
+
+        function enterEditMode() {
+            _editMode = true;
+            WtmDashboard.DashboardEditor.toggleEditMode();
+            getEl('btn-edit').style.display = 'none';
+            getEl('btn-add-widget').style.display = '';
+            getEl('btn-save').style.display = '';
+            getEl('btn-cancel-edit').style.display = '';
+        }
+
+        getEl('btn-cancel-edit').addEventListener('click', function () {
+            _editMode = false;
+            WtmDashboard.DashboardEditor.toggleEditMode();
+            getEl('btn-edit').style.display = '';
+            getEl('btn-add-widget').style.display = 'none';
+            getEl('btn-save').style.display = 'none';
+            getEl('btn-cancel-edit').style.display = 'none';
+            // Reload to discard unsaved changes
+            window.location.reload();
+        });
+
+        // ── Save ───────────────────────────────────────────────────────────
+        getEl('btn-save').addEventListener('click', function () {
+            WtmDashboard.DashboardEditor.saveDashboard()
+                .then(function () {
+                    layui.layer.msg('已儲存');
+                    _editMode = false;
+                    getEl('btn-edit').style.display = '';
+                    getEl('btn-add-widget').style.display = 'none';
+                    getEl('btn-save').style.display = 'none';
+                    getEl('btn-cancel-edit').style.display = 'none';
+                })
+                .catch(function () { layui.layer.msg('儲存失敗，請稍後再試'); });
+        });
+
+        // ── Delete ─────────────────────────────────────────────────────────
+        getEl('btn-delete').addEventListener('click', function () {
+            var title = getEl('db-title').textContent;
+            layui.layer.confirm('確定刪除「' + title + '」？此操作不可復原。',
+                { btn: ['刪除', '取消'] },
+                function () {
+                    layui.layer.closeAll();
+                    WtmDashboard.DashboardEditor.deleteDashboard()
+                        .then(function () {
+                            layui.layer.msg('已刪除', { time: 1200 });
+                            setTimeout(function () {
+                                window.location.href = '/_DashboardPage/Index';
+                            }, 1200);
+                        })
+                        .catch(function () { layui.layer.msg('刪除失敗'); });
+                });
+        });
+
+        // ── Add widget ─────────────────────────────────────────────────────
+        getEl('btn-add-widget').addEventListener('click', function () {
+            // Load data sources
+            fetch('/_dashboard/datasources')
+                .then(function (r) { return r.ok ? r.json() : []; })
+                .then(function (sources) {
+                    var sel = getEl('new-widget-source');
+                    // Clear and repopulate
+                    while (sel.options.length > 1) sel.remove(1);
+                    (sources || []).forEach(function (s) {
+                        var opt = document.createElement('option');
+                        opt.value = s.name;
+                        opt.textContent = s.name + ' (' + (s.kind || '') + ')';
+                        sel.appendChild(opt);
+                    });
+                    layui.form.render('select');
+                })
+                .catch(function () { /* non-critical, proceed without sources */ });
+
+            _addWidgetLayerId = layui.layer.open({
+                type: 1,
+                title: '新增 Dashboard 元件',
+                area: ['420px', 'auto'],
+                content: getEl('add-widget-tpl'),
+                end: function () { getEl('add-widget-tpl').style.display = 'none'; }
+            });
+            getEl('add-widget-tpl').style.display = '';
+            layui.form.render();
+        });
+
+        getEl('btn-widget-cancel').addEventListener('click', function () {
+            if (_addWidgetLayerId) layui.layer.close(_addWidgetLayerId);
+        });
+
+        getEl('btn-widget-confirm').addEventListener('click', function () {
+            var title  = getEl('new-widget-title').value.trim() || '新元件';
+            var type   = getEl('new-widget-type').value || 'kpi';
+            var source = getEl('new-widget-source').value;
+
+            var widgetId = 'w_' + Date.now();
+            var widgetDef = { type: type, title: title };
+            if (source) widgetDef.dataSource = source;
+
+            WtmDashboard.DashboardEditor.addWidget(widgetId, widgetDef, {
+                id: widgetId, w: 4, h: 3
+            });
+
+            if (_addWidgetLayerId) layui.layer.close(_addWidgetLayerId);
+        });
+
+    }());
+    </script>
+</body>
+</html>

--- a/src/WalkingTec.Mvvm.Mvc/_DashboardPageController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_DashboardPageController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Mvc
+{
+    [AllRights]
+    [ActionDescription("Dashboard")]
+    public class _DashboardPageController : BaseController
+    {
+        [ActionDescription("Dashboard管理")]
+        public IActionResult Index() => View();
+
+        [ActionDescription("Dashboard預覽")]
+        public IActionResult Render(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                return BadRequest("Dashboard ID is required.");
+            ViewBag.DashboardId = id;
+            return View();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a complete Dashboard management UI to the WTM framework. Previously the Dashboard module only had a REST API (`/_dashboard/`) with no way for users to navigate to dashboards via the browser.

### New files

| File | Purpose |
|------|---------|
| `_DashboardPageController.cs` | MVC controller (`BaseController`, no `[ApiController]`) serving two view actions |
| `Views/_DashboardPage/Index.cshtml` | Dashboard list management page |
| `Views/_DashboardPage/Render.cshtml` | Dashboard view/edit page |

### Index page (`/_DashboardPage/Index`)
- Loads user's dashboards via `GET /_dashboard/list` and renders as card grid
- **Create**: inline LayUI dialog with Title, RefreshInterval, Sharing mode → `POST /_dashboard/`; redirects to Render in edit mode on success
- **View**: navigates to `/_DashboardPage/Render?id={id}`
- **Edit**: navigates to Render with `?edit=1` (auto-enters edit mode)
- **Delete**: LayUI confirm dialog → `DELETE /_dashboard/{id}`
- All user-provided content inserted via `textContent` / DOM APIs (no `innerHTML` with API data)

### Render page (`/_DashboardPage/Render?id={id}`)
- Loads gridstack CSS/JS and framework_dashboard CSS/JS from `/_js/` embedded resources
- Initialises `WtmDashboard.DashboardManager.init('wtm-dashboard-grid', id)` — all widget rendering done by existing `framework_dashboard.js`
- **Edit mode** toggle (`DashboardEditor.toggleEditMode()`) — enables GridStack drag-and-drop
- **Add Widget** dialog: widget title, type (kpi/chart/table/progress/list), data source (loaded from `/_dashboard/datasources`)
- **Save** (`DashboardEditor.saveDashboard()` → `PUT /_dashboard/{id}`)
- **Delete** (`DashboardEditor.deleteDashboard()` → `DELETE /_dashboard/{id}`)
- `?edit=1` query param auto-enters edit mode (used by Index "Edit" button)
- Dashboard ID injected via `JsonSerializer.Serialize()` to prevent XSS

### Security
- `dashboardId` injected via `JsonSerializer.Serialize()` — prevents quote-injection
- User-provided content (titles, owner names) set via `textContent` only

### Notes
- Chart widgets require echarts to be loaded in the host application layout (e.g. demo's `_Layout.cshtml`). Without echarts, chart widgets show a graceful error; all other widget types (KPI, table, list, progress, embed) render normally.
- Views are standalone full-page (`Layout = null`) following the `_CodeGen` pattern — can be linked from the application menu system.

## Test plan

- [ ] `/_DashboardPage/Index` renders dashboard list; Create dialog creates and redirects
- [ ] `/_DashboardPage/Render?id={id}` renders dashboard widgets
- [ ] Edit mode enables GridStack drag; Save persists layout via PUT
- [ ] Delete from Render page redirects back to Index
- [ ] Build: 0 errors ✅
- [ ] Tests: 1,347 passed, 0 failures ✅

Closes #528