### PR TITLE
refactor(core): TimeProvider migration Phase 3 — Services, ETL, DateRange

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
+++ b/src/WalkingTec.Mvvm.Core/Dashboard/JsonFileDashboardService.cs
@@ -17,6 +17,7 @@ public class JsonFileDashboardService : IDashboardService
     private readonly DashboardOptions _options;
     private readonly IEnumerable<IWidgetDataSource> _dataSources;
     private readonly ILogger<JsonFileDashboardService> _logger;
+    private readonly TimeProvider _timeProvider;
     private readonly ConcurrentDictionary<string, DashboardSummary> _index = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
     private readonly string _baseDir;
@@ -26,11 +27,13 @@ public class JsonFileDashboardService : IDashboardService
     public JsonFileDashboardService(
         IOptions<DashboardOptions> options,
         IEnumerable<IWidgetDataSource> dataSources,
-        ILogger<JsonFileDashboardService> logger)
+        ILogger<JsonFileDashboardService> logger,
+        TimeProvider? timeProvider = null)
     {
         _options = options.Value;
         _dataSources = dataSources;
         _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
         _baseDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, _options.DashboardDirectory);
 
         logger.LogWarning(
@@ -184,7 +187,7 @@ public class JsonFileDashboardService : IDashboardService
             dashboard.Id = Guid.NewGuid().ToString("N");
         }
 
-        dashboard.CreatedAt = DateTime.UtcNow;
+        dashboard.CreatedAt = _timeProvider.GetUtcNow().UtcDateTime;
         dashboard.UpdatedAt = dashboard.CreatedAt;
 
         var path = GetFilePath(dashboard.Id, dashboard.TenantId);
@@ -241,7 +244,7 @@ public class JsonFileDashboardService : IDashboardService
             throw new ArgumentException("Dashboard ID cannot be null or empty.", nameof(dashboard));
         }
 
-        dashboard.UpdatedAt = DateTime.UtcNow;
+        dashboard.UpdatedAt = _timeProvider.GetUtcNow().UtcDateTime;
 
         var path = GetFilePath(dashboard.Id, dashboard.TenantId);
         var lockObj = GetLock(dashboard.Id);

--- a/src/WalkingTec.Mvvm.Core/DataContext.cs
+++ b/src/WalkingTec.Mvvm.Core/DataContext.cs
@@ -448,6 +448,11 @@ namespace WalkingTec.Mvvm.Core
 
         public DBTypeEnum DBType { get; set; }
 
+        /// <summary>
+        /// 可測試的時間來源。預設 TimeProvider.System。
+        /// </summary>
+        public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
         public string? Version { get; set; }
         public CS ConnectionString { get; set; } = null!;
         public DbSet<AnalysisSavedQuery> AnalysisSavedQueries { get; set; } = null!;
@@ -879,14 +884,14 @@ namespace WalkingTec.Mvvm.Core
                     {
                         case EntityState.Added:
                             if (entity.CreateTime == null)
-                                entity.CreateTime = DateTime.Now;
+                                entity.CreateTime = TimeProvider.GetLocalNow().DateTime;
                             if (string.IsNullOrEmpty(entity.CreateBy))
                                 entity.CreateBy = CurrentUserCode;
                             break;
 
                         case EntityState.Modified:
                             if (entity.UpdateTime == null)
-                                entity.UpdateTime = DateTime.Now;
+                                entity.UpdateTime = TimeProvider.GetLocalNow().DateTime;
                             if (string.IsNullOrEmpty(entity.UpdateBy))
                                 entity.UpdateBy = CurrentUserCode;
                             break;

--- a/src/WalkingTec.Mvvm.Core/Support/DateRange.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/DateRange.cs
@@ -276,59 +276,52 @@ namespace WalkingTec.Mvvm.Core
 
         public static DateRange UtcDefault => UtcToday;
 
-        public static DateRange UtcNinetyDays
+        /// <summary>UTC 過去 90 天。</summary>
+        public static DateRange UtcNinetyDays => CreateUtcNinetyDays();
+        public static DateRange CreateUtcNinetyDays(TimeProvider? timeProvider = null)
         {
-            get
-            {
-                var result = new DateRange(DateTime.UtcNow.Date.AddDays(-90), DateTime.UtcNow.Date);
-                return result;
-            }
+            var today = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime.Date;
+            return new DateRange(today.AddDays(-90), today);
         }
 
-        public static DateRange UtcThirtyDays
+        /// <summary>UTC 過去 30 天。</summary>
+        public static DateRange UtcThirtyDays => CreateUtcThirtyDays();
+        public static DateRange CreateUtcThirtyDays(TimeProvider? timeProvider = null)
         {
-            get
-            {
-                var result = new DateRange(DateTime.UtcNow.Date.AddDays(-30), DateTime.UtcNow.Date, DefaultType, UtCDefaultEpoch);
-                return result;
-            }
+            var today = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime.Date;
+            return new DateRange(today.AddDays(-30), today, DefaultType, UtCDefaultEpoch);
         }
 
-        public static DateRange UtcTwoWeek
+        /// <summary>UTC 過去 14 天。</summary>
+        public static DateRange UtcTwoWeek => CreateUtcTwoWeek();
+        public static DateRange CreateUtcTwoWeek(TimeProvider? timeProvider = null)
         {
-            get
-            {
-                var result = new DateRange(DateTime.UtcNow.Date.AddDays(-14), DateTime.UtcNow.Date, DefaultType, UtCDefaultEpoch);
-                return result;
-            }
+            var today = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime.Date;
+            return new DateRange(today.AddDays(-14), today, DefaultType, UtCDefaultEpoch);
         }
 
-        public static DateRange UtcWeek
+        /// <summary>UTC 過去 7 天。</summary>
+        public static DateRange UtcWeek => CreateUtcWeek();
+        public static DateRange CreateUtcWeek(TimeProvider? timeProvider = null)
         {
-            get
-            {
-                var result = new DateRange(DateTime.UtcNow.Date.AddDays(-7), DateTime.UtcNow.Date, DefaultType, UtCDefaultEpoch);
-                return result;
-            }
-
+            var today = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime.Date;
+            return new DateRange(today.AddDays(-7), today, DefaultType, UtCDefaultEpoch);
         }
 
-        public static DateRange UtcToday
+        /// <summary>UTC 昨天到今天。</summary>
+        public static DateRange UtcToday => CreateUtcToday();
+        public static DateRange CreateUtcToday(TimeProvider? timeProvider = null)
         {
-            get
-            {
-                var result = new DateRange(DateTime.UtcNow.Date.AddDays(-1), DateTime.UtcNow.Date, DefaultType, UtCDefaultEpoch);
-                return result;
-            }
+            var today = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime.Date;
+            return new DateRange(today.AddDays(-1), today, DefaultType, UtCDefaultEpoch);
         }
 
-        public static DateRange UtcYesterday
+        /// <summary>UTC 昨天。</summary>
+        public static DateRange UtcYesterday => CreateUtcYesterday();
+        public static DateRange CreateUtcYesterday(TimeProvider? timeProvider = null)
         {
-            get
-            {
-                var result = new DateRange(DateTime.UtcNow.Date.AddDays(-1), DateTime.UtcNow.Date, DefaultType, UtCDefaultEpoch);
-                return result;
-            }
+            var today = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime.Date;
+            return new DateRange(today.AddDays(-1), today, DefaultType, UtCDefaultEpoch);
         }
 
 

--- a/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmDataBaseFileHandler.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmDataBaseFileHandler.cs
@@ -35,7 +35,7 @@ namespace WalkingTec.Mvvm.Core.Support.FileHandlers
             FileAttachment file = new FileAttachment();
             file.FileName = fileName;
             file.Length = fileLength;
-            file.UploadTime = DateTime.Now;
+            file.UploadTime = wtm.TimeProvider.GetLocalNow().DateTime;
             file.SaveMode = _modeName;
             file.ExtraInfo = extra;
             file.TenantCode = wtm.LoginUserInfo?.CurrentTenant;

--- a/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmFileProvider.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmFileProvider.cs
@@ -113,7 +113,7 @@ namespace WalkingTec.Mvvm.Core.Support.FileHandlers
                     FileAttachment file = new FileAttachment();
                     file.FileName = fileName;
                     file.Length = fileLength;
-                    file.UploadTime = DateTime.Now;
+                    file.UploadTime = _wtm.TimeProvider.GetLocalNow().DateTime;
                     file.SaveMode = string.IsNullOrEmpty(saveMode) == true ? _wtm.ConfigInfo.FileUploadOptions.SaveFileMode! : saveMode;
                     file.ExtraInfo = extra;
                     var ext = string.Empty;

--- a/src/WalkingTec.Mvvm.Core/Support/WTMLogger.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/WTMLogger.cs
@@ -100,11 +100,12 @@ namespace WalkingTec.Mvvm.Core
                         ll = ActionLogTypesEnum.Exception;
                     }
 
+                    var now = (sp.GetService<TimeProvider>() ?? TimeProvider.System).GetLocalNow().DateTime;
                     log = new ActionLog
                     {
                         Remark = formatter?.Invoke(state, exception),
-                        CreateTime = DateTime.Now,
-                        ActionTime = DateTime.Now,
+                        CreateTime = now,
+                        ActionTime = now,
                         ActionName = "WtmLog",
                         ModuleName = "WtmLog",
                         LogType = ll

--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlQuartzJob.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlQuartzJob.cs
@@ -54,8 +54,8 @@ public class EtlQuartzJob : WtmJob
                 JobId = jobDefId,
                 Trigger = trigger,
                 Result = EtlRunResult.Skipped,
-                StartedAt = DateTime.UtcNow,
-                FinishedAt = DateTime.UtcNow
+                StartedAt = Wtm.TimeProvider.GetUtcNow().UtcDateTime,
+                FinishedAt = Wtm.TimeProvider.GetUtcNow().UtcDateTime
             });
 
             await dc.SaveChangesAsync();
@@ -71,7 +71,7 @@ public class EtlQuartzJob : WtmJob
         dc.Set<EtlJobDefinition>().Update(jobDef);
         await dc.SaveChangesAsync();
 
-        var startedAt = DateTime.UtcNow;
+        var startedAt = Wtm.TimeProvider.GetUtcNow().UtcDateTime;
 
         // 建立超時 CancellationToken（連結 Quartz 的 CancellationToken 以支援中止）
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
@@ -140,7 +140,7 @@ public class EtlQuartzJob : WtmJob
             if (result.Success)
             {
                 jobDef.LastWatermarkValue = result.NewWatermarkValue;
-                jobDef.LastRunAt = DateTime.UtcNow;
+                jobDef.LastRunAt = Wtm.TimeProvider.GetUtcNow().UtcDateTime;
                 jobDef.LastError = null;
                 jobDef.Status = EtlJobStatus.Enabled;
                 jobDef.ConsecutiveFailureCount = 0;  // reset on success
@@ -164,7 +164,7 @@ public class EtlQuartzJob : WtmJob
             {
                 Success = false,
                 ErrorMessage = sanitized,
-                ElapsedMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds
+                ElapsedMs = (long)(Wtm.TimeProvider.GetUtcNow().UtcDateTime - startedAt).TotalMilliseconds
             };
 
             var currentAttempt = context.MergedJobDataMap.ContainsKey("_retryAttempt")
@@ -207,7 +207,7 @@ public class EtlQuartzJob : WtmJob
                 ElapsedMs = result?.ElapsedMs ?? 0,
                 ErrorMessage = result?.ErrorMessage,
                 StartedAt = startedAt,
-                FinishedAt = DateTime.UtcNow,
+                FinishedAt = Wtm.TimeProvider.GetUtcNow().UtcDateTime,
                 WatermarkSnapshot = jobDef.LastWatermarkValue
             };
             dc.Set<EtlRunLog>().Add(runLog);

--- a/src/WalkingTec.Mvvm.Etl/Scheduling/EtlSchedulerService.cs
+++ b/src/WalkingTec.Mvvm.Etl/Scheduling/EtlSchedulerService.cs
@@ -42,7 +42,7 @@ public class EtlSchedulerService
 
         if (ghostJobs.Count == 0) return;
 
-        var now = DateTime.UtcNow;
+        var now = (_sp.GetService<TimeProvider>() ?? TimeProvider.System).GetUtcNow().UtcDateTime;
         foreach (var job in ghostJobs)
         {
             job.Status = EtlJobStatus.Failed;

--- a/src/WalkingTec.Mvvm.Mvc/Filters/FrameworkFilter.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Filters/FrameworkFilter.cs
@@ -377,7 +377,7 @@ namespace WalkingTec.Mvvm.Mvc.Filters
                 var postDes = ctrlActDesc.MethodInfo.GetCustomAttributes(typeof(HttpPostAttribute), false).Cast<HttpPostAttribute>().FirstOrDefault();
 
                 log.LogType = context.Exception == null ? ActionLogTypesEnum.Normal : ActionLogTypesEnum.Exception;
-                log.ActionTime = ctrl.Wtm?.TimeProvider.GetLocalNow().DateTime ?? DateTime.Now;
+                log.ActionTime = (ctrl.Wtm?.TimeProvider ?? TimeProvider.System).GetLocalNow().DateTime;
                 log.ITCode = ctrl.Wtm?.LoginUserInfo?.ITCode ?? string.Empty;
                 // 给日志的多语言属性赋值
                 log.ModuleName = ctrlDes?.GetDescription(ctrl) ?? ctrlActDesc.ControllerName;
@@ -392,7 +392,7 @@ namespace WalkingTec.Mvvm.Mvc.Filters
                 var starttime = context.HttpContext.Items["actionstarttime"] as DateTime?;
                 if (starttime != null)
                 {
-                    log.Duration = (ctrl.Wtm?.TimeProvider.GetLocalNow().DateTime ?? DateTime.Now).Subtract(starttime.Value).TotalSeconds;
+                    log.Duration = (ctrl.Wtm?.TimeProvider ?? TimeProvider.System).GetLocalNow().DateTime.Subtract(starttime.Value).TotalSeconds;
                 }
                 try
                 {


### PR DESCRIPTION
## Summary

- Migrate remaining `DateTime.Now`/`UtcNow` to `TimeProvider` across 9 files (Core services, ETL, DateRange, FrameworkFilter cleanup)
- `EmptyContext` (DataContext base): new `TimeProvider` property for `ApplyAuditFields()`
- `JsonFileDashboardService`: constructor-injected `TimeProvider`
- `DateRange`: 6 new `CreateUtc*()` factory methods with optional `TimeProvider?` param — existing static properties preserved as backward-compatible wrappers
- Clean up Phase 2 FrameworkFilter fallbacks (`?? DateTime.Now` → `?? TimeProvider.System`)

## Skipped (by design)

- `AnalysisExcelExporter` — static class, display timestamp only
- `LoginUserInfo.TimeTick` — property initializer, no DI
- `DashboardDefinition` property initializers — no DI at construction
- `EtlPipelineExecutor` — progress reporting only
- `QuartzHostService` — Quartz trigger API
- `.cshtml`, `TypeExtension`, codegen templates — unchanged from Phase 2

## Test plan

- [x] `dotnet build -c Release` — 0 new errors (BlazorDemo pre-existing)
- [x] Core tests: 1101 passed
- [x] Admin tests: 75 passed
- [x] ETL tests: 174 passed (17 skipped)
- [x] Total: 1350 passed, 0 failed

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)