### PR TITLE
perf(analysis): use ExecuteDeleteAsync for saved query deletion

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
@@ -396,19 +397,25 @@ result = await _engine.ExecutePivotDynamicAsync(ctx!.BaseQuery, req, ctx.Fields,
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public IActionResult DeleteSavedQuery(Guid id)
+        public async Task<IActionResult> DeleteSavedQuery(Guid id)
         {
-            var entity = Wtm!.DC.Set<AnalysisSavedQuery>().FirstOrDefault(q => q.ID == id);
-            if (entity == null) return NotFound();
+            var userCode = Wtm!.LoginUserInfo?.ITCode ?? string.Empty;
 
-            var userCode = Wtm.LoginUserInfo?.ITCode ?? string.Empty;
-            if (entity.OwnerCode != userCode) return Forbid();
+            // Single SQL DELETE WHERE — eliminates Load + Remove + SaveChanges round-trip
+            var deleted = await Wtm.DC.Set<AnalysisSavedQuery>()
+                .Where(q => q.ID == id && q.OwnerCode == userCode)
+                .ExecuteDeleteAsync();
 
-            Wtm.DC.Set<AnalysisSavedQuery>().Remove(entity);
-            Wtm.DC.SaveChanges();
+            if (deleted > 0)
+            {
+                _logger.LogInformation("Analysis saved query deleted Id={Id} Owner={Owner}", id, userCode);
+                return NoContent();
+            }
 
-            _logger.LogInformation("Analysis saved query deleted Id={Id} Owner={Owner}", id, userCode);
-            return NoContent();
+            // Distinguish 404 (not found) vs 403 (not owner)
+            var exists = await Wtm.DC.Set<AnalysisSavedQuery>()
+                .AnyAsync(q => q.ID == id);
+            return exists ? Forbid() : NotFound();
         }
 
         // ─── Helpers ───────────────────────────────────────────────────────

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -2541,18 +2541,18 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
         [TestMethod]
-        public void DeleteSavedQuery_removes_record_if_owner()
+        public async Task DeleteSavedQuery_removes_record_if_owner()
         {
             var controller = CreateController();
             controller.Wtm.LoginUserInfo.ITCode = "userA";
-            
+
             var id = Guid.NewGuid();
             controller.Wtm.DC.Set<AnalysisSavedQuery>().Add(
                 new AnalysisSavedQuery { ID = id, Name = "Test", ListVmType = "VM", OwnerCode = "userA", ConfigJson = "{}" }
             );
             controller.Wtm.DC.SaveChanges();
 
-            var result = controller.DeleteSavedQuery(id) as NoContentResult;
+            var result = await controller.DeleteSavedQuery(id) as NoContentResult;
             Assert.IsNotNull(result);
 
             var query = controller.Wtm.DC.Set<AnalysisSavedQuery>().FirstOrDefault(q => q.ID == id);
@@ -2560,18 +2560,18 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
         [TestMethod]
-        public void DeleteSavedQuery_returns_403_if_not_owner()
+        public async Task DeleteSavedQuery_returns_403_if_not_owner()
         {
             var controller = CreateController();
             controller.Wtm.LoginUserInfo.ITCode = "userA";
-            
+
             var id = Guid.NewGuid();
             controller.Wtm.DC.Set<AnalysisSavedQuery>().Add(
                 new AnalysisSavedQuery { ID = id, Name = "Test", ListVmType = "VM", OwnerCode = "userB", ConfigJson = "{}" }
             );
             controller.Wtm.DC.SaveChanges();
 
-            var result = controller.DeleteSavedQuery(id) as ForbidResult;
+            var result = await controller.DeleteSavedQuery(id) as ForbidResult;
             Assert.IsNotNull(result, "刪除他人查詢應回傳 403 Forbid");
 
             var query = controller.Wtm.DC.Set<AnalysisSavedQuery>().FirstOrDefault(q => q.ID == id);


### PR DESCRIPTION
## Summary
Replace the Load → ownership check → Remove → SaveChanges pattern with EF Core `ExecuteDeleteAsync` for `AnalysisSavedQuery` deletion.

### Before (3 DB round-trips)
```csharp
var entity = DC.Set<T>().FirstOrDefault(q => q.ID == id);  // SELECT
if (entity.OwnerCode != userCode) return Forbid();
DC.Set<T>().Remove(entity);
DC.SaveChanges();                                           // DELETE
```

### After (1 DB round-trip in happy path)
```csharp
var deleted = await DC.Set<T>()
    .Where(q => q.ID == id && q.OwnerCode == userCode)
    .ExecuteDeleteAsync();                                  // DELETE WHERE
if (deleted == 0) { /* distinguish 404 vs 403 */ }
```

Also converts sync `IActionResult` to `async Task<IActionResult>`.

## Test plan
- [ ] CI build + all tests pass
- [ ] Existing SavedQuery CRUD tests cover this path

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)