### PR TITLE
feat!: upgrade to .NET 10 (LTS)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,9 +2,9 @@ name: WTM Build and Test
 on:
   workflow_dispatch:
   push:
-    branches: [ dotnet8, "feature/**", "feat/**" ]
+    branches: [ dotnet8, dotnet10, "feature/**", "feat/**" ]
   pull_request:
-    branches: [ dotnet8 ]
+    branches: [ dotnet8, dotnet10 ]
 jobs:
   release-tooling-test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # wtm custom
 .worktrees/
+.claude/worktrees/
 
 demo/WalkingTec.Mvvm.Demo/wwwroot/layuiadminsrc
 .Publish/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@
 - **BaseImportVM — 行內錯誤清單**：新增 `InlineErrors` 屬性（最多 `InlineErrorLimit` 筆，預設 50）供 API 端點直接回傳驗證錯誤（#615）。
 - **BaseTemplateVM — 欄位說明列**：`ShowDescriptionRow = true`（預設）時，於模板第二行插入淺綠色斜體說明列，標示 Required/Optional、資料類型、min/max 限制；匯入時自動識別並跳過說明列（v2 標記）（#615）。
 
+### Fixed
+- **Test suite — EF Core 10 API**：`DataContext` 中 `modelBuilder.Model.SetMaxIdentifierLength(30)` 改為 `modelBuilder.HasMaxIdentifierLength(30)`，修正 EF Core 10 將內部 API 設為不可存取的問題（#676）。
+- **Test suite — MSTest / Test.Sdk 版本**：`MSTest.TestAdapter` / `MSTest.TestFramework` 從 3.2.2 升至 3.6.4；`Microsoft.NET.Test.Sdk` 從 17.9.0 升至 17.12.0，確保與 .NET 10 測試主機相容（#676）。
+- **Test suite — coverlet / xunit runner**：`coverlet.collector` 從 6.0.2 升至 6.0.4；`xunit.runner.visualstudio` 從 2.8.2 升至 2.8.3，修正與 Test.Sdk 17.12.0 的相容性（#676）。
+- **Test suite — Serilog Sinks**：`Serilog.Sinks.InMemory` 從 0.11.0 升至 1.0.0，解決與 `Serilog.AspNetCore 10.0.0`（使用 Serilog 4.x）的型別衝突（#676）。
+
 ### Deprecated
 - **Workflow API**：內建 Elsa workflow 整合（`IWorkflow`、`FrameworkWorkflow`、`ApproveTimeLine`、`ApproveInfo`、`FlowInfoTagHelper`、`IBaseCRUDVM` 工作流程方法、`DataContext.FrameworkWorkflows`）標記為 `[Obsolete]`，將於下一個主版本移除（#586）。
   - **遷移指引**：若仍需工作流程功能，請直接引用 Elsa 或改用其他工作流程引擎；移除 `IWorkflow` 介面實作及相關 TagHelper。

--- a/src/WalkingTec.Mvvm.Core/DataContext.cs
+++ b/src/WalkingTec.Mvvm.Core/DataContext.cs
@@ -661,7 +661,7 @@ namespace WalkingTec.Mvvm.Core
         {
             if (DBType == DBTypeEnum.Oracle)
             {
-                modelBuilder.Model.SetMaxIdentifierLength(30);
+                modelBuilder.HasMaxIdentifierLength(30);
                 // [Elsa removed] table mappings
                 // modelBuilder.Entity<Elsa_Bookmark>().ToTable("Bookmarks");
                 // modelBuilder.Entity<Elsa_Trigger>().ToTable("Triggers");

--- a/src/WalkingTec.Mvvm.Core/Utils.cs
+++ b/src/WalkingTec.Mvvm.Core/Utils.cs
@@ -79,7 +79,6 @@ namespace WalkingTec.Mvvm.Core
                 "Npgsql.",
                 "NPOI.",
                 "netstandard",
-                "MySqlConnector",
                 "VueCliMiddleware"
                 };
 

--- a/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
+++ b/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="10.23.60" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Quartz" Version="3.16.0" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/WalkingTec.Mvvm.Mvc.Tests/WalkingTec.Mvvm.Mvc.Tests.csproj
+++ b/src/WalkingTec.Mvvm.Mvc.Tests/WalkingTec.Mvvm.Mvc.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -18,7 +18,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/WalkingTec.Mvvm.Mvc/Filters/SwaggerFilter.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Filters/SwaggerFilter.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using WalkingTec.Mvvm.Core;
 
@@ -12,7 +11,7 @@ namespace WalkingTec.Mvvm.Mvc.Filters
 {
     public class SwaggerFilter : ISchemaFilter
     {
-        public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+        public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
         {
             var type = context.Type;
             if(type == typeof(List<ComboSelectListItem>))

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -34,7 +34,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Auth;
 using WalkingTec.Mvvm.Core.Extensions;
@@ -785,16 +785,12 @@ namespace WalkingTec.Mvvm.Mvc
 
                 };
                 c.AddSecurityDefinition("Bearer", bearer);
-                var sr = new OpenApiSecurityRequirement();
-                sr.Add(new OpenApiSecurityScheme
+                c.AddSecurityRequirement(_ =>
                 {
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.SecurityScheme,
-                        Id = "Bearer"
-                    }
-                }, new string[] { });
-                c.AddSecurityRequirement(sr);
+                    var sr = new OpenApiSecurityRequirement();
+                    sr.Add(new OpenApiSecuritySchemeReference("Bearer"), new List<string>());
+                    return sr;
+                });
                 c.SchemaFilter<SwaggerFilter>();
                 if (useFullName == true)
                 {

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,12 +5,12 @@
     referenced with Include in individual .csproj files.
 
     Shared versions:
-      Microsoft.NET.Test.Sdk  17.9.0
-      MSTest.TestAdapter       3.2.2
-      MSTest.TestFramework     3.2.2
+      Microsoft.NET.Test.Sdk  17.12.0
+      MSTest.TestAdapter       3.6.4
+      MSTest.TestFramework     3.6.4
       Moq                      4.20.72
       FluentAssertions         6.12.2
-      coverlet.collector       6.0.2
+      coverlet.collector       6.0.4
 
     To add a new shared package, add an Update line here and
     Include (without Version) in each consuming .csproj.
@@ -18,8 +18,8 @@
   <PropertyGroup>
     <MoqVersion>4.20.72</MoqVersion>
     <FluentAssertionsVersion>6.12.2</FluentAssertionsVersion>
-    <MSTestVersion>3.2.2</MSTestVersion>
-    <TestSdkVersion>17.9.0</TestSdkVersion>
-    <CoverletVersion>6.0.2</CoverletVersion>
+    <MSTestVersion>3.6.4</MSTestVersion>
+    <TestSdkVersion>17.12.0</TestSdkVersion>
+    <CoverletVersion>6.0.4</CoverletVersion>
   </PropertyGroup>
 </Project>

--- a/test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj
+++ b/test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
+    <PackageReference Include="Serilog.Sinks.InMemory" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- **Upgrade entire framework to .NET 10 (LTS)** — all src/test/demo projects now target `net10.0`
- **Update all NuGet dependencies** to .NET 10-compatible versions (EF Core 10, ASP.NET Core 10, Swashbuckle 10, Serilog 10, etc.)
- **Fix security vulnerabilities** — upgrade packages with known CVEs (#677)
- **Fix CI** — add `dotnet10` branch to CI triggers, stable CI with `ci.slnf` and `global.json` (#674)
- **Fix build compatibility** — resolve .NET 10 API breaking changes (#675)
- **Fix test compatibility** — EF Core 10 API changes, MSTest/test SDK upgrades, Serilog sink version conflict (#676)
- **CHANGELOG.md** updated with full migration notes for v10.0.0

Includes prior work from `dotnet10` branch:
- Analysis Mode: sort, pagination, sticky header (#539, #655)
- Multiple feature implementations (#539, #540, #565, #566, #607, #615, #619, #620)
- BatchSaveData signature fix (#661)
- Dependency bumps (#660, #662)

## Test plan

- [ ] `dotnet build WalkingTec.Mvvm.sln -c Release` passes
- [ ] `dotnet test WalkingTec.Mvvm.sln -c Release` passes
- [ ] JS tests pass (`cd test/WalkingTec.Mvvm.Js.Tests && npm ci && npm test`)
- [ ] `dotnet list WalkingTec.Mvvm.sln package --vulnerable --include-transitive` shows no actionable vulnerabilities
- [ ] Verify demo projects build against .NET 10

https://claude.ai/code/session_016CaWpVBDZvjrgyqWeMCktP