### PR TITLE
ci(nuget): switch smoke test to local nupkg source

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -66,48 +66,17 @@ jobs:
             --source ${{ env.PACKAGE_SOURCE }} \
             --skip-duplicate
 
-      - name: Setup NuGet source for smoke test
-        run: |
-          dotnet nuget add source "${{ env.PACKAGE_SOURCE }}" \
-            --name github-wtm \
-            --username "${{ github.actor }}" \
-            --password "${{ secrets.GITHUB_TOKEN }}" \
-            --store-password-in-clear-text
-
-      - name: Wait for package visibility
-        env:
-          PKG_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-          attempts=10
-          delay=15
-          for i in $(seq 1 $attempts); do
-            result="$(dotnet package search WalkingTec.Mvvm.Core \
-              --source "${{ env.PACKAGE_SOURCE }}" \
-              --exact-match \
-              --format json)"
-            if python3 -c 'import json, sys; payload = json.loads(sys.argv[1] or "{}"); version = sys.argv[2]; raise SystemExit(0 if any(item.get("version") == version for search_result in payload.get("searchResult", []) for package in search_result.get("packages", []) for item in package.get("versions", [])) else 1)' "$result" "$PKG_VERSION"
-            then
-              echo "Package version $PKG_VERSION is visible in feed."
-              exit 0
-            fi
-            echo "Package version $PKG_VERSION not visible yet (attempt $i/$attempts)."
-            sleep "$delay"
-          done
-          echo "Package version $PKG_VERSION did not become visible in time." >&2
-          exit 1
-
       - name: Smoke test package install
         env:
           PKG_VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          mkdir smoke
-          cd smoke
+          mkdir smoke && cd smoke
           dotnet new console --framework net10.0
-          dotnet add package WalkingTec.Mvvm.Core --version "$PKG_VERSION" --source "${{ env.PACKAGE_SOURCE }}"
-          dotnet add package WalkingTec.Mvvm.Mvc --version "$PKG_VERSION" --source "${{ env.PACKAGE_SOURCE }}"
-          dotnet add package WalkingTec.Mvvm.TagHelpers.LayUI --version "$PKG_VERSION" --source "${{ env.PACKAGE_SOURCE }}"
+          dotnet nuget add source "${{ github.workspace }}/nupkgs" --name local-nupkgs
+          dotnet add package WalkingTec.Mvvm.Core --version "$PKG_VERSION" --source local-nupkgs
+          dotnet add package WalkingTec.Mvvm.Mvc --version "$PKG_VERSION" --source local-nupkgs
+          dotnet add package WalkingTec.Mvvm.TagHelpers.LayUI --version "$PKG_VERSION" --source local-nupkgs
           dotnet restore
           dotnet build -c Release --no-restore
 


### PR DESCRIPTION
## Summary
- Remove flaky "Setup NuGet source for smoke test" and "Wait for package visibility" steps from publish-nuget workflow
- Smoke test now installs packages directly from local `./nupkgs` directory instead of polling the GitHub Packages feed
- "Upload .nupkg to release assets" step remains unchanged

## Test plan
- [ ] Trigger workflow via `workflow_dispatch` and verify smoke test passes using local nupkgs
- [ ] Verify `Push to GitHub Packages` and `Upload .nupkg to release assets` steps still work correctly

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)