### PR TITLE
refactor(core): inject TimeProvider via WTMContext for testable time

### DIFF
--- a/src/WalkingTec.Mvvm.Core/BaseCRUDVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BaseCRUDVM.cs
@@ -458,7 +458,7 @@ namespace WalkingTec.Mvvm.Core
                 IBasePoco ent = (Entity as IBasePoco)!;
                 if (ent.CreateTime == null)
                 {
-                    ent.CreateTime = DateTime.Now;
+                    ent.CreateTime = Wtm!.TimeProvider.GetLocalNow().DateTime;
                 }
                 if (string.IsNullOrEmpty(ent.CreateBy))
                 {
@@ -543,7 +543,7 @@ namespace WalkingTec.Mvvm.Core
                                     IBasePoco ent = (newitem as IBasePoco)!;
                                     if (ent.CreateTime == null)
                                     {
-                                        ent.CreateTime = DateTime.Now;
+                                        ent.CreateTime = Wtm!.TimeProvider.GetLocalNow().DateTime;
                                     }
                                     if (string.IsNullOrEmpty(ent.CreateBy))
                                     {
@@ -642,7 +642,7 @@ namespace WalkingTec.Mvvm.Core
                 IBasePoco ent = (Entity as IBasePoco)!;
                 //if (ent.UpdateTime == null)
                 //{
-                ent.UpdateTime = DateTime.Now;
+                ent.UpdateTime = Wtm!.TimeProvider.GetLocalNow().DateTime;
                 //}
                 //if (string.IsNullOrEmpty(ent.UpdateBy))
                 //{
@@ -705,7 +705,7 @@ namespace WalkingTec.Mvvm.Core
                                     IBasePoco ent = (newitem as IBasePoco)!;
                                     if (ent.UpdateTime == null)
                                     {
-                                        ent.UpdateTime = DateTime.Now;
+                                        ent.UpdateTime = Wtm!.TimeProvider.GetLocalNow().DateTime;
                                     }
                                     if (string.IsNullOrEmpty(ent.UpdateBy))
                                     {
@@ -811,7 +811,7 @@ namespace WalkingTec.Mvvm.Core
                                     (item as IPersistPoco)!.IsValid = false;
                                     if (typeof(IBasePoco).IsAssignableFrom(ftype))
                                     {
-                                        (item as IBasePoco)!.UpdateTime = DateTime.Now;
+                                        (item as IBasePoco)!.UpdateTime = Wtm!.TimeProvider.GetLocalNow().DateTime;
                                         (item as IBasePoco)!.UpdateBy = LoginUserInfo?.ITCode;
                                     }
                                     dynamic i = item;
@@ -838,7 +838,7 @@ namespace WalkingTec.Mvvm.Core
                                     IBasePoco ent = (item as IBasePoco)!;
                                     if (ent.CreateTime == null)
                                     {
-                                        ent.CreateTime = DateTime.Now;
+                                        ent.CreateTime = Wtm!.TimeProvider.GetLocalNow().DateTime;
                                     }
                                     if (string.IsNullOrEmpty(ent.CreateBy))
                                     {
@@ -884,7 +884,7 @@ namespace WalkingTec.Mvvm.Core
                                     (item as IPersistPoco)!.IsValid = false;
                                     if (typeof(IBasePoco).IsAssignableFrom(ftype))
                                     {
-                                        (item as IBasePoco)!.UpdateTime = DateTime.Now;
+                                        (item as IBasePoco)!.UpdateTime = Wtm!.TimeProvider.GetLocalNow().DateTime;
                                         (item as IBasePoco)!.UpdateBy = LoginUserInfo?.ITCode;
                                     }
                                     dynamic i = item;
@@ -1199,7 +1199,7 @@ namespace WalkingTec.Mvvm.Core
                 EntityType = typeof(TModel).FullName ?? typeof(TModel).Name,
                 EntityId   = Entity?.GetID()?.ToString(),
                 ChangedBy  = LoginUserInfo?.ITCode,
-                ChangedAt  = DateTime.UtcNow,
+                ChangedAt  = Wtm!.TimeProvider.GetUtcNow().DateTime,
                 OldValues  = oldJson,
                 NewValues  = newJson,
             });

--- a/src/WalkingTec.Mvvm.Core/WTMContext.cs
+++ b/src/WalkingTec.Mvvm.Core/WTMContext.cs
@@ -47,6 +47,13 @@ namespace WalkingTec.Mvvm.Core
         private IUIService? _uiservice;
         public IUIService? UIService { get => _uiservice; }
 
+        private readonly TimeProvider _timeProvider;
+        /// <summary>
+        /// 提供可測試的時間來源，取代直接使用 DateTime.Now/UtcNow。
+        /// 預設為 TimeProvider.System；測試可注入 FakeTimeProvider。
+        /// </summary>
+        public TimeProvider TimeProvider => _timeProvider;
+
         private IDistributedCache? _cache;
         public IDistributedCache? Cache { get { return _cache; } }
 
@@ -494,8 +501,9 @@ namespace WalkingTec.Mvvm.Core
             }
         }
 
-        public WTMContext(IOptionsMonitor<Configs>? _config, GlobalData? _gd = null, IHttpContextAccessor? _http = null, IUIService? _ui = null, List<IDataPrivilege>? _dp = null, IDataContext? dc = null, IStringLocalizerFactory? stringLocalizer = null, ILoggerFactory? loggerFactory = null, WtmLocalizationOption? lop = null, IDistributedCache? cache = null, IServiceProvider? sp=null)
+        public WTMContext(IOptionsMonitor<Configs>? _config, GlobalData? _gd = null, IHttpContextAccessor? _http = null, IUIService? _ui = null, List<IDataPrivilege>? _dp = null, IDataContext? dc = null, IStringLocalizerFactory? stringLocalizer = null, ILoggerFactory? loggerFactory = null, WtmLocalizationOption? lop = null, IDistributedCache? cache = null, IServiceProvider? sp=null, TimeProvider? timeProvider = null)
         {
+            _timeProvider = timeProvider ?? TimeProvider.System;
             _configInfo = _config?.CurrentValue ?? new Configs();
             _globaInfo = _gd ?? new GlobalData();
             _httpContext = _http?.HttpContext;
@@ -1063,7 +1071,7 @@ params string[] groupcode)
                 log = new ActionLog();
             }
             log.LogType = logtype;
-            log.ActionTime = DateTime.Now;
+            log.ActionTime = _timeProvider.GetLocalNow().DateTime;
             log.Remark = msg;
             log.ActionUrl = url;
             log.Duration = duration;

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -524,6 +524,7 @@ namespace WalkingTec.Mvvm.Mvc
             WtmFileProvider._subDirFunc = op.FileSubDirSelector;
             WTMContext.ReloadUserFunc = op.ReloadUserFunc;
             services.TryAddScoped<IDataContext, NullContext>();
+            services.TryAddSingleton(TimeProvider.System);
             services.AddScoped<WTMContext>();
             services.AddScoped<WtmFileProvider>();
             services.Configure<FormOptions>(y =>


### PR DESCRIPTION
## Summary
Add `TimeProvider` to `WTMContext` for deterministic, testable time access.

### Changes
- **WTMContext**: New `TimeProvider` property + constructor parameter (defaults to `TimeProvider.System`)
- **FrameworkServiceExtension**: Register `TimeProvider.System` as singleton
- **BaseCRUDVM**: Replace 8 `DateTime.Now/UtcNow` calls with `Wtm!.TimeProvider`
  - `CreateTime` (3 locations), `UpdateTime` (4 locations), `ChangedAt` (1 location)
- **WTMContext.DoLog()**: `ActionTime` uses TimeProvider

### Remaining (follow-up)
42 occurrences in 18 other files (DateRange, BaseImportVM, TokenService, etc.) — deferred to separate issue.

## Test plan
- [ ] CI build + all tests pass
- [ ] Existing CRUD tests cover CreateTime/UpdateTime paths

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)