### PR TITLE
release: v10.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [Unreleased]
 
+## [10.1.1] - 2026-04-04
+
+### Fixed
+- **Security hardening** — Resolve XSS (reflected user input in error pages), path traversal (file provider), and information disclosure (API client error responses) (#748)
+- **CI** — Update xunit.runner.visualstudio to 3.0.0 for .NET 10 compatibility
+
 ### Improved
-- **C# 12 collection expressions** — Extended `List<T>` → `[]` modernization from Core (10.0.1) to Mvc (11 files), TagHelpers.LayUI (11 files), and Etl (2 files), covering controllers, filters, helpers, data grids, tree views, form tag helpers, and pipeline loaders. CodeGenVM string literals unchanged (52 files total, 0 new warnings, 0 errors)
+- **C# 12 collection expressions** — Extended `List<T>` → `[]` modernization from Core (10.0.1) to Mvc (11 files), TagHelpers.LayUI (11 files), and Etl (2 files), covering controllers, filters, helpers, data grids, tree views, form tag helpers, and pipeline loaders (52 files total)
+- **Code comments** — Added English explanatory comments to non-obvious security logic (TokenService token-reuse detection, PasswordHashHelper legacy hash chain) and complex algorithms (DataContext multi-tenant filter, AnalysisQueryEngine expression trees, ServerSideGroupByStrategy measure projection) (#754, #755)
 
 ## [10.1.0] - 2026-03-28
 

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>10.1.0</VersionPrefix>
+    <VersionPrefix>10.1.1</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
## Summary

Patch release **10.1.1** covering changes since 10.1.0:

- **fix(security)**: XSS, path traversal, information disclosure (#748)
- **fix(ci)**: xunit.runner.visualstudio 3.0.0
- **refactor**: C# 12 collection expressions extended to Mvc/TagHelpers/Etl (52 files)
- **docs**: explanatory comments for security + analysis engine (#754, #755)

## Changes

- `version.props`: 10.1.0 → 10.1.1
- `CHANGELOG.md`: Unreleased → 10.1.1

Closes #756

## Test plan

- [x] `dotnet build` passes
- [x] `dotnet test` passes (1202 tests)
- [ ] Verify version in built assemblies

🤖 Generated with [Claude Code](https://claude.com/claude-code)