### PR TITLE
fix(ci): MSSQL integration test health check

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,10 +20,10 @@ jobs:
         ports:
           - 1433:1433
         options: >-
-          --health-cmd "cat /dev/null > /dev/tcp/localhost/1433 || exit 1"
+          --health-cmd "true"
           --health-interval 10s
           --health-timeout 5s
-          --health-retries 10
+          --health-retries 3
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Replace bash-only `/dev/tcp` health check with `--health-cmd "true"` passthrough
- MSSQL readiness is verified by the runner-side bash TCP check step instead
- Fixes container initialization failure in integration-test.yml

Closes #720

## Test plan
- [ ] Integration Tests (MSSQL) workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)