### PR TITLE
fix(core): propagate WTM time provider to created data contexts

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Models/FrameworkTenant.cs
+++ b/src/WalkingTec.Mvvm.Core/Models/FrameworkTenant.cs
@@ -89,6 +89,10 @@ namespace WalkingTec.Mvvm.Core
                     tenantdc.SetLoggerFactory(wtm.LoggerFactory);
                 }
                 tenantdc.SetTenantCode(this.TCode);
+                if (tenantdc is EmptyContext ec)
+                {
+                    ec.TimeProvider = wtm.TimeProvider;
+                }
                 return tenantdc;
             }
         }

--- a/src/WalkingTec.Mvvm.Core/WTMContext.cs
+++ b/src/WalkingTec.Mvvm.Core/WTMContext.cs
@@ -150,6 +150,7 @@ namespace WalkingTec.Mvvm.Core
             set
             {
                 _dc = value;
+                TrySetDataContextTimeProvider(_dc);
             }
         }
 
@@ -529,8 +530,17 @@ namespace WalkingTec.Mvvm.Core
             else
             {
                 _dc = dc;
+                TrySetDataContextTimeProvider(_dc);
             }
             _serviceProvider = sp;
+        }
+
+        private void TrySetDataContextTimeProvider(IDataContext? dc)
+        {
+            if (dc is EmptyContext ctx)
+            {
+                ctx.TimeProvider = _timeProvider;
+            }
         }
 
         public void SetServiceProvider(IServiceProvider? sp)
@@ -939,6 +949,7 @@ params string[] groupcode)
                 {
                     rv?.SetLoggerFactory(_loggerFactory);
                 }
+                TrySetDataContextTimeProvider(rv);
                 return rv;
             }
             finally

--- a/test/WalkingTec.Mvvm.Core.Test/TimeProviderPropagationTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/TimeProviderPropagationTests.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Core.Test
+{
+    [TestClass]
+    public class TimeProviderPropagationTests
+    {
+        private sealed class FixedTimeProvider : TimeProvider
+        {
+            private readonly DateTimeOffset _utcNow;
+
+            public FixedTimeProvider(DateTimeOffset utcNow)
+            {
+                _utcNow = utcNow;
+            }
+
+            public override DateTimeOffset GetUtcNow() => _utcNow;
+
+            public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Utc;
+        }
+
+        [TestMethod]
+        public void Setting_WtmContext_DC_propagates_TimeProvider_to_EmptyContext()
+        {
+            var fixedProvider = new FixedTimeProvider(new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero));
+            var wtm = new WTMContext(null, new GlobalData(), timeProvider: fixedProvider);
+            var dc = new EmptyContext("Data Source=file:tp_setter?mode=memory&cache=shared", DBTypeEnum.SQLite);
+
+            wtm.DC = dc;
+
+            Assert.AreSame(fixedProvider, dc.TimeProvider);
+            dc.Dispose();
+        }
+
+        [TestMethod]
+        public void FrameworkTenant_CreateDC_propagates_WtmContext_TimeProvider()
+        {
+            var fixedProvider = new FixedTimeProvider(new DateTimeOffset(2031, 6, 7, 8, 9, 10, TimeSpan.Zero));
+            var config = new Configs();
+            var monitor = new Mock<IOptionsMonitor<Configs>>();
+            monitor.Setup(x => x.CurrentValue).Returns(config);
+            var wtm = new WTMContext(monitor.Object, new GlobalData(), timeProvider: fixedProvider);
+            var tenant = new FrameworkTenant
+            {
+                TCode = "TENANT_A",
+                TDb = "Data Source=file:tp_tenant?mode=memory&cache=shared",
+                TDbType = DBTypeEnum.SQLite,
+                DbContext = "DataContext"
+            };
+
+            var dc = tenant.CreateDC(wtm);
+
+            Assert.IsNotNull(dc);
+            Assert.IsInstanceOfType(dc, typeof(EmptyContext));
+            Assert.AreSame(fixedProvider, ((EmptyContext)dc).TimeProvider);
+            dc.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- propagate `WTMContext.TimeProvider` to data contexts assigned via `WTMContext.DC`
- propagate `WTMContext.TimeProvider` when contexts are created via `WTMContext.CreateDC()`
- propagate `WTMContext.TimeProvider` in tenant-specific `FrameworkTenant.CreateDC()` path
- add regression tests for both setter and tenant context creation propagation

## Validation
- `dotnet build test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj -maxcpucount:1 -nodeReuse:false`
- `dotnet test test/WalkingTec.Mvvm.Core.Test/WalkingTec.Mvvm.Core.Test.csproj --filter "TimeProviderPropagationTests" -maxcpucount:1 -nodeReuse:false` *(blocked in sandbox: SocketException (13) Permission denied during VSTest socket bind)*

Closes #722
