### PR TITLE
fix(build): resolve NU1603, NU1510 warnings and remove unused import

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Grid/IGridColumn.cs
+++ b/src/WalkingTec.Mvvm.Core/Grid/IGridColumn.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Text.Json.Serialization;
 
 namespace WalkingTec.Mvvm.Core

--- a/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
+++ b/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
@@ -19,27 +19,16 @@
   <ItemGroup>
     <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="NPOI" Version="$(NPOIVersion)" />
     <PackageReference Include="Fare" Version="2.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EntityFrameworkCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EntityFrameworkCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageReference Include="Oracle.EntityFrameworkCore" Version="10.23.60" />
+    <PackageReference Include="Oracle.EntityFrameworkCore" Version="10.23.26100" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Quartz" Version="$(QuartzVersion)" />
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
+++ b/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
@@ -99,7 +99,6 @@
     <PackageReference Include="Asp.Versioning.Mvc" Version="$(AspVersioningVersion)" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="$(AspVersioningVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="$(SwashbuckleVersion)" />


### PR DESCRIPTION
## Summary
- **#681 (P1)**: Oracle.EntityFrameworkCore `10.23.60` → `10.23.26100` (fixes NU1603 — version not found on NuGet)
- **#682 (P2)**: Remove 12 redundant `PackageReference` entries from Core.csproj + 1 from Mvc.csproj (fixes NU1510 — already in shared framework via `FrameworkReference Microsoft.AspNetCore.App`)
- **#683 (P3)**: Remove unused `using System.Drawing` from `IGridColumn.cs`

## Test plan
- [ ] CI build passes (no NU1603/NU1510 warnings)
- [ ] All tests pass

Closes #681, Closes #682, Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)