### PR TITLE
docs(core): add explanatory comments to analysis engine and multi-tenant filter logic

### DIFF
--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -471,6 +471,7 @@ namespace WalkingTec.Mvvm.Core.Analysis
 
             List<FilterCondition> result = [];
             var today = DateTime.Today;
+            // ISO week offset: (dow + 6) % 7 maps Sun=0..Sat=6 → Mon=0..Sun=6.
             var mondayOffset = ((int)today.DayOfWeek + 6) % 7;
 
             foreach (var f in filters)
@@ -629,6 +630,8 @@ namespace WalkingTec.Mvvm.Core.Analysis
                             _ => throw new InvalidOperationException($"Operator {f.Operator} not supported in current analysis engine version.")
                         };
 
+                        // Nullable properties need a NOT-NULL guard: SQL silently excludes NULL
+                        // rows from comparisons, but LINQ-to-Objects would throw on .Value access.
                         if (Nullable.GetUnderlyingType(targetType) != null)
                         {
                             filterExpr = Expression.AndAlso(

--- a/src/WalkingTec.Mvvm.Core/Analysis/InProcessGroupByStrategy.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/InProcessGroupByStrategy.cs
@@ -120,6 +120,9 @@ namespace WalkingTec.Mvvm.Core.Analysis
                        && h != DateHierarchy.None
                        && val is DateTime dt)
                    {
+                       // Encode date hierarchy as a compact integer for grouping:
+                       //   Year: 2026, Quarter: 20261, Month: 202603, Day: 20260309
+                       // Formatted to a human-readable label by DateTruncator.FormatKey.
                        int key = h switch
                        {
                            DateHierarchy.Year    => dt.Year,

--- a/src/WalkingTec.Mvvm.Core/Analysis/ServerSideGroupByStrategy.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/ServerSideGroupByStrategy.cs
@@ -17,6 +17,9 @@ namespace WalkingTec.Mvvm.Core.Analysis
     public class ServerSideGroupByStrategy : IGroupByStrategy
     {
         private const int MaxRows = 10_000;
+        // Non-printable 3-byte separator used to join multiple dimension values into a
+        // single GROUP BY key. These characters never appear in real data, so the key can
+        // be split unambiguously after materialization.
         internal const string KeySeparator = "\x01\x02\x03";
 
         public virtual List<Dictionary<string, object?>> Execute<TModel>(
@@ -89,6 +92,10 @@ namespace WalkingTec.Mvvm.Core.Analysis
             var gParam = Expression.Parameter(typeof(IGrouping<string, TModel>), "g");
             var keyAccess = Expression.Property(gParam, nameof(IGrouping<string, TModel>.Key));
 
+            // Fixed to Tuple<string, double?, double?, double?> — max 3 measures.
+            // EF Core's GroupBy translator requires a compile-time-known projection shape;
+            // a dynamic anonymous type cannot be expressed as a translatable expression tree.
+            // Unused slots are filled with null. double (not decimal) for SQLite compatibility.
             var measureExprs = new Expression[3];
             for (int i = 0; i < 3; i++)
             {

--- a/src/WalkingTec.Mvvm.Core/DataContext.cs
+++ b/src/WalkingTec.Mvvm.Core/DataContext.cs
@@ -159,6 +159,13 @@ namespace WalkingTec.Mvvm.Core
                         builder!.HasOne(filepro.Name).WithMany().OnDelete(DeleteBehavior.Restrict);
                     }
                 }
+                // Dynamic global query filter construction for multi-tenancy and soft-delete.
+                // Only applied to "root" entity types (null/abstract base, or direct descendants
+                // of TopBasePoco/BasePoco/TreePoco) to avoid duplicate filters on inheritance hierarchies.
+                //   - IPersistPoco → "IsValid == true" (soft-delete)
+                //   - ITenant → "TenantCode == this.TenantCode" (tenant isolation; captures
+                //     the DataContext instance so EF reads the current TenantCode at query time)
+                // Conditions are combined with AndAlso and registered via HasQueryFilter.
                 List<Expression> list = [];
                 ParameterExpression pe = Expression.Parameter(item);
                 if (item.BaseType == null || item.BaseType.IsAbstract == true || (item.BaseType == typeof(TopBasePoco) || item.BaseType == typeof(BasePoco) || item.BaseType?.BaseType == typeof(TreePoco)))


### PR DESCRIPTION
## Summary

- Add English inline comments to non-obvious logic in 4 Core files
- DataContext: dynamic global query filter expression tree (soft-delete + tenant isolation)
- ServerSideGroupByStrategy: KeySeparator rationale, 3-measure tuple EF Core constraint
- InProcessGroupByStrategy: date hierarchy integer encoding scheme
- AnalysisQueryEngine: mondayOffset arithmetic, nullable guard on comparisons
- Comments only — no logic changes

Closes #753

## Test plan

- [x] `dotnet build` passes (Core project)
- [x] `dotnet test` passes (1202 tests)
- [ ] Visual review: each comment is 1-3 lines, English, explains WHY not WHAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)