### PR TITLE
docs(security): add explanatory comments to token rotation and password hashing

### DIFF
--- a/src/WalkingTec.Mvvm.Core/PasswordHashHelper.cs
+++ b/src/WalkingTec.Mvvm.Core/PasswordHashHelper.cs
@@ -25,6 +25,9 @@ namespace WalkingTec.Mvvm.Core
                 string.IsNullOrEmpty(password))
                 return PasswordVerifyResult.Failed;
 
+            // Legacy hash detection chain — oldest format first.
+            // MD5 (uppercase hex, 32 chars) was used in WTM <= 8.1.12.
+            // On match, return SuccessRehashNeeded so the caller upgrades to BCrypt.
             if (IsLegacyMD5Hash(storedHash))
             {
                 var md5 = ComputeMD5(password);
@@ -45,6 +48,9 @@ namespace WalkingTec.Mvvm.Core
                     : PasswordVerifyResult.Failed;
             }
 
+            // Current algorithm: BCrypt. If the stored hash is corrupted or in an
+            // unrecognized format, BCrypt.Verify throws a parse exception — return
+            // Failed instead of crashing, since the password simply cannot be verified.
             try
             {
                 bool isMatch = BCrypt.Net.BCrypt.Verify(password, storedHash);

--- a/src/WalkingTec.Mvvm.Mvc/Auth/JwtAuth/TokenService.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Auth/JwtAuth/TokenService.cs
@@ -60,6 +60,9 @@ namespace WalkingTec.Mvvm.Mvc.Auth
             var existing = await dbSet.FirstOrDefaultAsync(x => x.Token == refreshToken);
             if (existing == null || !existing.IsActive)
             {
+                // Token-reuse attack detection: a revoked token that was already replaced
+                // should never be presented again. If it is, an attacker may have stolen
+                // the old token. Revoke the entire descendant chain to contain the breach.
                 if (existing is { IsRevoked: true, ReplacedByToken: not null })
                 {
                     await RevokeDescendantsAsync(dbSet, existing, ipAddress,
@@ -157,6 +160,11 @@ namespace WalkingTec.Mvvm.Mvc.Auth
             return Convert.ToBase64String(bytes);
         }
 
+        /// <summary>
+        /// Walks the refresh-token replacement chain from a compromised token and
+        /// revokes any still-active descendant. If the immediate child is already
+        /// revoked, recurses deeper until an active token is found or the chain ends.
+        /// </summary>
         private static async Task RevokeDescendantsAsync(
             DbSet<RefreshTokenEntity> dbSet, RefreshTokenEntity token,
             string ipAddress, string reason, TimeProvider timeProvider)
@@ -165,13 +173,13 @@ namespace WalkingTec.Mvvm.Mvc.Auth
             var child = await dbSet.FirstOrDefaultAsync(
                 x => x.Token == token.ReplacedByToken);
             if (child == null) return;
-            if (child.IsActive)
+            if (child.IsActive)  // Base case: revoke the active descendant directly.
             {
                 child.RevokedUtc = timeProvider.GetUtcNow().UtcDateTime;
                 child.RevokedByIp = ipAddress;
                 child.RevokeReason = reason;
             }
-            else
+            else  // Already revoked — recurse deeper; attacker's rotation may have spawned more tokens.
             {
                 await RevokeDescendantsAsync(dbSet, child, ipAddress, reason, timeProvider);
             }


### PR DESCRIPTION
## Summary

- Add English inline comments to non-obvious security logic in `TokenService.cs` and `PasswordHashHelper.cs`
- Token-reuse attack detection, refresh-token chain revocation, legacy hash detection chain, BCrypt catch rationale
- Comments only — no logic changes

Closes #752

## Test plan

- [x] `dotnet build` passes (Core + Mvc projects)
- [x] `dotnet test` passes (1202 tests)
- [ ] Visual review: each comment is 1-3 lines, English, explains WHY not WHAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)