### PR TITLE
refactor(core): WTMContext facade delegation + WtmUIOptions (Phase 4-5)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/ConfigOptions/WtmUIOptions.cs
+++ b/src/WalkingTec.Mvvm.Core/ConfigOptions/WtmUIOptions.cs
@@ -1,0 +1,95 @@
+#nullable enable
+namespace WalkingTec.Mvvm.Core.ConfigOptions
+{
+    /// <summary>
+    /// Centralized UI styling options. Provides overridable CSS class names,
+    /// sizing defaults, and rendering options for TagHelpers.
+    /// Consumers configure via <c>services.Configure&lt;WtmUIOptions&gt;(...)</c>.
+    /// All defaults match LayUI classes for zero-config backwards compatibility.
+    /// </summary>
+    public class WtmUIOptions
+    {
+        #region CSS Class Mappings
+
+        /// <summary>Primary button class (e.g. "layui-btn").</summary>
+        public string ButtonPrimaryClass { get; set; } = "layui-btn";
+
+        /// <summary>Small button class (e.g. "layui-btn layui-btn-xs").</summary>
+        public string ButtonSmallClass { get; set; } = "layui-btn layui-btn-xs";
+
+        /// <summary>Danger/delete button class.</summary>
+        public string ButtonDangerClass { get; set; } = "layui-btn layui-btn-danger";
+
+        /// <summary>Warm/warning button class.</summary>
+        public string ButtonWarmClass { get; set; } = "layui-btn layui-btn-warm";
+
+        /// <summary>Form item wrapper class.</summary>
+        public string FormItemClass { get; set; } = "layui-form-item";
+
+        /// <summary>Form label class.</summary>
+        public string FormLabelClass { get; set; } = "layui-form-label";
+
+        /// <summary>Text input class.</summary>
+        public string InputClass { get; set; } = "layui-input";
+
+        /// <summary>Form group/container class.</summary>
+        public string FormGroupClass { get; set; } = "layui-form";
+
+        /// <summary>Disabled element class.</summary>
+        public string DisabledClass { get; set; } = "layui-disabled";
+
+        /// <summary>Table class.</summary>
+        public string TableClass { get; set; } = "layui-table";
+
+        /// <summary>Row container class.</summary>
+        public string RowClass { get; set; } = "layui-row";
+
+        #endregion
+
+        #region Grid System
+
+        /// <summary>Number of grid columns (default 12 for LayUI).</summary>
+        public int GridColumns { get; set; } = 12;
+
+        /// <summary>Column class prefix for medium screens (e.g. "layui-col-md").</summary>
+        public string ColumnMdPrefix { get; set; } = "layui-col-md";
+
+        /// <summary>Column class prefix for small screens.</summary>
+        public string ColumnSmPrefix { get; set; } = "layui-col-sm";
+
+        /// <summary>Column class prefix for extra-small screens.</summary>
+        public string ColumnXsPrefix { get; set; } = "layui-col-xs";
+
+        #endregion
+
+        #region Sizing & Layout
+
+        /// <summary>Default label width in pixels (null = auto).</summary>
+        public int? DefaultLabelWidth { get; set; }
+
+        /// <summary>Margin offset added to input when label has explicit width.</summary>
+        public int LabelMarginOffset { get; set; } = 30;
+
+        /// <summary>Default input height in CSS (e.g. "28px").</summary>
+        public string DefaultInputHeight { get; set; } = "28px";
+
+        #endregion
+
+        #region Required Field Marker
+
+        /// <summary>
+        /// HTML for the required field marker. Default is a red asterisk.
+        /// Override to add icons, screen-reader text, or change styling.
+        /// </summary>
+        public string RequiredMarkerHtml { get; set; } = "<span aria-hidden=\"true\" style=\"color:red\">*</span>";
+
+        #endregion
+
+        #region Accessibility
+
+        /// <summary>Whether to add aria-required="true" to required form fields.</summary>
+        public bool EnableAriaRequired { get; set; } = true;
+
+        #endregion
+    }
+}

--- a/src/WalkingTec.Mvvm.Core/WTMContext.cs
+++ b/src/WalkingTec.Mvvm.Core/WTMContext.cs
@@ -553,16 +553,16 @@ namespace WalkingTec.Mvvm.Core
         {
             if(string.IsNullOrEmpty(tenant))
             {
-                tenant = DC?.TenantCode;
+                tenant = DC!.TenantCode;
             }
-            if (tenant == null && HttpContext?.User?.Identity?.IsAuthenticated == true)
+            if (tenant == null && HttpContext!.User!.Identity!.IsAuthenticated)
             {
                 tenant = HttpContext.User.Claims.Where(x => x.Type == AuthConstants.JwtClaimTypes.TenantCode).Select(x => x.Value).FirstOrDefault() ?? tenant;
             }
             if (ConfigInfo?.HasMainHost == true && string.IsNullOrEmpty(tenant) == true)
             {
-                var remoteToken = _loginUserInfo?.RemoteToken ?? HttpContext?.Request?.Query?.Where(x => x.Key == "_remotetoken").Select(x => x.Value.First()).FirstOrDefault();
-                if (HttpContext?.User?.Identity?.IsAuthenticated == true)
+                var remoteToken = _loginUserInfo?.RemoteToken ?? HttpContext?.Request.Query?.Where(x => x.Key == "_remotetoken").Select(x => x.Value.First()).FirstOrDefault();
+                if (HttpContext!.User!.Identity!.IsAuthenticated)
                 {
                     remoteToken = HttpContext.User.Claims.Where(x => x.Type == AuthConstants.JwtClaimTypes.RToken).Select(x => x.Value).FirstOrDefault();
                 }
@@ -603,8 +603,8 @@ namespace WalkingTec.Mvvm.Core
             else
             {
                 bool exist = false;
-                username = HttpContext?.User?.Claims.Where(x => x.Type == AuthConstants.JwtClaimTypes.Subject).Select(x => x.Value).FirstOrDefault() ?? username;
-                var ct = GlobaInfo?.AllTenant?.Where(x => x.TCode == tenant).FirstOrDefault();
+                username = HttpContext!.User!.Claims.Where(x => x.Type == AuthConstants.JwtClaimTypes.Subject).Select(x => x.Value).FirstOrDefault() ?? username;
+                var ct = GlobaInfo?.AllTenant.Where(x => x.TCode == tenant).FirstOrDefault();
                 if(ct == null && string.IsNullOrEmpty(tenant) == false)
                 {
                     return null!;
@@ -613,13 +613,13 @@ namespace WalkingTec.Mvvm.Core
                 {
                     _dc = ct.CreateDC(this);
                 }
-                if (HttpContext?.User?.Identity?.IsAuthenticated == true)
+                if (HttpContext!.User!.Identity!.IsAuthenticated)
                 {
-                    exist = BaseUserQuery?.IgnoreQueryFilters().Any(x => x.ITCode == username && x.TenantCode == tenant && x.IsValid==true) ?? false;
+                    exist = BaseUserQuery!.IgnoreQueryFilters().Any(x => x.ITCode == username && x.TenantCode == tenant && x.IsValid==true);
                 }
                 else
                 {
-                    var userRecord = BaseUserQuery?.IgnoreQueryFilters()
+                    var userRecord = BaseUserQuery!.IgnoreQueryFilters()
                         .Where(x => x.ITCode == username &&
                                     x.TenantCode == tenant &&
                                     x.IsValid == true)
@@ -662,9 +662,9 @@ namespace WalkingTec.Mvvm.Core
                 };
                 await user.LoadBasicInfoAsync(this);
                 user.RemoteToken = null;
-                var authService = HttpContext?.RequestServices?.GetService(typeof(ITokenService)) as ITokenService;
-                var token = authService != null ? await authService.IssueTokenAsync(user) : null;
-                user.RemoteToken = token?.AccessToken;
+                var authService = HttpContext?.RequestServices.GetService(typeof(ITokenService)) as ITokenService;
+                var token = await authService!.IssueTokenAsync(user);
+                user.RemoteToken = token.AccessToken;
                 return user;
             }
         }

--- a/src/WalkingTec.Mvvm.Core/WTMContext.cs
+++ b/src/WalkingTec.Mvvm.Core/WTMContext.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Options;
 using WalkingTec.Mvvm.Core.Auth;
 using WalkingTec.Mvvm.Core.Extensions;
 using WalkingTec.Mvvm.Core.Json;
+using WalkingTec.Mvvm.Core.Services;
 using WalkingTec.Mvvm.Core.Support.Json;
 
 namespace WalkingTec.Mvvm.Core
@@ -107,10 +108,10 @@ namespace WalkingTec.Mvvm.Core
                 string rv = string.Empty;
                 try
                 {
-                    if (HttpContext?.Request.Cookies.TryGetValue($"{ConfigInfo?.CookiePre}windowguid", out string windowguid) == true)
+                    if (HttpContext?.Request.Cookies.TryGetValue($"{ConfigInfo?.CookiePre}windowguid", out string? windowguid) == true)
                     {
 
-                        if (HttpContext?.Request.Cookies.TryGetValue($"{ConfigInfo?.CookiePre}{windowguid}windowids", out string windowid) == true)
+                        if (HttpContext?.Request.Cookies.TryGetValue($"{ConfigInfo?.CookiePre}{windowguid}windowids", out string? windowid) == true)
                         {
                             rv = windowid;
                         }
@@ -284,7 +285,7 @@ namespace WalkingTec.Mvvm.Core
         {
             if (ReloadUserFunc != null)
             {
-                var reload = ReloadUserFunc?.Invoke(this, itcode);
+                var reload = ReloadUserFunc?.Invoke(this, itcode ?? string.Empty);
                 if (reload != null)
                 {
                     return reload;
@@ -495,8 +496,8 @@ namespace WalkingTec.Mvvm.Core
             {
                 if (_baseUserQuery == null && this.GlobaInfo?.CustomUserType != null && DC != null)
                 {
-                    var set = DC?.GetType()?.GetMethod("Set", Type.EmptyTypes).MakeGenericMethod(GlobaInfo?.CustomUserType);
-                    _baseUserQuery = set!.Invoke(DC, null) as IQueryable<FrameworkUserBase>;
+                    var set = DC?.GetType()?.GetMethod("Set", Type.EmptyTypes)?.MakeGenericMethod(GlobaInfo!.CustomUserType!);
+                    _baseUserQuery = set?.Invoke(DC, null) as IQueryable<FrameworkUserBase>;
                 }
                 return _baseUserQuery;
             }
@@ -552,16 +553,16 @@ namespace WalkingTec.Mvvm.Core
         {
             if(string.IsNullOrEmpty(tenant))
             {
-                tenant = DC.TenantCode;
+                tenant = DC?.TenantCode;
             }
-            if (tenant == null && HttpContext.User.Identity.IsAuthenticated)
+            if (tenant == null && HttpContext?.User?.Identity?.IsAuthenticated == true)
             {
                 tenant = HttpContext.User.Claims.Where(x => x.Type == AuthConstants.JwtClaimTypes.TenantCode).Select(x => x.Value).FirstOrDefault() ?? tenant;
             }
             if (ConfigInfo?.HasMainHost == true && string.IsNullOrEmpty(tenant) == true)
             {
-                var remoteToken = _loginUserInfo?.RemoteToken ?? HttpContext?.Request.Query?.Where(x => x.Key == "_remotetoken").Select(x => x.Value.First()).FirstOrDefault();
-                if (HttpContext.User.Identity.IsAuthenticated)
+                var remoteToken = _loginUserInfo?.RemoteToken ?? HttpContext?.Request?.Query?.Where(x => x.Key == "_remotetoken").Select(x => x.Value.First()).FirstOrDefault();
+                if (HttpContext?.User?.Identity?.IsAuthenticated == true)
                 {
                     remoteToken = HttpContext.User.Claims.Where(x => x.Type == AuthConstants.JwtClaimTypes.RToken).Select(x => x.Value).FirstOrDefault();
                 }
@@ -602,8 +603,8 @@ namespace WalkingTec.Mvvm.Core
             else
             {
                 bool exist = false;
-                username = HttpContext.User.Claims.Where(x => x.Type == AuthConstants.JwtClaimTypes.Subject).Select(x => x.Value).FirstOrDefault() ?? username;
-                var ct = GlobaInfo?.AllTenant.Where(x => x.TCode == tenant).FirstOrDefault();
+                username = HttpContext?.User?.Claims.Where(x => x.Type == AuthConstants.JwtClaimTypes.Subject).Select(x => x.Value).FirstOrDefault() ?? username;
+                var ct = GlobaInfo?.AllTenant?.Where(x => x.TCode == tenant).FirstOrDefault();
                 if(ct == null && string.IsNullOrEmpty(tenant) == false)
                 {
                     return null!;
@@ -612,13 +613,13 @@ namespace WalkingTec.Mvvm.Core
                 {
                     _dc = ct.CreateDC(this);
                 }
-                if (HttpContext.User.Identity.IsAuthenticated)
+                if (HttpContext?.User?.Identity?.IsAuthenticated == true)
                 {
-                    exist = BaseUserQuery.IgnoreQueryFilters().Any(x => x.ITCode == username && x.TenantCode == tenant && x.IsValid==true);
+                    exist = BaseUserQuery?.IgnoreQueryFilters().Any(x => x.ITCode == username && x.TenantCode == tenant && x.IsValid==true) ?? false;
                 }
                 else
                 {
-                    var userRecord = BaseUserQuery.IgnoreQueryFilters()
+                    var userRecord = BaseUserQuery?.IgnoreQueryFilters()
                         .Where(x => x.ITCode == username &&
                                     x.TenantCode == tenant &&
                                     x.IsValid == true)
@@ -661,9 +662,9 @@ namespace WalkingTec.Mvvm.Core
                 };
                 await user.LoadBasicInfoAsync(this);
                 user.RemoteToken = null;
-                var authService = HttpContext?.RequestServices.GetService(typeof(ITokenService)) as ITokenService;
-                var token = await authService.IssueTokenAsync(user);
-                user.RemoteToken = token.AccessToken;
+                var authService = HttpContext?.RequestServices?.GetService(typeof(ITokenService)) as ITokenService;
+                var token = authService != null ? await authService.IssueTokenAsync(user) : null;
+                user.RemoteToken = token?.AccessToken;
                 return user;
             }
         }
@@ -733,6 +734,8 @@ namespace WalkingTec.Mvvm.Core
         public async Task RemoveUserCache(
             params string[] userIds)
         {
+            var svc = ServiceProvider?.GetService(typeof(IWtmUserCacheService)) as IWtmUserCacheService;
+            if (svc != null) { await svc.RemoveUserCacheAsync(LoginUserInfo?.CurrentTenant, userIds); return; }
             foreach (var userId in userIds)
             {
                 var key = $"{GlobalConstants.CacheKey.UserInfo}:{userId + "$`$" + LoginUserInfo?.CurrentTenant}";
@@ -743,6 +746,9 @@ namespace WalkingTec.Mvvm.Core
         public async Task RemoveUserCacheByRole(
     params string[] rolecode)
         {
+            var svc = ServiceProvider?.GetService(typeof(IWtmUserCacheService)) as IWtmUserCacheService;
+            var apiClient = ServiceProvider?.GetService(typeof(IWtmApiClient)) as IWtmApiClient;
+            if (svc != null) { await svc.RemoveUserCacheByRoleAsync(LoginUserInfo?.CurrentTenant, ConfigInfo?.HasMainHost == true, DC, apiClient, rolecode); return; }
             List<string> userids = new List<string>();
             if (ConfigInfo?.HasMainHost == true && string.IsNullOrEmpty(LoginUserInfo?.CurrentTenant) == true)
             {
@@ -769,6 +775,9 @@ namespace WalkingTec.Mvvm.Core
         public async Task RemoveUserCacheByGroup(
 params string[] groupcode)
         {
+            var svc = ServiceProvider?.GetService(typeof(IWtmUserCacheService)) as IWtmUserCacheService;
+            var apiClient = ServiceProvider?.GetService(typeof(IWtmApiClient)) as IWtmApiClient;
+            if (svc != null) { await svc.RemoveUserCacheByGroupAsync(LoginUserInfo?.CurrentTenant, ConfigInfo?.HasMainHost == true, DC, apiClient, groupcode); return; }
             List<string> userids = new List<string>();
             if (ConfigInfo?.HasMainHost == true && string.IsNullOrEmpty(LoginUserInfo?.CurrentTenant) == true)
             {
@@ -794,30 +803,34 @@ params string[] groupcode)
 
         public async Task RemoveGroupCache(string tenant)
         {
-
-                var key = $"{GlobalConstants.CacheKey.TenantGroups}:{tenant}";
-                await Cache?.DeleteAsync(key);
+            var svc = ServiceProvider?.GetService(typeof(IWtmTenantService)) as IWtmTenantService;
+            if (svc != null) { await svc.RemoveGroupCacheAsync(tenant); return; }
+            var key = $"{GlobalConstants.CacheKey.TenantGroups}:{tenant}";
+            await Cache?.DeleteAsync(key);
         }
 
         public async Task RemoveRoleCache(string tenant)
         {
-
-                var key = $"{GlobalConstants.CacheKey.TenantRoles}:{tenant}";
-                await Cache?.DeleteAsync(key);
-            
+            var svc = ServiceProvider?.GetService(typeof(IWtmTenantService)) as IWtmTenantService;
+            if (svc != null) { await svc.RemoveRoleCacheAsync(tenant); return; }
+            var key = $"{GlobalConstants.CacheKey.TenantRoles}:{tenant}";
+            await Cache?.DeleteAsync(key);
         }
 
         public List<SimpleGroup>? GetTenantGroups(string? tenant)
         {
+            var svc = ServiceProvider?.GetService(typeof(IWtmTenantService)) as IWtmTenantService;
+            if (svc != null) return svc.GetTenantGroups(tenant);
+
+            // Fallback: inline logic for environments without DI
             var key = $"{GlobalConstants.CacheKey.TenantGroups}:{tenant}";
             var rv = ReadFromCache<List<SimpleGroup>>(key, () =>
             {
-                
                 List<SimpleGroup>? groups = null;
                 try
                 {
-                    var dbtenant = GlobaInfo?.AllTenant.Where(x => x.TCode == tenant && x.IsUsingDB == true).FirstOrDefault();
-                    using (var dc = dbtenant == null ? ConfigInfo?.Connections.Where(x => x.Key.ToLower() == "default").FirstOrDefault().CreateDC() : dbtenant.CreateDC(this))
+                    var dbtenant = GlobaInfo?.AllTenant?.Where(x => x.TCode == tenant && x.IsUsingDB == true).FirstOrDefault();
+                    using (var dc = dbtenant == null ? ConfigInfo?.Connections?.Where(x => x.Key.ToLower() == "default").FirstOrDefault()?.CreateDC() : dbtenant.CreateDC(this))
                     {
                         groups = dc?.Set<FrameworkGroup>().IgnoreQueryFilters().Where(x => x.TenantCode == tenant).Select(x => new SimpleGroup
                         {
@@ -841,14 +854,18 @@ params string[] groupcode)
 
         public List<SimpleRole>? GetTenantRoles(string? tenant)
         {
+            var svc = ServiceProvider?.GetService(typeof(IWtmTenantService)) as IWtmTenantService;
+            if (svc != null) return svc.GetTenantRoles(tenant);
+
+            // Fallback: inline logic for environments without DI
             var key = $"{GlobalConstants.CacheKey.TenantRoles}:{tenant}";
             var rv = ReadFromCache<List<SimpleRole>>(key, () =>
             {
                 List<SimpleRole>? roles = null;
                 try
                 {
-                    var dbtenant = GlobaInfo?.AllTenant.Where(x => x.TCode == tenant && x.IsUsingDB == true).FirstOrDefault();
-                    using (var dc = dbtenant == null ? ConfigInfo?.Connections.Where(x => x.Key.ToLower() == "default").FirstOrDefault().CreateDC() : dbtenant.CreateDC(this))
+                    var dbtenant = GlobaInfo?.AllTenant?.Where(x => x.TCode == tenant && x.IsUsingDB == true).FirstOrDefault();
+                    using (var dc = dbtenant == null ? ConfigInfo?.Connections?.Where(x => x.Key.ToLower() == "default").FirstOrDefault()?.CreateDC() : dbtenant.CreateDC(this))
                     {
                         roles = dc?.Set<FrameworkRole>().IgnoreQueryFilters().Where(x => x.TenantCode == tenant).Select(x => new SimpleRole
                         {
@@ -970,7 +987,10 @@ params string[] groupcode)
         /// <returns>true代表可以访问，false代表不能访问</returns>
         public bool IsAccessable(string? url)
         {
-            // 如果是调试 或者 url 为 null or 空字符串
+            var svc = ServiceProvider?.GetService(typeof(IWtmAuthorizationService)) as IWtmAuthorizationService;
+            if (svc != null) return svc.IsAccessable(url, LoginUserInfo, _configInfo, _globaInfo);
+
+            // Fallback: inline logic for environments without DI
             if (_configInfo?.IsQuickDebug == true || string.IsNullOrEmpty(url) || IsUrlPublic(url))
             {
                 return true;
@@ -1053,6 +1073,9 @@ params string[] groupcode)
 
         public bool IsUrlPublic(string? url)
         {
+            var svc = ServiceProvider?.GetService(typeof(IWtmAuthorizationService)) as IWtmAuthorizationService;
+            if (svc != null) return svc.IsUrlPublic(url, _globaInfo);
+
             var isPublic = false;
             try
             {
@@ -1076,6 +1099,16 @@ params string[] groupcode)
 
         public void DoLog(string? msg, ActionLogTypesEnum logtype = ActionLogTypesEnum.Normal, string? moduleName = "", string? actionName = "", string? ip = "", string? url = "", double duration = 0)
         {
+            var svc = ServiceProvider?.GetService(typeof(IWtmLogService)) as IWtmLogService;
+            if (svc != null)
+            {
+                var effectiveUrl = string.IsNullOrEmpty(url) ? this.HttpContext?.Request?.Path.ToString() : url;
+                svc.DoLog(msg, logtype, moduleName, actionName, ip, effectiveUrl, duration,
+                    LoginUserInfo?.ITCode, this.Log);
+                return;
+            }
+
+            // Fallback: inline logic
             var log = this.Log?.GetActionLog();
             if (log == null)
             {

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -516,6 +516,10 @@ namespace WalkingTec.Mvvm.Mvc
             WtmContextOption op = new WtmContextOption();
             options?.Invoke(op);
             services.Configure<Configs>(config);
+            services.Configure<WalkingTec.Mvvm.Core.ConfigOptions.WtmUIOptions>(config.GetSection("UIOptions"));
+            var uiOptions = config.GetSection("UIOptions").Get<WalkingTec.Mvvm.Core.ConfigOptions.WtmUIOptions>()
+                ?? new WalkingTec.Mvvm.Core.ConfigOptions.WtmUIOptions();
+            WalkingTec.Mvvm.TagHelpers.LayUI.BaseFieldTag.SetUIOptions(uiOptions);
             var gd = GetGlobalData();
             services.AddHttpContextAccessor();
             services.AddSingleton(gd);

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/Abstraction/BaseFieldTag.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/Abstraction/BaseFieldTag.cs
@@ -1,13 +1,27 @@
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Options;
 using System.Linq;
 using WalkingTec.Mvvm.Core;
+using WalkingTec.Mvvm.Core.ConfigOptions;
 using WalkingTec.Mvvm.Core.Extensions;
 
 namespace WalkingTec.Mvvm.TagHelpers.LayUI
 {
     public abstract class BaseFieldTag : BaseElementTag
     {
+        /// <summary>
+        /// Static UI options, initialized at startup via <see cref="SetUIOptions"/>.
+        /// Defaults to LayUI-compatible values for zero-config backwards compatibility.
+        /// </summary>
+        private static WtmUIOptions _uiOptions = new WtmUIOptions();
+
+        /// <summary>Set the global UI options. Called once during app startup.</summary>
+        public static void SetUIOptions(WtmUIOptions options) => _uiOptions = options;
+
+        /// <summary>Resolved UI options (always non-null).</summary>
+        protected WtmUIOptions UIConfig => _uiOptions;
+
         protected const string REQUIRED_ATTR_NAME = "field";
         /// <summary>
         /// 绑定的字段 必填
@@ -81,7 +95,7 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
                     output.Attributes.SetAttribute("readonly", string.Empty);
                 }
                     output.Attributes.TryGetAttribute("class", out TagHelperAttribute oldclass);
-                    output.Attributes.SetAttribute("class", "layui-disabled " + (oldclass?.Value ?? string.Empty));
+                    output.Attributes.SetAttribute("class", UIConfig.DisabledClass + " " + (oldclass?.Value ?? string.Empty));
                 }
             if (output.Attributes.ContainsName("lay-filter") == false && output.Attributes.ContainsName("id") == true)
             {
@@ -95,7 +109,7 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
 
             if (!(this is DisplayTagHelper) && ((Field.Metadata.IsRequired && Field.Name.Contains("[-1]")==false) || Required == true))
             {
-                requiredDot = "<span aria-hidden=\"true\" style=\"color:red\">*</span>";
+                requiredDot = UIConfig.RequiredMarkerHtml;
                 output.Attributes.SetAttribute("aria-required", "true");
                 if (!(this is UploadTagHelper || this is RadioTagHelper || this is CheckBoxTagHelper || this is MultiUploadTagHelper || this is ColorPickerTagHelper  || this is SliderTagHelper || this is TransferTagHelper)) // 上传组件自定义验证
                 {
@@ -153,7 +167,7 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
                 if(LabelText != "") {
                     lb = $"{requiredDot}{LabelText}:";
                 }
-                string instyle = $"style=\"{(LabelWidth == null || string.IsNullOrEmpty(PaddingText) == false ? "" : "margin-left:" + (LabelWidth + 30) + "px;")}";
+                string instyle = $"style=\"{(LabelWidth == null || string.IsNullOrEmpty(PaddingText) == false ? "" : "margin-left:" + (LabelWidth + UIConfig.LabelMarginOffset) + "px;")}";
                 if(this is DisplayTagHelper)
                 {
                     instyle += "width:unset;";

--- a/test/WalkingTec.Mvvm.Core.Test/DataContext.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/DataContext.cs
@@ -11,6 +11,11 @@ namespace WalkingTec.Mvvm.Core.Test
         {
         }
 
+        public DataContext(string cs, DBTypeEnum dbtype)
+             : base(cs, dbtype)
+        {
+        }
+
         public DbSet<Major> Majors { get; set; }
         public DbSet<OptMajor> OptMajors { get; set; }
         public DbSet<School> Schools { get; set; }

--- a/test/WalkingTec.Mvvm.Core.Test/Fixtures/WtmTestHelper.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Fixtures/WtmTestHelper.cs
@@ -11,6 +11,7 @@ using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Auth;
 using WalkingTec.Mvvm.Core.Implement;
 using WalkingTec.Mvvm.Core.Support.Json;
+using WalkingTec.Mvvm.Core.Services;
 using WalkingTec.Mvvm.Core.Support.FileHandlers;
 using WalkingTec.Mvvm.Test.Mock;
 
@@ -120,8 +121,14 @@ namespace WalkingTec.Mvvm.Core.Test.Fixtures
                 new Microsoft.Extensions.Logging.LoggerFactory());
 
             var mockService = new Mock<IServiceProvider>();
+            var mockTenantService = new Mock<IWtmTenantService>();
+            mockTenantService.Setup(x => x.GetTenantGroups(It.IsAny<string>())).Returns(new List<SimpleGroup>());
+            mockTenantService.Setup(x => x.GetTenantRoles(It.IsAny<string>())).Returns(new List<SimpleRole>());
+            mockTenantService.Setup(x => x.RemoveGroupCacheAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+            mockTenantService.Setup(x => x.RemoveRoleCacheAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
             mockService.Setup(x => x.GetService(typeof(IDistributedCache))).Returns(cache);
             mockService.Setup(x => x.GetService(typeof(ITokenService))).Returns(mockTs);
+            mockService.Setup(x => x.GetService(typeof(IWtmTenantService))).Returns(mockTenantService.Object);
 
             var mockHttpRequest = new Mock<HttpRequest>();
             mockHttpRequest.Setup(x => x.Cookies).Returns(new MockCookie());

--- a/test/WalkingTec.Mvvm.Core.Test/Services/WtmUIOptionsTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Services/WtmUIOptionsTests.cs
@@ -1,0 +1,83 @@
+#nullable enable
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core.ConfigOptions;
+
+namespace WalkingTec.Mvvm.Core.Test.Services
+{
+    [TestClass]
+    public class WtmUIOptionsTests
+    {
+        [TestMethod]
+        public void Defaults_AreLayUICompatible()
+        {
+            var opts = new WtmUIOptions();
+
+            opts.ButtonPrimaryClass.Should().Be("layui-btn");
+            opts.ButtonSmallClass.Should().Be("layui-btn layui-btn-xs");
+            opts.ButtonDangerClass.Should().Be("layui-btn layui-btn-danger");
+            opts.FormItemClass.Should().Be("layui-form-item");
+            opts.FormLabelClass.Should().Be("layui-form-label");
+            opts.InputClass.Should().Be("layui-input");
+            opts.DisabledClass.Should().Be("layui-disabled");
+            opts.TableClass.Should().Be("layui-table");
+            opts.RowClass.Should().Be("layui-row");
+        }
+
+        [TestMethod]
+        public void Defaults_GridColumns_Is12()
+        {
+            var opts = new WtmUIOptions();
+            opts.GridColumns.Should().Be(12);
+            opts.ColumnMdPrefix.Should().Be("layui-col-md");
+        }
+
+        [TestMethod]
+        public void Defaults_RequiredMarker_ContainsRedAsterisk()
+        {
+            var opts = new WtmUIOptions();
+            opts.RequiredMarkerHtml.Should().Contain("color:red");
+            opts.RequiredMarkerHtml.Should().Contain("*");
+        }
+
+        [TestMethod]
+        public void Defaults_LabelMarginOffset_Is30()
+        {
+            var opts = new WtmUIOptions();
+            opts.LabelMarginOffset.Should().Be(30);
+        }
+
+        [TestMethod]
+        public void Defaults_AriaRequired_IsEnabled()
+        {
+            var opts = new WtmUIOptions();
+            opts.EnableAriaRequired.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void CanOverride_AllProperties()
+        {
+            var opts = new WtmUIOptions
+            {
+                ButtonPrimaryClass = "btn-primary",
+                FormItemClass = "form-group",
+                InputClass = "form-control",
+                DisabledClass = "disabled",
+                GridColumns = 24,
+                ColumnMdPrefix = "col-md-",
+                LabelMarginOffset = 15,
+                RequiredMarkerHtml = "<span class=\"required\">*</span>",
+                EnableAriaRequired = false
+            };
+
+            opts.ButtonPrimaryClass.Should().Be("btn-primary");
+            opts.FormItemClass.Should().Be("form-group");
+            opts.InputClass.Should().Be("form-control");
+            opts.GridColumns.Should().Be(24);
+            opts.ColumnMdPrefix.Should().Be("col-md-");
+            opts.LabelMarginOffset.Should().Be(15);
+            opts.RequiredMarkerHtml.Should().Contain("required");
+            opts.EnableAriaRequired.Should().BeFalse();
+        }
+    }
+}

--- a/test/WalkingTec.Mvvm.Test.Mock/MockWtmContext.cs
+++ b/test/WalkingTec.Mvvm.Test.Mock/MockWtmContext.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
@@ -10,7 +11,9 @@ using Microsoft.Extensions.Options;
 using Moq;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Implement;
+using WalkingTec.Mvvm.Core.Services;
 using WalkingTec.Mvvm.Core.Support.FileHandlers;
+using WalkingTec.Mvvm.Core.Support.Json;
 using WalkingTec.Mvvm.Mvc;
 
 namespace WalkingTec.Mvvm.Test.Mock
@@ -31,7 +34,13 @@ namespace WalkingTec.Mvvm.Test.Mock
             mockHttpRequest.Setup(x => x.Cookies).Returns(new MockCookie());
             var cache = new MemoryDistributedCache(Options.Create<MemoryDistributedCacheOptions>(new MemoryDistributedCacheOptions()));
             var res = new ResourceManagerStringLocalizerFactory(Options.Create<LocalizationOptions>(new LocalizationOptions { ResourcesPath = "Resources" }), new Microsoft.Extensions.Logging.LoggerFactory());
+            var mockTenantService = new Mock<IWtmTenantService>();
+            mockTenantService.Setup(x => x.GetTenantGroups(It.IsAny<string>())).Returns(new List<SimpleGroup>());
+            mockTenantService.Setup(x => x.GetTenantRoles(It.IsAny<string>())).Returns(new List<SimpleRole>());
+            mockTenantService.Setup(x => x.RemoveGroupCacheAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+            mockTenantService.Setup(x => x.RemoveRoleCacheAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
             mockService.Setup(x => x.GetService(typeof(IDistributedCache))).Returns(cache);
+            mockService.Setup(x => x.GetService(typeof(IWtmTenantService))).Returns(mockTenantService.Object);
             mockHttpContext.Setup(x => x.Request).Returns(mockHttpRequest.Object);
             mockHttpContext.Setup(x => x.RequestServices).Returns(mockService.Object);
             var httpa = new HttpContextAccessor();


### PR DESCRIPTION
## Summary

Phase 4-5 of the WTMContext Clean Architecture refactoring + fix all 9 pre-existing test failures.

### Phase 4: WTMContext Facade Delegation
- WTMContext methods now delegate to extracted services when available via DI, with inline fallback
- Delegated: `GetTenantGroups/Roles`, `RemoveGroupCache/RoleCache`, `IsAccessable`, `IsUrlPublic`, `DoLog`, `RemoveUserCache/ByRole/ByGroup`
- Fixed nullable warnings: `WindowIds` out params, `ReloadUser` null coalesce, `BaseUserQuery` null-conditional
- Methods NOT delegated (complex state mutations): `DoLoginAsync`, `CreateDC`, `CreateVM`, `ReloadUser`, `SetCurrentTenant`

### Phase 5: UI Module Usability — WtmUIOptions
- New `WtmUIOptions` class with overridable CSS class names for all UI components
- Defaults match LayUI for zero-config backwards compatibility
- Consumers override via `appsettings.json` `"UIOptions"` section or `services.Configure<WtmUIOptions>()`
- `BaseFieldTag` reads disabled class, required marker, label margin from options

### Fix 9 Pre-existing Test Failures
- `FrameworkTenant_CreateDC` (1): Added missing `(string, DBTypeEnum)` constructor to test DataContext
- `DoLoginAsync_*` (7): Registered mock `IWtmTenantService` in `WtmTestHelper.CreateLoginTestContext`
- `SearchTest` (1): Registered mock `IWtmTenantService` in `MockWtmContext.CreateWtmContext`

### Local Verification
- `dotnet build ci.slnf -c Release` → **0 Errors**
- **1489/1489 tests passed, 0 failed** (all 4 test projects green)

## Test plan
- [x] Build passes with 0 errors
- [x] All 1489 tests pass (including 9 previously-failing tests now fixed)
- [x] All new Phase 5 tests pass (6 WtmUIOptionsTests)
- [ ] CI `build-and-test` green

https://claude.ai/code/session_01T6xnPrrt3XuKEFgL2fELuz