### PR TITLE
perf(core): Phase 1a — FrozenDictionary, Lock, Span/stackalloc optimizations

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -746,14 +747,14 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
             };
 
-        private static readonly Dictionary<AggregateFunc, string> _funcDisplayNames = new()
+        private static readonly FrozenDictionary<AggregateFunc, string> _funcDisplayNames = new Dictionary<AggregateFunc, string>
         {
             { AggregateFunc.Sum,   "合計" },
             { AggregateFunc.Count, "計數" },
             { AggregateFunc.Avg,   "平均" },
             { AggregateFunc.Max,   "最大" },
             { AggregateFunc.Min,   "最小" },
-        };
+        }.ToFrozenDictionary();
 
         /// <summary>
         /// 建立欄位 key → 使用者友善顯示名稱的對照表。
@@ -807,9 +808,10 @@ namespace WalkingTec.Mvvm.Core.Analysis
             {
                 raw += "|" + identityKey;
             }
-            var bytes = System.Security.Cryptography.SHA256.HashData(
-                System.Text.Encoding.UTF8.GetBytes(raw));
-            return Convert.ToHexString(bytes).Substring(0, 16);
+            Span<byte> hash = stackalloc byte[32]; // SHA256 = 32 bytes
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(raw), hash);
+            return Convert.ToHexString(hash)[..16];
         }
     }
 }

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisVmRegistry.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -12,14 +13,14 @@ namespace WalkingTec.Mvvm.Core.Analysis
     /// </summary>
     public class AnalysisVmRegistry
     {
-        private readonly Dictionary<string, Type> _whitelist = new Dictionary<string, Type>();
+        private FrozenDictionary<string, Type> _whitelist = FrozenDictionary<string, Type>.Empty;
 
         /// <summary>
         /// 掃描指定 Assembly 集合，將所有標記 [EnableAnalysis] 的 BasePagedListVM 子類別加入白名單。
         /// </summary>
         public void Build(IEnumerable<Assembly> assemblies)
         {
-            _whitelist.Clear();
+            var dict = new Dictionary<string, Type>();
             foreach (var asm in assemblies)
             {
                 Type[] types;
@@ -41,11 +42,12 @@ namespace WalkingTec.Mvvm.Core.Analysis
                     {
                         if (!string.IsNullOrEmpty(type.FullName))
                         {
-                            _whitelist[type.FullName] = type;
+                            dict[type.FullName] = type;
                         }
                     }
                 }
             }
+            _whitelist = dict.ToFrozenDictionary();
         }
 
         /// <summary>

--- a/src/WalkingTec.Mvvm.Core/Analysis/MemoryAnalysisCache.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/MemoryAnalysisCache.cs
@@ -15,7 +15,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
         private readonly IMemoryCache _cache;
         private readonly TimeSpan _defaultTtl;
         private CancellationTokenSource _cts;
-        private readonly object _lock = new();
+        private readonly Lock _lock = new();
 
         public MemoryAnalysisCache(IMemoryCache cache, TimeSpan? defaultTtl = null)
         {

--- a/src/WalkingTec.Mvvm.Core/Cache/LookupCacheService.cs
+++ b/src/WalkingTec.Mvvm.Core/Cache/LookupCacheService.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -27,14 +28,14 @@ namespace WalkingTec.Mvvm.Core.Cache
 
         // per-type CTS，用於 InvalidateType（IMemoryCache 無 Clear 方法）
         private readonly Dictionary<Type, CancellationTokenSource> _ctsByType = new();
-        private readonly object _ctsLock = new();
+        private readonly Lock _ctsLock = new();
 
         // per-key SemaphoreSlim，防 stampede
         private readonly ConcurrentDictionary<string, SemaphoreSlim> _keyLocks = new();
         private static readonly TimeSpan StampedeTimeout = TimeSpan.FromSeconds(10);
 
-        // 啟動時掃描結果
-        private readonly Dictionary<Type, CacheLookupAttribute> _registry;
+        // 啟動時掃描結果（Build 後不再修改，FrozenDictionary 優化讀取路徑）
+        private readonly FrozenDictionary<Type, CacheLookupAttribute> _registry;
 
         public LookupCacheService(IMemoryCache cache, IEnumerable<Assembly> assemblies, LookupCacheOptions? options = null)
         {
@@ -197,7 +198,7 @@ namespace WalkingTec.Mvvm.Core.Cache
             where T : TopBasePoco =>
             dc.Set<T>().AsNoTracking().ToListAsync(ct);
 
-        private static Dictionary<Type, CacheLookupAttribute> ScanAssemblies(IEnumerable<Assembly> assemblies)
+        private static FrozenDictionary<Type, CacheLookupAttribute> ScanAssemblies(IEnumerable<Assembly> assemblies)
         {
             var result = new Dictionary<Type, CacheLookupAttribute>();
             foreach (var asm in assemblies)
@@ -223,7 +224,7 @@ namespace WalkingTec.Mvvm.Core.Cache
                     }
                 }
             }
-            return result;
+            return result.ToFrozenDictionary();
         }
     }
 }

--- a/src/WalkingTec.Mvvm.Core/PasswordHashHelper.cs
+++ b/src/WalkingTec.Mvvm.Core/PasswordHashHelper.cs
@@ -78,11 +78,9 @@ namespace WalkingTec.Mvvm.Core
         internal static string ComputeMD5(string? input)
         {
             if (string.IsNullOrEmpty(input)) return string.Empty;
-            byte[] buffer = Encoding.UTF8.GetBytes(input);
-            byte[] hash = MD5.HashData(buffer);
-            var sb = new StringBuilder(32);
-            foreach (byte b in hash) sb.Append(b.ToString("X2"));
-            return sb.ToString();
+            Span<byte> hash = stackalloc byte[16]; // MD5 = 16 bytes
+            MD5.HashData(Encoding.UTF8.GetBytes(input), hash);
+            return Convert.ToHexString(hash);
         }
     }
 

--- a/src/WalkingTec.Mvvm.Core/Support/DateRange.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/DateRange.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
@@ -169,14 +170,14 @@ namespace WalkingTec.Mvvm.Core
             return string.Empty;
         }
 
-        public static readonly Dictionary<DateTimeTypeEnum, string> DateTimeFormatDic = new Dictionary<DateTimeTypeEnum, string>()
+        public static readonly FrozenDictionary<DateTimeTypeEnum, string> DateTimeFormatDic = new Dictionary<DateTimeTypeEnum, string>()
         {
             { DateTimeTypeEnum.Date,"yyyy-MM-dd"},
             { DateTimeTypeEnum.DateTime,"yyyy-MM-dd HH:mm:ss"},
             { DateTimeTypeEnum.Year,"yyyy"},
             { DateTimeTypeEnum.Month,"yyyy-MM"},
             { DateTimeTypeEnum.Time,"HH:mm:ss"},
-        };
+        }.ToFrozenDictionary();
 
         private DateTime SwitchTime(DateTime time)
         {
@@ -331,14 +332,14 @@ namespace WalkingTec.Mvvm.Core
         }
 
 
-        private static readonly Dictionary<DateTimeTypeEnum, string> DateTimeRegexDic = new Dictionary<DateTimeTypeEnum, string>()
+        private static readonly FrozenDictionary<DateTimeTypeEnum, string> DateTimeRegexDic = new Dictionary<DateTimeTypeEnum, string>()
         {
             { DateTimeTypeEnum.DateTime,@"((\d{4}|\d{3}|\d{2}|\d{1})[-](1[0-2]|0?[1-9])[-](3[01]|[12][0-9]|0?[1-9])\s+(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d)"},
             { DateTimeTypeEnum.Date,@"(\d{4}|\d{3}|\d{2}|\d{1})[-](1[0-2]|0?[1-9])[-](3[01]|[12][0-9]|0?[1-9])"},
             { DateTimeTypeEnum.Month,@"(\d{4}|\d{3}|\d{2}|\d{1})[-](1[0-2]|0?[1-9])"},
             { DateTimeTypeEnum.Time,@"(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d"},
             { DateTimeTypeEnum.Year,@"(\d{4}|\d{3}|\d{2}|\d{1})"},
-        };
+        }.ToFrozenDictionary();
 
         public static bool TryParse(string input, out DateRange? result)
         {

--- a/src/WalkingTec.Mvvm.Core/Utils.cs
+++ b/src/WalkingTec.Mvvm.Core/Utils.cs
@@ -512,7 +512,7 @@ namespace WalkingTec.Mvvm.Core
             //string r9 = "class&nbsp;(.+)&nbsp;";//匹配类
             //string r10 = "&lt;(.+)&gt;";//匹配泛型类
 
-            string rs = string.Format("{0}|{1}|{2}|{3}|{4}|{5}|{6}|{7}", r1, r2, r3, r4, r5, r6, r7, r8);
+            string rs = $"{r1}|{r2}|{r3}|{r4}|{r5}|{r6}|{r7}|{r8}";
             //string rs = string.Format("{0}|{1}|{2}|{3}|{4}|{5}|{6}|{7}|{8}|{9}", r1, r2, r3, r4, r5, r6, r7, r8, r9,r10);
 
             //<font color=#44C796>$9$10</font>


### PR DESCRIPTION
## Summary
.NET 10 optimization Phase 1a — low-risk, high-reward performance improvements.

### P0-01: FrozenDictionary (6 locations)
- `AnalysisVmRegistry._whitelist` — Build() then read-only
- `AnalysisQueryEngine._funcDisplayNames` — static readonly
- `LookupCacheService._registry` + `ScanAssemblies()` — startup scan then read-only
- `DateRange.DateTimeFormatDic` / `DateTimeRegexDic` — static readonly

### P0-02: System.Threading.Lock (2 locations)
- `MemoryAnalysisCache._lock` — compiler-optimized lock IL
- `LookupCacheService._ctsLock`

### P0-04: string interpolation (1 location)
- `Utils.cs` — `string.Format` → `$"..."` 

### P0-05: Span/stackalloc (2 locations)
- `AnalysisQueryEngine.ComputeHash()` — `stackalloc byte[32]` avoids heap alloc
- `PasswordHashHelper.ComputeMD5()` — `stackalloc byte[16]` + `Convert.ToHexString` replaces StringBuilder

## Test plan
- [ ] CI build passes
- [ ] All .NET tests pass (existing tests cover all modified code paths)
- [ ] All JS tests pass

Closes #694, Closes #695, Closes #697, Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)