### PR TITLE
chore(deps): .NET 10 package version alignment & upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+- chore(deps): 集中化 NuGet 套件版本至 `common.props` MSBuild 變數，統一管理 Microsoft、EF Core、ASP.NET Core 及主要第三方套件版本
+- chore(deps): Microsoft.AspNetCore.* 套件 10.0.3 → 10.0.4
+- chore(deps): Swashbuckle.AspNetCore.SwaggerUI 10.1.4 → 10.1.5（對齊其他 Swashbuckle 套件）
+- chore(deps): System.Text.Json 10.0.0 → 10.0.4
+- chore(deps): Quartz 3.16.0 → 3.16.1 (patch)
+
 ## [10.0.0] - 2026-03-20
 
 ### Changed

--- a/common.props
+++ b/common.props
@@ -36,4 +36,28 @@
     <None Include="$(MSBuildThisFileDirectory)demo/WalkingTec.Mvvm.BlazorDemo/WalkingTec.Mvvm.BlazorDemo/wwwroot/logo.png" Pack="true" PackagePath="icon.png" Visible="false" />
   </ItemGroup>
 
+  <!--
+    Centralized package versions for src projects.
+    Microsoft packages follow the .NET 10 release cadence (all 10.0.4).
+    Third-party packages pinned to latest stable.
+    DB providers (Npgsql, Oracle, MySql) are NOT centralized here —
+    they follow independent release cadences.
+  -->
+  <PropertyGroup>
+    <!-- Microsoft .NET 10 packages -->
+    <MicrosoftExtensionsVersion>10.0.4</MicrosoftExtensionsVersion>
+    <EntityFrameworkCoreVersion>10.0.4</EntityFrameworkCoreVersion>
+    <AspNetCoreVersion>10.0.4</AspNetCoreVersion>
+    <SystemTextJsonVersion>10.0.4</SystemTextJsonVersion>
+    <!-- Third-party packages -->
+    <SwashbuckleVersion>10.1.5</SwashbuckleVersion>
+    <OpenTelemetryVersion>1.15.0</OpenTelemetryVersion>
+    <SerilogAspNetCoreVersion>10.0.0</SerilogAspNetCoreVersion>
+    <QuartzVersion>3.16.0</QuartzVersion>
+    <NPOIVersion>2.7.6</NPOIVersion>
+    <ImageSharpVersion>3.1.12</ImageSharpVersion>
+    <ImageSharpDrawingVersion>2.1.7</ImageSharpDrawingVersion>
+    <AspVersioningVersion>8.1.1</AspVersioningVersion>
+  </PropertyGroup>
+
 </Project>

--- a/common.props
+++ b/common.props
@@ -53,7 +53,7 @@
     <SwashbuckleVersion>10.1.5</SwashbuckleVersion>
     <OpenTelemetryVersion>1.15.0</OpenTelemetryVersion>
     <SerilogAspNetCoreVersion>10.0.0</SerilogAspNetCoreVersion>
-    <QuartzVersion>3.16.0</QuartzVersion>
+    <QuartzVersion>3.16.1</QuartzVersion>
     <NPOIVersion>2.7.6</NPOIVersion>
     <ImageSharpVersion>3.1.12</ImageSharpVersion>
     <ImageSharpDrawingVersion>2.1.7</ImageSharpDrawingVersion>

--- a/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
+++ b/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
@@ -19,27 +19,27 @@
   <ItemGroup>
     <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.4" />
-    <PackageReference Include="NPOI" Version="2.7.6" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="NPOI" Version="$(NPOIVersion)" />
     <PackageReference Include="Fare" Version="2.2.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="10.23.60" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.1" />
-    <PackageReference Include="Quartz" Version="3.16.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+    <PackageReference Include="Quartz" Version="$(QuartzVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
+++ b/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
@@ -89,24 +89,24 @@
 
   <ItemGroup>
     <PackageReference Include="DUWENINK.Captcha" Version="0.8.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
-    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="$(ImageSharpVersion)" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="$(ImageSharpDrawingVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="$(AspVersioningVersion)" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="$(AspVersioningVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="$(SwashbuckleVersion)" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="$(SwashbuckleVersion)" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="$(SwashbuckleVersion)" />
     <PackageReference Include="VueCliMiddleware" Version="6.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="$(SerilogAspNetCoreVersion)" />
   </ItemGroup>
 
 


### PR DESCRIPTION
## Summary
- Centralize NuGet package versions in `common.props` MSBuild variables for single-point management
- Upgrade Microsoft.AspNetCore.* packages from 10.0.3 to 10.0.4
- Fix Swashbuckle.AspNetCore.SwaggerUI version inconsistency (10.1.4 → 10.1.5)
- Upgrade System.Text.Json 10.0.0 → 10.0.4
- Upgrade Quartz 3.16.0 → 3.16.1 (patch)

## Changes

| Area | What |
|------|------|
| `common.props` | Added 12 MSBuild version variables |
| `Core.csproj` | 15 packages now use variables |
| `Mvc.csproj` | 16 packages now use variables |
| Upgrades | 5x ASP.NET Core 10.0.3→10.0.4, SwaggerUI 10.1.4→10.1.5, System.Text.Json 10.0.0→10.0.4, Quartz 3.16.0→3.16.1 |

## What's NOT changed (intentional)
- DB providers (Npgsql, Oracle, MySql) — independent cadence, conservative upgrade policy
- FluentAssertions — stays at 6.x (7.x has breaking changes)
- Packages already at latest stable (Serilog, ImageSharp, NPOI, OTel, BCrypt, Fare, Asp.Versioning)

## Test plan
- [ ] CI build passes
- [ ] All .NET tests pass
- [ ] All JS tests pass

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)