### PR TITLE
refactor(core): collection expressions for Analysis DTOs and core VMs

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryRequest.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryRequest.cs
@@ -15,13 +15,13 @@ namespace WalkingTec.Mvvm.Core.Analysis
         public string? SearcherFormData { get; set; }
 
         /// <summary>選取的維度欄位名稱（最多 3 個）。</summary>
-        public List<string> Dimensions { get; set; } = new List<string>();
+        public List<string> Dimensions { get; set; } = [];
 
         /// <summary>選取的度量及聚合函式。</summary>
-        public List<MeasureRequest> Measures { get; set; } = new List<MeasureRequest>();
+        public List<MeasureRequest> Measures { get; set; } = [];
 
         /// <summary>額外過濾條件（白名單驗證後進 Expression Tree）。</summary>
-        public List<FilterCondition> Filters { get; set; } = new List<FilterCondition>();
+        public List<FilterCondition> Filters { get; set; } = [];
 
         /// <summary>維度對應的日期階層（僅日期維度需要，key=fieldName, value=hierarchy）</summary>
         public Dictionary<string, DateHierarchy>? DimensionHierarchies { get; set; }

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryResponse.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryResponse.cs
@@ -9,10 +9,10 @@ namespace WalkingTec.Mvvm.Core.Analysis
     public class AnalysisQueryResponse
     {
         /// <summary>欄位名稱清單（有序，對應 Rows 中的 key）。</summary>
-        public List<string> Columns { get; set; } = new List<string>();
+        public List<string> Columns { get; set; } = [];
 
         /// <summary>資料列（每列為 欄位名→值 的字典）。</summary>
-        public List<Dictionary<string, object?>> Rows { get; set; } = new List<Dictionary<string, object?>>();
+        public List<Dictionary<string, object?>> Rows { get; set; } = [];
 
         /// <summary>GroupBy 後總筆數。</summary>
         public int TotalCount { get; set; }

--- a/src/WalkingTec.Mvvm.Core/Analysis/ServerSideGroupByStrategy.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/ServerSideGroupByStrategy.cs
@@ -26,7 +26,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
             CancellationToken cancellationToken = default)
         {
             if (req.Dimensions.Count == 0)
-                return new List<Dictionary<string, object?>>();
+                return [];
 
             if (req.DimensionHierarchies != null && req.Dimensions.Any(d => req.DimensionHierarchies.TryGetValue(d, out var h) && h != DateHierarchy.None))
             {
@@ -51,7 +51,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
             CancellationToken cancellationToken = default)
         {
             if (req.Dimensions.Count == 0)
-                return new List<Dictionary<string, object?>>();
+                return [];
 
             if (req.DimensionHierarchies != null && req.Dimensions.Any(d => req.DimensionHierarchies.TryGetValue(d, out var h) && h != DateHierarchy.None))
             {

--- a/src/WalkingTec.Mvvm.Core/BasePagedListVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BasePagedListVM.cs
@@ -423,7 +423,7 @@ namespace WalkingTec.Mvvm.Core
         /// <summary>
         ///记录批量操作时列表中选择的Id
         /// </summary>
-        public List<string> Ids { get; set; } = new List<string>();
+        public List<string> Ids { get; set; } = [];
         public string? SelectorValueField { get; set; }
         /// <summary>
         /// 是否已经搜索过


### PR DESCRIPTION
## Summary
Replace `new List<T>()` property initializers with C# 12 collection expressions `[]`.

### Files changed
- `AnalysisQueryRequest.cs` — Dimensions, Measures, Filters (3 properties)
- `AnalysisQueryResponse.cs` — Columns, Rows (2 properties)
- `ServerSideGroupByStrategy.cs` — empty list returns (2 locations)
- `BasePagedListVM.cs` — Ids (1 property)

### Not changed (intentional)
- Dictionary initializers — `[]` doesn't support dictionaries
- Local variables with `var` — collection expressions need explicit target type
- TagHelper/UI code — readability concern per plan

## Test plan
- [ ] CI passes (pure syntax sugar, zero behavior change)

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)