### PR TITLE
fix(security): TagHelpers XSS follow-up, cookie hardening, Excel formula injection, ETL IAsyncDisposable

### DIFF
--- a/src/WalkingTec.Mvvm.Core/BaseImportVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BaseImportVM.cs
@@ -419,6 +419,16 @@ namespace WalkingTec.Mvvm.Core
         {
             if (!string.IsNullOrEmpty(Value) && Value.IndexOf("=") == 0)
             {
+                // Block dangerous external-reference formulas to prevent formula injection attacks
+                string formulaUpper = Value.Substring(1).TrimStart().ToUpperInvariant();
+                if (formulaUpper.Contains('|') || formulaUpper.StartsWith("CMD") ||
+                    formulaUpper.StartsWith("WEBSERVICE") || formulaUpper.StartsWith("HYPERLINK") ||
+                    formulaUpper.StartsWith("IMPORTXML") || formulaUpper.StartsWith("IMPORTDATA") ||
+                    formulaUpper.StartsWith("IMPORTFEED") || formulaUpper.StartsWith("IMPORTRANGE"))
+                {
+                    return Value;
+                }
+
                 try
                 {
                     string Formula = Value.Substring(1);

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/IEtlSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/IEtlSource.cs
@@ -9,7 +9,7 @@ namespace WalkingTec.Mvvm.Etl.Pipeline;
 /// <summary>
 /// ETL Extract 介面 — 從來源 DB 串流讀取資料
 /// </summary>
-public interface IEtlSource : IDisposable
+public interface IEtlSource : IDisposable, IAsyncDisposable
 {
     /// <summary>
     /// 以 DbDataReader 方式串流讀取資料，分批 yield return DataTable

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/Sources/CompositeEtlSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/Sources/CompositeEtlSource.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace WalkingTec.Mvvm.Etl.Pipeline.Sources;
 
@@ -60,5 +61,11 @@ public sealed class CompositeEtlSource : IEtlSource
     {
         foreach (var (_, _, source) in _sources)
             source.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var (_, _, source) in _sources)
+            await source.DisposeAsync();
     }
 }

--- a/src/WalkingTec.Mvvm.Etl/Testing/MockEtlSource.cs
+++ b/src/WalkingTec.Mvvm.Etl/Testing/MockEtlSource.cs
@@ -42,4 +42,6 @@ public class MockEtlSource : IEtlSource
     }
 
     public void Dispose() { }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/WalkingTec.Mvvm.Mvc/Filters/FrameworkFilter.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Filters/FrameworkFilter.cs
@@ -428,7 +428,11 @@ namespace WalkingTec.Mvvm.Mvc.Filters
                 context.ExceptionHandled = true;
                 if (ctrl.Wtm.ConfigInfo.IsQuickDebug == true)
                 {
-                    context.HttpContext.Response.WriteAsync(context.Exception.ToString());
+                    var ex = context.Exception;
+                    var debugMsg = $"[Debug] {ex.GetType().Name}: {ex.Message}";
+                    if (ex.InnerException != null)
+                        debugMsg += $"\n  Inner: {ex.InnerException.GetType().Name}: {ex.InnerException.Message}";
+                    context.HttpContext.Response.WriteAsync(debugMsg);
                 }
                 else
                 {

--- a/src/WalkingTec.Mvvm.Mvc/_FrameworkController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_FrameworkController.cs
@@ -292,7 +292,7 @@ namespace WalkingTec.Mvvm.Mvc
                 }
 
                 var now = Wtm.TimeProvider.GetLocalNow().DateTime;
-                HttpContext.Response.Cookies.Append("DONOTUSEDOWNLOADING", "0", new Microsoft.AspNetCore.Http.CookieOptions() { Path = "/", Expires = now.AddDays(2) });
+                HttpContext.Response.Cookies.Append("DONOTUSEDOWNLOADING", "0", new Microsoft.AspNetCore.Http.CookieOptions() { Path = "/", Expires = now.AddDays(2), SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, Secure = Request.IsHttps });
 
                 return File(data, "application/vnd.ms-excel", $"Export_{instanceType.Name}_{now.ToString("yyyy-MM-dd")}.xls");
             }
@@ -319,7 +319,7 @@ namespace WalkingTec.Mvvm.Mvc
             }
             importVM.SetParms(qs);
             var data = importVM.GenerateTemplate(out string fileName);
-            HttpContext.Response.Cookies.Append("DONOTUSEDOWNLOADING", "0", new Microsoft.AspNetCore.Http.CookieOptions() { Path = "/", Expires = Wtm.TimeProvider.GetLocalNow().DateTime.AddDays(2) });
+            HttpContext.Response.Cookies.Append("DONOTUSEDOWNLOADING", "0", new Microsoft.AspNetCore.Http.CookieOptions() { Path = "/", Expires = Wtm.TimeProvider.GetLocalNow().DateTime.AddDays(2), SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, Secure = Request.IsHttps });
             return File(data, "application/vnd.ms-excel", fileName);
         }
 

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/Form/FormTagHelper.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/Form/FormTagHelper.cs
@@ -135,7 +135,8 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
                     output.Attributes.SetAttribute("action", baseVM?.CurrentUrl ?? baseSearcher?.Wtm?.BaseUrl ?? "#");
                 }
             }
-            output.PostContent.AppendHtml($"<input type='hidden' name='FromView' value='{baseVM?.CurrentView}' />");
+            var encodedView = System.Net.WebUtility.HtmlEncode(baseVM?.CurrentView ?? "");
+            output.PostContent.AppendHtml($"<input type='hidden' name='FromView' value='{encodedView}' />");
 
             output.PostElement.AppendHtml($@"
 <script>

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/Form/RichTextBox.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/Form/RichTextBox.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.Encodings.Web;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Extensions;
 
@@ -75,14 +76,14 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI.Form
             }
             url = url.AppendQuery(ExtraQuery);
 
-
+            var encodedUrl = JavaScriptEncoder.Default.Encode(url ?? "");
             output.PostElement.AppendHtml($@"
 <script>
 layui.use('layedit', function(){{
   var layedit = layui.layedit;
   layedit.set({{
     uploadImage: {{
-      url: '{url}'
+      url: '{encodedUrl}'
     }}
   }});
   var index = layedit.build('{Id}'{(Height.HasValue?$",{{height:{Height.Value}}}":"")});

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/Form/TextAreaTagHelper.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/Form/TextAreaTagHelper.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using System.Web;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace WalkingTec.Mvvm.TagHelpers.LayUI
@@ -22,11 +20,11 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
             }
             if (DefaultValue != null)
             {
-                output.Content.SetContent(WebUtility.HtmlDecode(DefaultValue.ToString()));
+                output.Content.SetContent(DefaultValue.ToString());
             }
             else
             {
-                output.Content.SetContent(WebUtility.HtmlDecode(Field?.Model?.ToString()));
+                output.Content.SetContent(Field?.Model?.ToString());
             }
 
             base.Process(context, output);


### PR DESCRIPTION
## Summary

Security follow-up fixes from deep analysis round 2:

- **TagHelpers XSS** (#785): RichTextBox JS encode upload URL, FormTagHelper HtmlEncode CurrentView, TextAreaTagHelper remove HtmlDecode
- **Cookie hardening** (#786): DONOTUSEDOWNLOADING cookie add SameSite/Secure
- **Excel formula injection** (#787): Block dangerous formula functions (CMD, WEBSERVICE, HYPERLINK, etc.) in BaseImportVM
- **IEtlSource** (#788): Add IAsyncDisposable to interface + sanitize QuickDebug exception output

## Issues Closed

Closes #785 #786 #787 #788

## Test Plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `dotnet test -c Release` — 1509/1518 passed (9 Integration tests need DB, unrelated)
- [x] Core: 1202 ✅ | Mvc: 38 ✅ | ETL: 174 ✅ | Admin: 75 ✅ | API: 20 ✅