### PR TITLE
feat!: upgrade to .NET 10 (LTS) — version 10.0.0

### DIFF
--- a/.claude/rules/dependency-management.md
+++ b/.claude/rules/dependency-management.md
@@ -8,8 +8,8 @@
 
 ## .NET Version Strategy
 
-- Current target: **.NET 8** (LTS)
-- Upgrade to next LTS (.NET 10) only after it reaches GA and ecosystem stabilizes
+- Current target: **.NET 10** (LTS)
+- Upgrade to next LTS only after it reaches GA and ecosystem stabilizes
 - Multi-target only if there is a concrete user need
 
 ## Package Versioning

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,9 +2,9 @@ name: WTM Build and Test
 on:
   workflow_dispatch:
   push:
-    branches: [ dotnet8, "feature/**", "feat/**" ]
+    branches: [ dotnet8, dotnet10, "feature/**", "feat/**" ]
   pull_request:
-    branches: [ dotnet8 ]
+    branches: [ dotnet8, dotnet10 ]
 jobs:
   release-tooling-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
     - run: dotnet restore ci.slnf
     - run: dotnet build ci.slnf --no-restore -c Release
 
@@ -101,6 +101,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
     - run: dotnet restore WalkingTec.Mvvm.sln
     - run: dotnet list WalkingTec.Mvvm.sln package --vulnerable --include-transitive

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Determine package version
         id: version
@@ -104,7 +104,7 @@ jobs:
           set -euo pipefail
           mkdir smoke
           cd smoke
-          dotnet new console --framework net8.0
+          dotnet new console --framework net10.0
           dotnet add package WalkingTec.Mvvm.Core --version "$PKG_VERSION" --source "${{ env.PACKAGE_SOURCE }}"
           dotnet add package WalkingTec.Mvvm.Mvc --version "$PKG_VERSION" --source "${{ env.PACKAGE_SOURCE }}"
           dotnet add package WalkingTec.Mvvm.TagHelpers.LayUI --version "$PKG_VERSION" --source "${{ env.PACKAGE_SOURCE }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # wtm custom
 .worktrees/
+.claude/worktrees/
 
 demo/WalkingTec.Mvvm.Demo/wwwroot/layuiadminsrc
 .Publish/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@
 - **BaseImportVM — 行內錯誤清單**：新增 `InlineErrors` 屬性（最多 `InlineErrorLimit` 筆，預設 50）供 API 端點直接回傳驗證錯誤（#615）。
 - **BaseTemplateVM — 欄位說明列**：`ShowDescriptionRow = true`（預設）時，於模板第二行插入淺綠色斜體說明列，標示 Required/Optional、資料類型、min/max 限制；匯入時自動識別並跳過說明列（v2 標記）（#615）。
 
+### Fixed
+- **Test suite — EF Core 10 API**：`DataContext` 中 `modelBuilder.Model.SetMaxIdentifierLength(30)` 改為 `modelBuilder.HasMaxIdentifierLength(30)`，修正 EF Core 10 將內部 API 設為不可存取的問題（#676）。
+- **Test suite — MSTest / Test.Sdk 版本**：`MSTest.TestAdapter` / `MSTest.TestFramework` 從 3.2.2 升至 3.6.4；`Microsoft.NET.Test.Sdk` 從 17.9.0 升至 17.12.0，確保與 .NET 10 測試主機相容（#676）。
+- **Test suite — coverlet / xunit runner**：`coverlet.collector` 從 6.0.2 升至 6.0.4；`xunit.runner.visualstudio` 從 2.8.2 升至 2.8.3，修正與 Test.Sdk 17.12.0 的相容性（#676）。
+- **Test suite — Serilog Sinks**：`Serilog.Sinks.InMemory` 從 0.11.0 升至 1.0.0，解決與 `Serilog.AspNetCore 10.0.0`（使用 Serilog 4.x）的型別衝突（#676）。
+
 ### Deprecated
 - **Workflow API**：內建 Elsa workflow 整合（`IWorkflow`、`FrameworkWorkflow`、`ApproveTimeLine`、`ApproveInfo`、`FlowInfoTagHelper`、`IBaseCRUDVM` 工作流程方法、`DataContext.FrameworkWorkflows`）標記為 `[Obsolete]`，將於下一個主版本移除（#586）。
   - **遷移指引**：若仍需工作流程功能，請直接引用 Elsa 或改用其他工作流程引擎；移除 `IWorkflow` 介面實作及相關 TagHelper。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## [Unreleased]
 
+## [10.0.0] - 2026-03-20
+
+### Changed
+- **BREAKING: .NET 10 升級** — 所有專案目標框架從 `net8.0` 升級至 `net10.0`（.NET 10 LTS）
+- **BREAKING: 版本號跟隨 .NET 版本** — `VersionPrefix` 從 `8.6.1` 升至 `10.0.0`
+- **BREAKING: MySQL Provider 替換** — 從 `Pomelo.EntityFrameworkCore.MySql` 改為官方 `MySql.EntityFrameworkCore` 10.0.1
+  - `UseMySql()` → `UseMySQL()`（大寫 SQL）
+  - 不再需要 `ServerVersion` 參數
+  - `MySqlSchemaBehavior` 不再可用
+  - `MySqlConnector` namespace → `MySql.Data.MySqlClient`
+- **BREAKING: API Versioning 套件替換** — `Microsoft.AspNetCore.Mvc.Versioning` → `Asp.Versioning.Mvc` 8.1.1
+  - `AddVersionedApiExplorer()` → `AddApiVersioning().AddApiExplorer()`
+  - 新增 `using Asp.Versioning;` namespace
+- **EF Core 10** — 全部 EF Core 套件升至 10.0.3
+- **ASP.NET Core 10** — 全部 ASP.NET Core 套件升至 10.0.3
+- **Swashbuckle 10** — 從 6.6.2 升至 10.1.5（依賴 OpenAPI.NET v2）
+- **Serilog 10** — `Serilog.AspNetCore` 從 8.0.3 升至 10.0.0
+- **Npgsql 10** — `Npgsql.EntityFrameworkCore.PostgreSQL` 從 8.0.11 升至 10.0.1
+- **Oracle EF Core 10** — `Oracle.EntityFrameworkCore` 從 8.23.70 升至 10.23.60
+- **SDK** — `global.json` 升至 .NET SDK 10.0.0
+- **Dockerfile** — 基底映像從 .NET 3.1 更新至 .NET 10
+- **CI** — GitHub Actions 的 `dotnet-version` 從 `8.0.x` 更新至 `10.0.x`
+- 修正遺留 demo 測試專案：`net5.0`/`net6.0` → `net10.0`
+
+### Migration Guide
+1. 將您的專案 `TargetFramework` 從 `net8.0` 改為 `net10.0`
+2. 安裝 .NET 10 SDK
+3. 若使用 MySQL：將 `Pomelo.EntityFrameworkCore.MySql` 替換為 `MySql.EntityFrameworkCore`
+   - `using MySqlConnector;` → `using MySql.Data.MySqlClient;`
+   - `optionsBuilder.UseMySql(cs, serverVersion, ...)` → `optionsBuilder.UseMySQL(cs)`
+4. 若使用 API Versioning：更新套件引用及 namespace
+   - `Microsoft.AspNetCore.Mvc.Versioning` → `Asp.Versioning.Mvc`
+5. 更新所有 Microsoft.EntityFrameworkCore.* 套件至 10.0.x
+6. 更新所有 Microsoft.AspNetCore.* 套件至 10.0.x
+
 ### Added
 - **BaseCRUDVM — 批量刪除預覽**：新增 `GetDeletePreviewString()` 虛擬方法，回傳實體的人類可讀標籤（依序搜尋 Name/Title/Code/ITCode 等屬性，否則回退至主鍵）；同時新增 `IBaseCRUDVM<T>.GetDeletePreviewString()` 介面成員（#619）。
 - **`_FrameworkController` — 批量刪除預覽端點**：POST `/_Framework/GetDeletePreview` — 接受 vmType 名稱與最多 10 個 ID，回傳 `[{id, label}]` 陣列供前端確認對話框使用（#619）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ dotnet list WalkingTec.Mvvm.sln package --vulnerable --include-transitive
 
 ## Architecture (quick ref)
 
-WTM is an ASP.NET Core 8 framework. Four VM types: `BaseCRUDVM<T>`, `BasePagedListVM<T,S>`, `BaseImportVM<T>`, `BaseBatchVM<T>` — all extend `BaseVM` with `WTMContext Wtm`.
+WTM is an ASP.NET Core 10 framework. Four VM types: `BaseCRUDVM<T>`, `BasePagedListVM<T,S>`, `BaseImportVM<T>`, `BaseBatchVM<T>` — all extend `BaseVM` with `WTMContext Wtm`.
 
 | Project | Role |
 |---------|------|

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /app
 
 COPY . .
 RUN dotnet publish "./demo/WalkingTec.Mvvm.Demo/WalkingTec.Mvvm.Demo.csproj" -c Release -o /app/out
 
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 
-# install libgdiplus for System.Drawing
-RUN apt-get update && \
-    apt-get install -y --allow-unauthenticated libgdiplus libc6-dev
-
-ENV ASPNETCORE_URLS http://+:80
-ENV ASPNETCORE_ENVIRONMENT Production
+ENV ASPNETCORE_URLS=http://+:80
+ENV ASPNETCORE_ENVIRONMENT=Production
 ENTRYPOINT ["dotnet", "WalkingTec.Mvvm.Demo.dll"]

--- a/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.Client/WalkingTec.Mvvm.BlazorDemo.Client.csproj
+++ b/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.Client/WalkingTec.Mvvm.BlazorDemo.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
   </PropertyGroup>
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.3" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.DataAccess/WalkingTec.Mvvm.BlazorDemo.DataAccess.csproj
+++ b/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.DataAccess/WalkingTec.Mvvm.BlazorDemo.DataAccess.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.Model/WalkingTec.Mvvm.BlazorDemo.Model.csproj
+++ b/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.Model/WalkingTec.Mvvm.BlazorDemo.Model.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.Shared/WalkingTec.Mvvm.BlazorDemo.Shared.csproj
+++ b/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.Shared/WalkingTec.Mvvm.BlazorDemo.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.Test/WalkingTec.Mvvm.BlazorDemo.Test.csproj
+++ b/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.Test/WalkingTec.Mvvm.BlazorDemo.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />

--- a/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.ViewModel/WalkingTec.Mvvm.BlazorDemo.ViewModel.csproj
+++ b/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.ViewModel/WalkingTec.Mvvm.BlazorDemo.ViewModel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.csproj
+++ b/demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UserSecretsId>dfda008d-8108-415d-8ee3-9b03ef1e77a9</UserSecretsId>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/WalkingTec.Mvvm.ConsoleDemo/WalkingTec.Mvvm.ConsoleDemo.csproj
+++ b/demo/WalkingTec.Mvvm.ConsoleDemo/WalkingTec.Mvvm.ConsoleDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/WalkingTec.Mvvm.Demo.Test/WalkingTec.Mvvm.Demo.Test.csproj
+++ b/demo/WalkingTec.Mvvm.Demo.Test/WalkingTec.Mvvm.Demo.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/demo/WalkingTec.Mvvm.Demo/WalkingTec.Mvvm.Demo.csproj
+++ b/demo/WalkingTec.Mvvm.Demo/WalkingTec.Mvvm.Demo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>WalkingTec.Mvvm</Description>
     <AssemblyName>WalkingTec.Mvvm.Demo</AssemblyName>
     <Title>$(AssemblyName)</Title>

--- a/demo/WalkingTec.Mvvm.ReactDemo/WalkingTec.Mvvm.ReactDemo.csproj
+++ b/demo/WalkingTec.Mvvm.ReactDemo/WalkingTec.Mvvm.ReactDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>WalkingTec.Mvvm</Description>
     <AssemblyName>WalkingTec.Mvvm.ReactDemo</AssemblyName>
     <Title>$(AssemblyName)</Title>

--- a/demo/WalkingTec.Mvvm.Vue3Demo/WalkingTec.Mvvm.Vue3Demo.csproj
+++ b/demo/WalkingTec.Mvvm.Vue3Demo/WalkingTec.Mvvm.Vue3Demo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>4.5</TypeScriptToolsVersion>

--- a/demo/WalkingTec.Mvvm.VueDemo/WalkingTec.Mvvm.VueDemo.csproj
+++ b/demo/WalkingTec.Mvvm.VueDemo/WalkingTec.Mvvm.VueDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>4.3</TypeScriptToolsVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.0",
     "rollForward": "latestFeature"
   }
 }

--- a/src/WalkingTec.Mvvm.Core/BasePagedListVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BasePagedListVM.cs
@@ -15,7 +15,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using MySqlConnector;
+using MySql.Data.MySqlClient;
 using Npgsql;
 using NpgsqlTypes;
 using NPOI.HSSF.Util;

--- a/src/WalkingTec.Mvvm.Core/DataContext.cs
+++ b/src/WalkingTec.Mvvm.Core/DataContext.cs
@@ -661,7 +661,7 @@ namespace WalkingTec.Mvvm.Core
         {
             if (DBType == DBTypeEnum.Oracle)
             {
-                modelBuilder.Model.SetMaxIdentifierLength(30);
+                modelBuilder.HasMaxIdentifierLength(30);
                 // [Elsa removed] table mappings
                 // modelBuilder.Entity<Elsa_Bookmark>().ToTable("Bookmarks");
                 // modelBuilder.Entity<Elsa_Trigger>().ToTable("Triggers");

--- a/src/WalkingTec.Mvvm.Core/DataContext.cs
+++ b/src/WalkingTec.Mvvm.Core/DataContext.cs
@@ -10,9 +10,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Logging.Debug;
 using Microsoft.Extensions.Options;
-using MySqlConnector;
+using MySql.Data.MySqlClient;
 using Npgsql;
-using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
+using MySql.EntityFrameworkCore.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -688,17 +688,7 @@ namespace WalkingTec.Mvvm.Core
                     optionsBuilder.UseSqlServer(CSName,o => o.UseCompatibilityLevel(ver));
                     break;
                 case DBTypeEnum.MySql:
-                    ServerVersion? sv = null;
-                    if (string.IsNullOrEmpty(Version) == false)
-                    {
-                        ServerVersion.TryParse(Version, out sv);
-                    }
-                    if (sv == null)
-                    {
-                        sv = ServerVersion.AutoDetect(CSName);
-                    }
-                    optionsBuilder.UseMySql(CSName, sv, b => b.SchemaBehavior(MySqlSchemaBehavior.Translate,
-    (schema, entity) => $"{entity}"));
+                    optionsBuilder.UseMySQL(CSName);
                     break;
                 case DBTypeEnum.PgSql:
                     optionsBuilder.UseNpgsql(CSName);

--- a/src/WalkingTec.Mvvm.Core/Utils.cs
+++ b/src/WalkingTec.Mvvm.Core/Utils.cs
@@ -79,7 +79,6 @@ namespace WalkingTec.Mvvm.Core
                 "Npgsql.",
                 "NPOI.",
                 "netstandard",
-                "MySqlConnector",
                 "VueCliMiddleware"
                 };
 

--- a/src/WalkingTec.Mvvm.Core/Utils.cs
+++ b/src/WalkingTec.Mvvm.Core/Utils.cs
@@ -66,7 +66,7 @@ namespace WalkingTec.Mvvm.Core
                 "ICSharpCode",
                 "Newtonsoft.",
                 "Oracle.",
-                "Pomelo.",
+                "MySql.",
                 "SQLitePCLRaw.",
                 "Aliyun.OSS",
                 "BouncyCastle.",

--- a/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
+++ b/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="10.23.60" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Quartz" Version="3.16.0" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
+++ b/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>WalkingTec.Mvvm</Description>
     <AssemblyName>WalkingTec.Mvvm.Core</AssemblyName>
     <Title>$(AssemblyName)</Title>
@@ -12,35 +12,35 @@
 
   <ItemGroup>
     <!-- FrameworkReference provides Microsoft.AspNetCore.Http and other ASP.NET Core APIs
-         at the correct .NET 8 version, replacing the old Microsoft.AspNetCore.Http 2.1.34 NuGet package. -->
+         at the correct .NET 10 version, replacing the old Microsoft.AspNetCore.Http 2.1.34 NuGet package. -->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.22" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.3" />
     <PackageReference Include="NPOI" Version="2.7.6" />
     <PackageReference Include="Fare" Version="2.2.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.22" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-    <PackageReference Include="Oracle.EntityFrameworkCore" Version="8.23.70" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="Oracle.EntityFrameworkCore" Version="10.23.60" />
+    <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Quartz" Version="3.16.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WalkingTec.Mvvm.Etl/WalkingTec.Mvvm.Etl.csproj
+++ b/src/WalkingTec.Mvvm.Etl/WalkingTec.Mvvm.Etl.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>WalkingTec.Mvvm.Etl</AssemblyName>
     <Title>$(AssemblyName)</Title>
     <Description>WTM ETL Module - Batch data import pipeline</Description>

--- a/src/WalkingTec.Mvvm.Mvc.Tests/WalkingTec.Mvvm.Mvc.Tests.csproj
+++ b/src/WalkingTec.Mvvm.Mvc.Tests/WalkingTec.Mvvm.Mvc.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -16,8 +16,8 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.22" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/WalkingTec.Mvvm.Mvc.Tests/WalkingTec.Mvvm.Mvc.Tests.csproj
+++ b/src/WalkingTec.Mvvm.Mvc.Tests/WalkingTec.Mvvm.Mvc.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -18,7 +18,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/WalkingTec.Mvvm.Mvc/Filters/SwaggerFilter.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Filters/SwaggerFilter.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using WalkingTec.Mvvm.Core;
 
@@ -12,7 +11,7 @@ namespace WalkingTec.Mvvm.Mvc.Filters
 {
     public class SwaggerFilter : ISchemaFilter
     {
-        public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+        public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
         {
             var type = context.Type;
             if(type == typeof(List<ComboSelectListItem>))

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -34,7 +34,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Auth;
 using WalkingTec.Mvvm.Core.Extensions;
@@ -785,16 +785,12 @@ namespace WalkingTec.Mvvm.Mvc
 
                 };
                 c.AddSecurityDefinition("Bearer", bearer);
-                var sr = new OpenApiSecurityRequirement();
-                sr.Add(new OpenApiSecurityScheme
+                c.AddSecurityRequirement(_ =>
                 {
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.SecurityScheme,
-                        Id = "Bearer"
-                    }
-                }, new string[] { });
-                c.AddSecurityRequirement(sr);
+                    var sr = new OpenApiSecurityRequirement();
+                    sr.Add(new OpenApiSecuritySchemeReference("Bearer"), new List<string>());
+                    return sr;
+                });
                 c.SchemaFilter<SwaggerFilter>();
                 if (useFullName == true)
                 {

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Asp.Versioning;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.AspNetCore.SpaServices.StaticFiles;
 using Microsoft.EntityFrameworkCore;
@@ -573,18 +574,17 @@ namespace WalkingTec.Mvvm.Mvc
                     Console.Error.WriteLine($"[WTM] Warning: could not initialize database connection '{item.Key}' ({item.DbType}): {ex.Message}");
                 }
             }
-            services.AddVersionedApiExplorer(o=>
+            services.AddApiVersioning(options =>
+             {
+                 options.ReportApiVersions = true;
+                 options.DefaultApiVersion = new ApiVersion(1, 0);
+                 options.AssumeDefaultVersionWhenUnspecified = true;
+             })
+            .AddApiExplorer(o =>
             {
                 o.GroupNameFormat = "'v'VVV";
                 o.SubstituteApiVersionInUrl = true;
             });
-            services.AddApiVersioning(
-             options =>
-             {
-                 options.ReportApiVersions = true;
-                 options.DefaultApiVersion = ApiVersion.Default;
-                 options.AssumeDefaultVersionWhenUnspecified = true;
-             });
 
             return services;
         }

--- a/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
+++ b/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>WalkingTec.Mvvm</Description>
     <AssemblyName>WalkingTec.Mvvm.Mvc</AssemblyName>
     <CopyRefAssembliesToPublishDirectory>true</CopyRefAssembliesToPublishDirectory>
@@ -95,18 +95,18 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.22" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.6.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.4" />
     <PackageReference Include="VueCliMiddleware" Version="6.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
   </ItemGroup>
 
 

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/WalkingTec.Mvvm.TagHelpers.LayUI.csproj
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/WalkingTec.Mvvm.TagHelpers.LayUI.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>WalkingTec.Mvvm</Description>
     <AssemblyName>WalkingTec.Mvvm.TagHelpers.LayUI</AssemblyName>
     <Title>$(AssemblyName)</Title>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,12 +5,12 @@
     referenced with Include in individual .csproj files.
 
     Shared versions:
-      Microsoft.NET.Test.Sdk  17.9.0
-      MSTest.TestAdapter       3.2.2
-      MSTest.TestFramework     3.2.2
+      Microsoft.NET.Test.Sdk  17.12.0
+      MSTest.TestAdapter       3.6.4
+      MSTest.TestFramework     3.6.4
       Moq                      4.20.72
       FluentAssertions         6.12.2
-      coverlet.collector       6.0.2
+      coverlet.collector       6.0.4
 
     To add a new shared package, add an Update line here and
     Include (without Version) in each consuming .csproj.
@@ -18,8 +18,8 @@
   <PropertyGroup>
     <MoqVersion>4.20.72</MoqVersion>
     <FluentAssertionsVersion>6.12.2</FluentAssertionsVersion>
-    <MSTestVersion>3.2.2</MSTestVersion>
-    <TestSdkVersion>17.9.0</TestSdkVersion>
-    <CoverletVersion>6.0.2</CoverletVersion>
+    <MSTestVersion>3.6.4</MSTestVersion>
+    <TestSdkVersion>17.12.0</TestSdkVersion>
+    <CoverletVersion>6.0.4</CoverletVersion>
   </PropertyGroup>
 </Project>

--- a/test/WalkingTec.Mvvm.Admin.Test/WalkingTec.Mvvm.Admin.Test.csproj
+++ b/test/WalkingTec.Mvvm.Admin.Test/WalkingTec.Mvvm.Admin.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj
+++ b/test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -16,12 +16,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.22" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj
+++ b/test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
+    <PackageReference Include="Serilog.Sinks.InMemory" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
   </ItemGroup>
 

--- a/test/WalkingTec.Mvvm.Etl.Test/WalkingTec.Mvvm.Etl.Test.csproj
+++ b/test/WalkingTec.Mvvm.Etl.Test/WalkingTec.Mvvm.Etl.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/WalkingTec.Mvvm.Test.Mock/WalkingTec.Mvvm.Test.Mock.csproj
+++ b/test/WalkingTec.Mvvm.Test.Mock/WalkingTec.Mvvm.Test.Mock.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
 

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>8.6.1</VersionPrefix>
+    <VersionPrefix>10.0.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
## Summary

- **Upgrade entire WTM framework from .NET 8 to .NET 10 (LTS)**
- Replace `Pomelo.EntityFrameworkCore.MySql` with official `MySql.EntityFrameworkCore`
- Replace deprecated `Microsoft.AspNetCore.Mvc.Versioning` with `Asp.Versioning.Mvc`
- Bump version from 8.6.1 to 10.0.0

### 34 files changed across 6 phases:
- SDK & TFM: `global.json` → 10.0.0, all 22 `.csproj` → `net10.0`
- NuGet: EF Core 10.0.3, ASP.NET Core 10.0.3, Npgsql 10.0.1, Oracle 10.23.60, Swashbuckle 10.1.5, Serilog 10.0.0
- Code: `DataContext.cs` MySQL provider migration, `FrameworkServiceExtension.cs` API versioning migration
- Infra: Dockerfile (.NET 3.1→10), CI/CD (8.0.x→10.0.x), legacy demo TFMs (net5.0/net6.0→net10.0)
- Docs: CHANGELOG migration guide, version.props, CLAUDE.md

## Breaking Changes

1. **TFM**: `net8.0` → `net10.0`
2. **MySQL**: `Pomelo.EntityFrameworkCore.MySql` → `MySql.EntityFrameworkCore`
   - `UseMySql()` → `UseMySQL()` (capitalization)
   - `ServerVersion` parameter removed
   - `using MySqlConnector;` → `using MySql.Data.MySqlClient;`
3. **API Versioning**: `Microsoft.AspNetCore.Mvc.Versioning` → `Asp.Versioning.Mvc`
4. **Version**: 8.6.1 → 10.0.0

## Test plan

- [ ] Install .NET 10 SDK and run `dotnet build WalkingTec.Mvvm.sln -c Release`
- [ ] Run `dotnet test WalkingTec.Mvvm.sln -c Release --verbosity normal`
- [ ] Run JS tests: `cd test/WalkingTec.Mvvm.Js.Tests && npm ci && npm test`
- [ ] Verify MySQL connection with new provider (`UseMySQL`)
- [ ] Verify Swagger UI loads correctly with Swashbuckle 10.x
- [ ] Verify API versioning still works with `Asp.Versioning.Mvc`
- [ ] Run `dotnet list WalkingTec.Mvvm.sln package --vulnerable --include-transitive`

https://claude.ai/code/session_016CaWpVBDZvjrgyqWeMCktP