### PR TITLE
fix(core): BaseBatchVM ErrorMessage thread safety (#790)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/BaseBatchVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BaseBatchVM.cs
@@ -68,6 +68,11 @@ namespace WalkingTec.Mvvm.Core
         [JsonIgnore]
         public Dictionary<string, string> ErrorMessage { get; set; }
 
+        // Issue #790: guards every mutation of ErrorMessage so that concurrent
+        // batch calls (Task.WhenAll / Parallel.ForEach against a shared instance)
+        // cannot corrupt the underlying Dictionary<string,string>.
+        private readonly object _errorMessageLock = new();
+
         /// <summary>
         /// 列表数据的Id数组
         /// </summary>
@@ -91,7 +96,12 @@ namespace WalkingTec.Mvvm.Core
         {
             if (id != null)
             {
-                ErrorMessage.Add(id, e.Message);
+                lock (_errorMessageLock)
+                {
+                    // TryAdd preserves the first recorded error for a given id
+                    // instead of throwing on duplicate keys (cf. old Dictionary.Add).
+                    ErrorMessage.TryAdd(id, e.Message);
+                }
             }
         }
 
@@ -137,7 +147,10 @@ namespace WalkingTec.Mvvm.Core
                 //检查是否可以删除，如不能删除则直接跳过
                 if (CheckIfCanDelete(idsData[i], out checkErro) == false)
                 {
-                    ErrorMessage.Add(idsData[i], checkErro!);
+                    lock (_errorMessageLock)
+                    {
+                        ErrorMessage.TryAdd(idsData[i], checkErro!);
+                    }
                     rv = false;
                     break;
                 }
@@ -238,22 +251,28 @@ namespace WalkingTec.Mvvm.Core
             //如果失败，添加错误信息
             if (rv == false)
             {
-                if (ErrorMessage.Count > 0)
+                lock (_errorMessageLock)
                 {
-                    foreach (var id in idsData)
+                    if (ErrorMessage.Count > 0)
                     {
-                        if (!ErrorMessage.ContainsKey(id))
+                        var fallback = (CoreProgram._localizer != null ? (string?)CoreProgram._localizer["Sys.Rollback"] : null) ?? "";
+                        foreach (var id in idsData)
                         {
-                            ErrorMessage.Add(id, (CoreProgram._localizer != null ? (string?)CoreProgram._localizer["Sys.Rollback"] : null) ?? "");
+                            ErrorMessage.TryAdd(id, fallback);
                         }
                     }
                 }
                 ListVM?.DoSearch();
                 if (ListVM != null)
                 {
+                    Dictionary<string, string> errorSnapshot;
+                    lock (_errorMessageLock)
+                    {
+                        errorSnapshot = new Dictionary<string, string>(ErrorMessage);
+                    }
                     foreach (var item in ListVM.GetEntityList())
                     {
-                        item.BatchError = ErrorMessage.Where(x => x.Key == item.GetID().ToString()).Select(x => x.Value).FirstOrDefault();
+                        item.BatchError = errorSnapshot.Where(x => x.Key == item.GetID().ToString()).Select(x => x.Value).FirstOrDefault();
                     }
                 }
                 MSD?.AddModelError("", CoreProgram._localizer?["Sys.DataCannotDelete"]?.Value ?? "");
@@ -339,7 +358,10 @@ namespace WalkingTec.Mvvm.Core
                             }
                             if (error != "")
                             {
-                                ErrorMessage.Add(idsData[i], error);
+                                lock (_errorMessageLock)
+                                {
+                                    ErrorMessage.TryAdd(idsData[i], error);
+                                }
                                 rv = false;
                                 break;
                             }
@@ -383,13 +405,14 @@ namespace WalkingTec.Mvvm.Core
             //如果有错误，输出错误信息
             if (rv == false)
             {
-                if (ErrorMessage.Count > 0)
+                lock (_errorMessageLock)
                 {
-                    foreach (var id in idsData)
+                    if (ErrorMessage.Count > 0)
                     {
-                        if (!ErrorMessage.ContainsKey(id))
+                        var fallback = (CoreProgram._localizer != null ? (string?)CoreProgram._localizer["Sys.Rollback"] : null) ?? "";
+                        foreach (var id in idsData)
                         {
-                            ErrorMessage.Add(id, (CoreProgram._localizer != null ? (string?)CoreProgram._localizer["Sys.Rollback"] : null) ?? "");
+                            ErrorMessage.TryAdd(id, fallback);
                         }
                     }
                 }
@@ -403,9 +426,14 @@ namespace WalkingTec.Mvvm.Core
             ListVM?.DoSearch();
             if (ListVM != null)
             {
+                Dictionary<string, string> errorSnapshot;
+                lock (_errorMessageLock)
+                {
+                    errorSnapshot = new Dictionary<string, string>(ErrorMessage);
+                }
                 foreach (var item in ListVM.GetEntityList())
                 {
-                    item.BatchError = ErrorMessage.Where(x => x.Key == item.GetID().ToString()).Select(x => x.Value).FirstOrDefault();
+                    item.BatchError = errorSnapshot.Where(x => x.Key == item.GetID().ToString()).Select(x => x.Value).FirstOrDefault();
                 }
             }
         }

--- a/test/WalkingTec.Mvvm.Core.Test/VM/BaseBatchVMTest.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/VM/BaseBatchVMTest.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using WalkingTec.Mvvm.Test.Mock;
@@ -89,6 +91,75 @@ namespace WalkingTec.Mvvm.Core.Test.VM
             }
 
         }
+
+        [TestMethod]
+        [Description("Issue #790: SetExceptionMessage with duplicate key must not throw (TryAdd semantics)")]
+        public void SetExceptionMessage_DuplicateKey_DoesNotThrow_PreservesFirstValue()
+        {
+            var vm = new ConcurrencyTestBatchVM<School, SchoolEdit>();
+
+            vm.InvokeSetExceptionMessage(new InvalidOperationException("first"), "id1");
+            vm.InvokeSetExceptionMessage(new InvalidOperationException("second"), "id1");
+
+            Assert.AreEqual(1, vm.ErrorMessage.Count);
+            Assert.AreEqual("first", vm.ErrorMessage["id1"]);
+        }
+
+        [TestMethod]
+        [Description("Issue #790: SetExceptionMessage under parallel distinct keys must not lose writes or throw")]
+        public void SetExceptionMessage_Concurrent_DistinctKeys_AllAddedWithoutException()
+        {
+            var vm = new ConcurrencyTestBatchVM<School, SchoolEdit>();
+            const int count = 5000;
+            var exceptions = new ConcurrentBag<Exception>();
+
+            Parallel.For(0, count, i =>
+            {
+                try
+                {
+                    vm.InvokeSetExceptionMessage(new InvalidOperationException("err" + i), i.ToString());
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+            Assert.AreEqual(0, exceptions.Count, "Unexpected exceptions: " + string.Join(";", exceptions.Select(e => e.GetType().Name + ":" + e.Message)));
+            Assert.AreEqual(count, vm.ErrorMessage.Count);
+        }
+
+        [TestMethod]
+        [Description("Issue #790: concurrent duplicate-key SetExceptionMessage must not throw — one value wins")]
+        public void SetExceptionMessage_Concurrent_DuplicateKeys_DoesNotThrow()
+        {
+            var vm = new ConcurrencyTestBatchVM<School, SchoolEdit>();
+            const int count = 500;
+            var exceptions = new ConcurrentBag<Exception>();
+
+            Parallel.For(0, count, i =>
+            {
+                try
+                {
+                    vm.InvokeSetExceptionMessage(new InvalidOperationException("err" + i), "same-id");
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+            Assert.AreEqual(0, exceptions.Count, "Unexpected exceptions: " + string.Join(";", exceptions.Select(e => e.GetType().Name)));
+            Assert.AreEqual(1, vm.ErrorMessage.Count);
+            Assert.IsTrue(vm.ErrorMessage.ContainsKey("same-id"));
+        }
+    }
+
+    internal sealed class ConcurrencyTestBatchVM<TModel, TLinkModel> : BaseBatchVM<TModel, TLinkModel>
+        where TModel : TopBasePoco, new()
+        where TLinkModel : BaseVM
+    {
+        public void InvokeSetExceptionMessage(Exception e, string id) => SetExceptionMessage(e, id);
     }
 
     public class SchoolEdit:BaseVM


### PR DESCRIPTION
## Summary

Closes #790.

`Dictionary<string,string>` is not thread-safe. Under `Parallel.ForEach` or `Task.WhenAll` on a shared `BaseBatchVM` instance, `SetExceptionMessage` and the `DoBatchDelete` / `DoBatchEdit` rollback paths corrupted the underlying Dictionary, surfacing as:

> InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.

This PR introduces a private lock and rewrites every mutation site to be atomic.

## Changes

### `src/WalkingTec.Mvvm.Core/BaseBatchVM.cs`
- Add private `_errorMessageLock` field.
- Wrap every mutation of `ErrorMessage`:
  - `SetExceptionMessage` (L~94)
  - `DoBatchDelete` — `CheckIfCanDelete` error path (L~140)
  - `DoBatchDelete` — rollback fallback block (L~241)
  - `DoBatchEdit` — validation error path (L~342)
  - `DoBatchEdit` — rollback fallback block (L~386)
- Replace `Dictionary.Add` with `TryAdd` so the pre-existing `if (!ContainsKey) Add` pattern becomes atomic and duplicate keys no longer throw `ArgumentException`.
- Snapshot `ErrorMessage` under lock before enumerating in the rollback read paths (`DoBatchDelete` + `RefreshErrorList`) so reads do not race with writes.

### `test/WalkingTec.Mvvm.Core.Test/VM/BaseBatchVMTest.cs`
Added three tests (plus an internal `ConcurrencyTestBatchVM` helper that exposes the `protected` `SetExceptionMessage`):

1. **`SetExceptionMessage_DuplicateKey_DoesNotThrow_PreservesFirstValue`** — deterministic: calling twice with the same id no longer throws and the first value wins.
2. **`SetExceptionMessage_Concurrent_DistinctKeys_AllAddedWithoutException`** — 5000-iteration `Parallel.For` with distinct keys; reproduces the exact `InvalidOperationException` from #790 before the fix, passes after.
3. **`SetExceptionMessage_Concurrent_DuplicateKeys_DoesNotThrow`** — 500-iteration `Parallel.For` against the same key; asserts exactly one entry, no exceptions.

## Compatibility

**No public API changes.** `ErrorMessage` remains `Dictionary<string, string>` in both `IBaseBatchVM<TEditModel>` (L43) and the concrete `BaseBatchVM<TModel, TLinkModel>` (L69). Downstream code that declares `Dictionary<string, string> err = vm.ErrorMessage;` continues to compile.

The only semantic change is in the `SetExceptionMessage` duplicate-key behavior: where previously a second call with the same id would throw `ArgumentException`, it now silently preserves the first value (`TryAdd`). This matches the intent of the pre-existing `if (!ContainsKey) Add` rollback pattern and removes a latent bug.

## Test plan

- [x] RED: new tests fail on `main` (dotnet10) with `ArgumentException` and `InvalidOperationException: corrupted its state` — issue #790 reproduced.
- [x] GREEN: new tests pass after the fix.
- [x] `dotnet test test/WalkingTec.Mvvm.Core.Test` — **1205/1205 passed**, no regressions.
- [x] `dotnet build src/WalkingTec.Mvvm.Core -c Release` — clean (0 errors, only pre-existing XML doc warnings).
- [ ] CI green