### PR TITLE
refactor(core): remove last #nullable disable in Core project

### DIFF
--- a/src/WalkingTec.Mvvm.Core/BaseImportVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BaseImportVM.cs
@@ -1522,12 +1522,10 @@ namespace WalkingTec.Mvvm.Core
             };
         }
 
-#nullable disable
         public override IOrderedQueryable<ErrorMessage> GetSearchQuery()
         {
-            return EntityList.AsQueryable().OrderBy(x => x.Index);
+            return EntityList!.AsQueryable().OrderBy(x => x.Index);
         }
-#nullable enable
     }
 
     #endregion


### PR DESCRIPTION
## Summary
Remove the final `#nullable disable` directive in `WalkingTec.Mvvm.Core`.

`TemplateErrorListVM.GetSearchQuery()` used `#nullable disable` to suppress a warning on `EntityList.AsQueryable()`. Since the constructor guarantees `EntityList = new List<ErrorMessage>()`, a null-forgiving `!` is sufficient.

**Result:** Core project now has zero `#nullable disable` directives.

## Test plan
- [ ] CI build passes
- [ ] All tests pass

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)