### PR TITLE
fix(ci): use absolute path in NuGet smoke test

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -69,14 +69,15 @@ jobs:
       - name: Smoke test package install
         env:
           PKG_VERSION: ${{ steps.version.outputs.version }}
+          NUPKG_DIR: ${{ github.workspace }}/nupkgs
         run: |
           set -euo pipefail
           mkdir smoke && cd smoke
           dotnet new console --framework net10.0
-          dotnet nuget add source "${{ github.workspace }}/nupkgs" --name local-nupkgs
-          dotnet add package WalkingTec.Mvvm.Core --version "$PKG_VERSION" --source local-nupkgs
-          dotnet add package WalkingTec.Mvvm.Mvc --version "$PKG_VERSION" --source local-nupkgs
-          dotnet add package WalkingTec.Mvvm.TagHelpers.LayUI --version "$PKG_VERSION" --source local-nupkgs
+          dotnet nuget add source "$NUPKG_DIR" --name local-nupkgs
+          dotnet add package WalkingTec.Mvvm.Core --version "$PKG_VERSION" --source "$NUPKG_DIR"
+          dotnet add package WalkingTec.Mvvm.Mvc --version "$PKG_VERSION" --source "$NUPKG_DIR"
+          dotnet add package WalkingTec.Mvvm.TagHelpers.LayUI --version "$PKG_VERSION" --source "$NUPKG_DIR"
           dotnet restore
           dotnet build -c Release --no-restore
 


### PR DESCRIPTION
## Summary
- Fix NuGet smoke test path resolution bug that has caused every publish workflow to fail since v8.6.0
- `--source local-nupkgs` (source name) was resolved as a relative path after `cd smoke` → use `$NUPKG_DIR` absolute path instead
- Move `github.workspace` into env var per GitHub Actions security best practices

## Impact
- Smoke test will now pass → release asset upload step will no longer be skipped
- NuGet packages were always published successfully (push step runs before smoke test)

Fixes #731