### PR TITLE
fix(analysis): enforce RBAC checks for saved query endpoints

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs
@@ -304,6 +304,12 @@ result = await _engine.ExecutePivotDynamicAsync(ctx!.BaseQuery, req, ctx.Fields,
             if (string.IsNullOrWhiteSpace(listVmType))
                 return BadRequest("listVmType is required.");
 
+            Type vmType;
+            try { vmType = _registry.Resolve(listVmType); }
+            catch (AnalysisVmNotFoundException ex) { return NotFound(ex.Message); }
+            catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
+            if (!CheckAccess(vmType)) return Forbid();
+
             var userCode = Wtm?.LoginUserInfo?.ITCode ?? string.Empty;
 
             var rows = Wtm!.DC.Set<AnalysisSavedQuery>()
@@ -337,8 +343,11 @@ result = await _engine.ExecutePivotDynamicAsync(ctx!.BaseQuery, req, ctx.Fields,
             if (string.IsNullOrWhiteSpace(req.Name)) return BadRequest("查詢名稱不可為空。");
             if (string.IsNullOrWhiteSpace(req.Config?.ListVmType)) return BadRequest("Config.ListVmType is required.");
 
-            try { _registry.Resolve(req.Config.ListVmType); }
+            Type vmType;
+            try { vmType = _registry.Resolve(req.Config.ListVmType); }
             catch (AnalysisVmNotFoundException ex) { return NotFound(ex.Message); }
+            catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
+            if (!CheckAccess(vmType)) return Forbid();
 
             var userCode = Wtm?.LoginUserInfo?.ITCode ?? string.Empty;
             var configJson = JsonSerializer.Serialize(req.Config, _camelCase);
@@ -385,6 +394,11 @@ result = await _engine.ExecutePivotDynamicAsync(ctx!.BaseQuery, req, ctx.Fields,
             catch (JsonException) { return BadRequest("儲存的查詢格式無效。"); }
 
             if (config == null) return BadRequest("儲存的查詢格式無效。");
+            Type vmType;
+            try { vmType = _registry.Resolve(config.ListVmType); }
+            catch (AnalysisVmNotFoundException ex) { return NotFound(ex.Message); }
+            catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
+            if (!CheckAccess(vmType)) return Forbid();
 
             return new JsonResult(config, _camelCase);
         }

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisControllerTests.cs
@@ -2497,6 +2497,36 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
         }
 
         [TestMethod]
+        public void ListSavedQueries_returns_403_when_user_lacks_required_role()
+        {
+            var controller = CreateControllerWithRoles("Viewer");
+            var vmType = typeof(RestrictedSaleListVM).FullName;
+
+            var result = controller.ListSavedQueries(vmType);
+            Assert.IsInstanceOfType(result, typeof(ForbidResult));
+        }
+
+        [TestMethod]
+        public void SaveQuery_returns_403_when_user_lacks_required_role()
+        {
+            var controller = CreateControllerWithRoles("Viewer");
+            var req = new SaveQueryRequest
+            {
+                Name = "Restricted",
+                IsPublic = false,
+                Config = new AnalysisQueryRequest
+                {
+                    ListVmType = typeof(RestrictedSaleListVM).FullName,
+                    Dimensions = new List<string> { "Region" },
+                    Measures = new List<MeasureRequest> { new MeasureRequest { Field = "Amount", Func = AggregateFunc.Sum } }
+                }
+            };
+
+            var result = controller.SaveQuery(req);
+            Assert.IsInstanceOfType(result, typeof(ForbidResult));
+        }
+
+        [TestMethod]
         public void GetSavedQuery_returns_config_for_authorized_user()
         {
             var controller = CreateController();
@@ -2538,6 +2568,30 @@ namespace WalkingTec.Mvvm.Core.Test.Analysis
 
             var result = controller.GetSavedQuery(id) as ForbidResult;
             Assert.IsNotNull(result, "存取他人的私有查詢應回傳 403 Forbid");
+        }
+
+        [TestMethod]
+        public void GetSavedQuery_returns_403_when_public_query_vm_is_role_restricted()
+        {
+            var controller = CreateControllerWithRoles("Viewer");
+            controller.Wtm.LoginUserInfo.ITCode = "userA";
+            var id = Guid.NewGuid();
+            var vmType = typeof(RestrictedSaleListVM).FullName;
+            controller.Wtm.DC.Set<AnalysisSavedQuery>().Add(
+                new AnalysisSavedQuery
+                {
+                    ID = id,
+                    Name = "RestrictedPublic",
+                    ListVmType = vmType,
+                    OwnerCode = "userB",
+                    IsPublic = true,
+                    ConfigJson = "{\"listVmType\":\"" + vmType + "\"}"
+                }
+            );
+            controller.Wtm.DC.SaveChanges();
+
+            var result = controller.GetSavedQuery(id);
+            Assert.IsInstanceOfType(result, typeof(ForbidResult));
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- enforce `Resolve + CheckAccess` in analysis saved-query endpoints (`ListSavedQueries`, `SaveQuery`, `GetSavedQuery`)
- keep existing endpoint behavior for invalid VM / invalid config by returning `NotFound` or `BadRequest`
- add regression tests for forbidden access on role-restricted VM types

## Why
Saved-query endpoints introduced in #684 did not run the same VM RBAC gate used by query/export flows, allowing unauthorized users to interact with restricted VM saved queries.

## Testing
- Attempted: `dotnet test test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj --filter "FullyQualifiedName~AnalysisControllerTests"`
- Blocked in this environment by offline NuGet restore (`NU1301` to `https://api.nuget.org/v3/index.json`)

Closes #709
