### PR TITLE
feat(analysis): sort, pagination, sticky header for query result table (#539)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,6 +21,8 @@ jobs:
     - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
+    - name: Install Blazor WASM workload
+      run: dotnet workload install wasm-tools
     - run: dotnet restore WalkingTec.Mvvm.sln
     - run: dotnet build WalkingTec.Mvvm.sln --no-restore -c Release
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         dotnet-version: '8.0.x'
     - name: Install Blazor WASM workload
-      run: dotnet workload install wasm-tools
+      run: sudo dotnet workload install wasm-tools
     - run: dotnet restore WalkingTec.Mvvm.sln
     - run: dotnet build WalkingTec.Mvvm.sln --no-restore -c Release
 

--- a/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.ViewModel/FrameworkUserVms/FrameworkUserImportVM.cs
+++ b/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.ViewModel/FrameworkUserVms/FrameworkUserImportVM.cs
@@ -23,7 +23,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.ViewModels.FrameworkUserVms
 
     public class FrameworkUserImportVM : BaseImportVM<FrameworkUserTemplateVM, FrameworkUser>
     {
-        public override bool BatchSaveData()
+        public override bool BatchSaveData(System.IProgress<WalkingTec.Mvvm.Core.ImportProgress>? progress = null)
         {
             SetEntityList();
             foreach (var item in EntityList)

--- a/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/ViewModels/FrameworkUserVms/FrameworkUserImportVM.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/ViewModels/FrameworkUserVms/FrameworkUserImportVM.cs
@@ -23,7 +23,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.ViewModels.FrameworkUserVms
 
     public class FrameworkUserImportVM : BaseImportVM<FrameworkUserTemplateVM, FrameworkUser>
     {
-        public override bool BatchSaveData()
+        public override bool BatchSaveData(System.IProgress<WalkingTec.Mvvm.Core.ImportProgress>? progress = null)
         {
             SetEntityList();
             foreach (var item in EntityList)

--- a/demo/WalkingTec.Mvvm.ReactDemo/Areas/_Admin/ViewModels/FrameworkUserVms/FrameworkUserImportVM.cs
+++ b/demo/WalkingTec.Mvvm.ReactDemo/Areas/_Admin/ViewModels/FrameworkUserVms/FrameworkUserImportVM.cs
@@ -23,7 +23,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.ViewModels.FrameworkUserVms
 
     public class FrameworkUserImportVM : BaseImportVM<FrameworkUserTemplateVM, FrameworkUser>
     {
-        public override bool BatchSaveData()
+        public override bool BatchSaveData(System.IProgress<WalkingTec.Mvvm.Core.ImportProgress>? progress = null)
         {
             SetEntityList();
             foreach (var item in EntityList)

--- a/demo/WalkingTec.Mvvm.Vue3Demo/Areas/_Admin/ViewModels/FrameworkUserVms/FrameworkUserImportVM.cs
+++ b/demo/WalkingTec.Mvvm.Vue3Demo/Areas/_Admin/ViewModels/FrameworkUserVms/FrameworkUserImportVM.cs
@@ -23,7 +23,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.ViewModels.FrameworkUserVms
 
     public class FrameworkUserImportVM : BaseImportVM<FrameworkUserTemplateVM, FrameworkUser>
     {
-        public override bool BatchSaveData()
+        public override bool BatchSaveData(System.IProgress<WalkingTec.Mvvm.Core.ImportProgress>? progress = null)
         {
             SetEntityList();
             foreach (var item in EntityList)

--- a/demo/WalkingTec.Mvvm.VueDemo/Areas/_Admin/ViewModels/FrameworkUserVms/FrameworkUserImportVM.cs
+++ b/demo/WalkingTec.Mvvm.VueDemo/Areas/_Admin/ViewModels/FrameworkUserVms/FrameworkUserImportVM.cs
@@ -23,7 +23,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.ViewModels.FrameworkUserVms
 
     public class FrameworkUserImportVM : BaseImportVM<FrameworkUserTemplateVM, FrameworkUser>
     {
-        public override bool BatchSaveData()
+        public override bool BatchSaveData(System.IProgress<WalkingTec.Mvvm.Core.ImportProgress>? progress = null)
         {
             SetEntityList();
             foreach (var item in EntityList)

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestFeature"
+  }
+}

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_analysis.test.js
@@ -5331,7 +5331,6 @@ describe('#539 renderTable — sort, pagination, sticky wrapper', () => {
         expect(container.querySelector('tbody td').textContent).toBe('0');
     });
 });
-
 // ─── #566 createValueInput — date field relative date mode ───────────────────
 describe('#566 createValueInput — date field relative date mode', () => {
     const dateMeta = {


### PR DESCRIPTION
## Summary

- **Sticky header**: wraps `<table>` in `.analysis-table-wrap` div; CSS provides `position: sticky` on `<thead>` headers with `max-height: 420px / overflow-y: auto`
- **Client-side sorting**: click any column header to cycle asc → desc → original order; sort indicator rendered via CSS `::after` (so `th.textContent` is unchanged — all 15+ existing header-text tests continue to pass)
- **Pagination**: 50 rows per page; prev/next buttons + page-info span; only rendered when row count exceeds page size; sort resets to page 1
- **% share columns** remain non-sortable (cosmetic/derived)

## Implementation notes

- `th.dataset.sortDir` carries the current sort direction (`''` / `'asc'` / `'desc'`); CSS `[data-sort-dir="asc"]::after` provides the ▲/▼ indicator without touching `textContent`
- Original rows array is never mutated — sort operates on a sliced copy
- All existing DOM-structure tests still pass (29 new tests added, 344 total)

## Test plan

- [x] `npm test` in `test/WalkingTec.Mvvm.Js.Tests` — 344 tests pass
- [x] All existing `renderTable` tests unmodified and green
- [x] New sort tests: asc, desc, reset, multi-column reset, string sort, immutability
- [x] New pagination tests: no-div ≤50 rows, div >50, page info text, next page, prev-disabled, sort-resets-to-page-1

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)