### PR TITLE
refactor(core): replace bare catch blocks with diagnostic logging (#791)

### DIFF
--- a/src/WalkingTec.Mvvm.Core/BaseCRUDVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BaseCRUDVM.cs
@@ -933,8 +933,9 @@ namespace WalkingTec.Mvvm.Core
                                 DC!.UpdateProperty(Entity, itempro.Name);
                             }
                         }
-                        catch (Exception)
+                        catch (Exception ex)
                         {
+                            Wtm?.ServiceProvider?.GetService<ILoggerFactory>()?.CreateLogger("BaseCRUDVM")?.LogWarning(ex, "DoEdit: UpdateProperty failed for FC field '{Field}'", name);
                         }
                     }
                 }
@@ -945,8 +946,9 @@ namespace WalkingTec.Mvvm.Core
                         DC!.UpdateProperty(Entity, "UpdateTime");
                         DC!.UpdateProperty(Entity, "UpdateBy");
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
+                        Wtm?.ServiceProvider?.GetService<ILoggerFactory>()?.CreateLogger("BaseCRUDVM")?.LogWarning(ex, "DoEdit: UpdateProperty failed for UpdateTime/UpdateBy on '{EntityType}'", typeof(TModel).Name);
                     }
                 }
             }

--- a/src/WalkingTec.Mvvm.Core/BaseImportVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BaseImportVM.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Text.Json.Serialization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NPOI.HSSF.Util;
 using NPOI.SS.UserModel;
 using NPOI.XSSF.UserModel;
@@ -436,8 +437,9 @@ namespace WalkingTec.Mvvm.Core
                     XE.EvaluateFormulaCell(cell!);
                     Value = cell!.NumericCellValue.ToString();
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    Wtm?.ServiceProvider?.GetService<ILoggerFactory>()?.CreateLogger("BaseImportVM")?.LogDebug(ex, "Excel formula evaluation failed for '{Value}'; falling back to raw string", Value);
                 }
             }
             return Value;
@@ -1034,7 +1036,10 @@ namespace WalkingTec.Mvvm.Core
                                 {
                                     DC!.UpdateProperty(exist, proToSet.Name);
                                 }
-                                catch { }
+                                catch (Exception ex)
+                                {
+                                    Wtm?.ServiceProvider?.GetService<ILoggerFactory>()?.CreateLogger("BaseImportVM")?.LogWarning(ex, "Import update: UpdateProperty failed for '{Property}' on duplicate row", proToSet.Name);
+                                }
                             }
                         }
 

--- a/src/WalkingTec.Mvvm.Core/BasePagedListVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BasePagedListVM.cs
@@ -13,6 +13,8 @@ using System.Reflection;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using MySql.Data.MySqlClient;
@@ -890,7 +892,10 @@ namespace WalkingTec.Mvvm.Core
                         Searcher.Count = long.Parse(total.ToString()!);
                         Searcher.PageCount = (int)((Searcher.Count - 1) / Searcher.Limit + 1);
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        Wtm?.ServiceProvider?.GetService<ILoggerFactory>()?.CreateLogger("BasePagedListVM")?.LogDebug(ex, "Paging count parse failed for total='{Total}'", total);
+                    }
                 }
             }
             else
@@ -1091,7 +1096,10 @@ namespace WalkingTec.Mvvm.Core
                                         haserror = true;
                                     }
                                 }
-                                catch { }
+                                catch (Exception ex)
+                                {
+                                    Wtm?.ServiceProvider?.GetService<ILoggerFactory>()?.CreateLogger("BasePagedListVM")?.LogDebug(ex, "BatchError detail-grid index parse failed for key '{Key}'", item);
+                                }
                             }
                         }
                     }

--- a/src/WalkingTec.Mvvm.Core/ConfigOptions/CS.cs
+++ b/src/WalkingTec.Mvvm.Core/ConfigOptions/CS.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace WalkingTec.Mvvm.Core
 {
@@ -48,7 +49,10 @@ namespace WalkingTec.Mvvm.Core
                                     }
                                 }
                             }
-                            catch { }
+                            catch (Exception ex)
+                            {
+                                CoreProgram.GetLogger("CS")?.LogDebug(ex, "CS.Cis: scanning assembly '{Asm}' for DbContext(CS) constructors threw; skipping", ass.FullName);
+                            }
                         }
                     }
                 }
@@ -81,7 +85,10 @@ namespace WalkingTec.Mvvm.Core
                                     }
                                 }
                             }
-                            catch { }
+                            catch (Exception ex)
+                            {
+                                CoreProgram.GetLogger("CS")?.LogDebug(ex, "CS.CisFull: scanning assembly '{Asm}' for DbContext(string,DBTypeEnum) constructors threw; skipping", ass.FullName);
+                            }
                         }
                     }
                 }

--- a/src/WalkingTec.Mvvm.Core/CoreProgram.cs
+++ b/src/WalkingTec.Mvvm.Core/CoreProgram.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Text.Json;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace WalkingTec.Mvvm.Core
@@ -11,6 +12,19 @@ namespace WalkingTec.Mvvm.Core
             get;
             set;
         }
+
+        // Issue #791: static utility classes (PropertyHelper, Utils, TypeExtension, CS,
+        // JSON converters, QuartzHostService, ...) have no Wtm/ServiceProvider access
+        // and previously silently swallowed exceptions. This factory is wired during
+        // startup next to _localizer so those classes can emit real diagnostic logs.
+        public static ILoggerFactory? _loggerFactory
+        {
+            get;
+            set;
+        }
+
+        public static ILogger? GetLogger(string category) =>
+            _loggerFactory?.CreateLogger(category);
 
         public static JsonSerializerOptions DefaultJsonOption
         {

--- a/src/WalkingTec.Mvvm.Core/DataContext.cs
+++ b/src/WalkingTec.Mvvm.Core/DataContext.cs
@@ -202,7 +202,10 @@ namespace WalkingTec.Mvvm.Core
             {
                 emptydb = Set<FrameworkUserRole>().Count() == 0 && Set<FrameworkMenu>().Count() == 0;
             }
-            catch { }
+            catch (Exception ex)
+            {
+                CoreProgram.GetLogger("DataContext")?.LogDebug(ex, "DataInit: FrameworkUserRole/FrameworkMenu count probe failed; assuming seeded DB");
+            }
 
             if (emptydb == true)
             {

--- a/src/WalkingTec.Mvvm.Core/Extensions/SystemExtensions/TypeExtension.cs
+++ b/src/WalkingTec.Mvvm.Core/Extensions/SystemExtensions/TypeExtension.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
 using Fare;
+using Microsoft.Extensions.Logging;
 
 namespace WalkingTec.Mvvm.Core.Extensions
 {
@@ -216,7 +217,10 @@ namespace WalkingTec.Mvvm.Core.Extensions
                                 start = (int)Math.Truncate(double.Parse(range.Minimum.ToString()!));
                                 end = (int)Math.Truncate(double.Parse(range.Maximum.ToString()!));
                             }
-                            catch { }
+                            catch (Exception ex)
+                            {
+                                CoreProgram.GetLogger("TypeExtension")?.LogDebug(ex, "Range attribute parse failed for '{Property}'; using default 0..100", pro.Name);
+                            }
                         }
                         Random r = new Random();
                         val = r.Next(start, end).ToString();
@@ -355,7 +359,10 @@ namespace WalkingTec.Mvvm.Core.Extensions
                                     start = (int)Math.Truncate(double.Parse(range.Minimum.ToString()!));
                                     end = (int)Math.Truncate(double.Parse(range.Maximum.ToString()!));
                                 }
-                                catch { }
+                                catch (Exception ex)
+                                {
+                                    CoreProgram.GetLogger("TypeExtension")?.LogDebug(ex, "Range attribute parse failed for '{Property}'; using default 0..100", pro.Name);
+                                }
                             }
                             Random r = new Random();
                             val = r.Next(start, end).ToString();

--- a/src/WalkingTec.Mvvm.Core/Helper/PropertyHelper.cs
+++ b/src/WalkingTec.Mvvm.Core/Helper/PropertyHelper.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections;
@@ -423,7 +424,10 @@ namespace WalkingTec.Mvvm.Core
                 {
                     rv = (lambda.Compile().DynamicInvoke(obj) as IEnumerable<string>)?.ToList() ?? [];
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    CoreProgram.GetLogger("PropertyHelper")?.LogDebug(ex, "GetPropertyStringValues dynamic-invoke failed; returning empty list");
+                }
                 return rv;
             }
             else
@@ -580,7 +584,10 @@ namespace WalkingTec.Mvvm.Core
                                     list = value.ConvertValue(propertyType) as IList;
                                 }
                             }
-                            catch { }
+                            catch (Exception ex)
+                            {
+                                CoreProgram.GetLogger("PropertyHelper")?.LogDebug(ex, "SetPropertyValue list-conversion failed for '{Property}'", fproperty.Name);
+                            }
                             fproperty.SetMemberValue(temp, list, null);
                         }
                     }
@@ -600,7 +607,10 @@ namespace WalkingTec.Mvvm.Core
                                 fproperty.SetMemberValue(temp, arr, null);
                             }
                         }
-                        catch { }
+                        catch (Exception ex)
+                        {
+                            CoreProgram.GetLogger("PropertyHelper")?.LogDebug(ex, "SetPropertyValue array-conversion failed for '{Property}'", fproperty.Name);
+                        }
                     }
                     else
                     {
@@ -629,8 +639,9 @@ namespace WalkingTec.Mvvm.Core
                     fproperty.SetMemberValue(temp, value, null);
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                CoreProgram.GetLogger("PropertyHelper")?.LogDebug(ex, "SetPropertyValue failed for '{Property}'", property);
             }
         }
 
@@ -823,7 +834,10 @@ namespace WalkingTec.Mvvm.Core
                 {
                     val = ConvertValue(value, gs[0]);
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    CoreProgram.GetLogger("PropertyHelper")?.LogDebug(ex, "ConvertValue nullable-generic fallback for type '{Type}', value '{Value}'", propertyType.Name, value);
+                }
             }
             else if (propertyType.IsEnum())
             {
@@ -880,8 +894,9 @@ namespace WalkingTec.Mvvm.Core
                         val = Convert.ChangeType(value?.ToString(), propertyType);
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    CoreProgram.GetLogger("PropertyHelper")?.LogDebug(ex, "ConvertValue generic fallback for type '{Type}', value '{Value}'", propertyType.Name, value);
                 }
             }
             return val;

--- a/src/WalkingTec.Mvvm.Core/Json/DateRangeConverter.cs
+++ b/src/WalkingTec.Mvvm.Core/Json/DateRangeConverter.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace WalkingTec.Mvvm.Core.Json
 {
@@ -34,8 +35,9 @@ namespace WalkingTec.Mvvm.Core.Json
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                CoreProgram.GetLogger("DateRangeConverter")?.LogDebug(ex, "DateRangeConverter.Read: array parse failed; returning null");
             }
             return null;
         }

--- a/src/WalkingTec.Mvvm.Core/Json/RawStringConverter.cs
+++ b/src/WalkingTec.Mvvm.Core/Json/RawStringConverter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace WalkingTec.Mvvm.Core.Json
 {
@@ -22,8 +23,9 @@ namespace WalkingTec.Mvvm.Core.Json
                     return reader.GetString();
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                CoreProgram.GetLogger("RawStringConverter")?.LogDebug(ex, "RawStringConverter.Read: GetString failed at TokenType '{Token}'; returning null", reader.TokenType);
             }
             return null;
         }

--- a/src/WalkingTec.Mvvm.Core/Services/WtmApiClient.cs
+++ b/src/WalkingTec.Mvvm.Core/Services/WtmApiClient.cs
@@ -128,7 +128,10 @@ namespace WalkingTec.Mvvm.Core.Services
                         {
                             rv.Errors = JsonSerializer.Deserialize<ErrorObj>(responseTxt, CoreProgram.DefaultJsonOption);
                         }
-                        catch { }
+                        catch (Exception ex)
+                        {
+                            _logger?.LogDebug(ex, "CallAPI: 400 response body could not be deserialized into ErrorObj; keeping raw text");
+                        }
                     }
                     // Return only truncated response to avoid exposing sensitive data
                     rv.ErrorMsg = responseTxt.Length > 500 ? responseTxt[..500] + "..." : responseTxt;

--- a/src/WalkingTec.Mvvm.Core/Services/WtmVmFactory.cs
+++ b/src/WalkingTec.Mvvm.Core/Services/WtmVmFactory.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using WalkingTec.Mvvm.Core.Extensions;
 
 namespace WalkingTec.Mvvm.Core.Services
@@ -130,7 +132,10 @@ namespace WalkingTec.Mvvm.Core.Services
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                httpContext.RequestServices?.GetService<ILoggerFactory>()?.CreateLogger("WtmVmFactory")?.LogDebug(ex, "PopulateFormCollection: reading query/form for ViewModel '{VmType}' failed", rv.GetType().Name);
+            }
         }
 
         private static void InitBatchVM(IBaseBatchVM<BaseVM> temp, BaseVM rv, object[]? ids, bool passInit)

--- a/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmFileProvider.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmFileProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WalkingTec.Mvvm.Core.Extensions;
 using WalkingTec.Mvvm.Core.Models;
@@ -205,7 +206,10 @@ namespace WalkingTec.Mvvm.Core.Support.FileHandlers
                     var fh = CreateFileHandler(file.SaveMode, dc);
                     fh.DeleteFile(file);
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    CoreProgram.GetLogger("WtmFileProvider")?.LogWarning(ex, "DeleteFile failed for FileAttachment '{FileId}' (name '{FileName}')", file.ID, file.FileName);
+                }
             }
 
         }

--- a/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmLocalFileHandler.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmLocalFileHandler.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using WalkingTec.Mvvm.Core.Extensions;
 using WalkingTec.Mvvm.Core.Models;
 
@@ -95,7 +96,10 @@ namespace WalkingTec.Mvvm.Core.Support.FileHandlers
                 {
                     File.Delete(GetFullPath(file?.Path!));
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    CoreProgram.GetLogger("WtmLocalFileHandler")?.LogWarning(ex, "DeleteFile failed for path '{Path}'", file?.Path);
+                }
             }
         }
 

--- a/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmOssFileHandler.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/FileHandlers/WtmOssFileHandler.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Aliyun.OSS;
+using Microsoft.Extensions.Logging;
 using WalkingTec.Mvvm.Core.ConfigOptions;
 using WalkingTec.Mvvm.Core.Extensions;
 using WalkingTec.Mvvm.Core.Models;
@@ -140,7 +141,10 @@ namespace WalkingTec.Mvvm.Core.Support.FileHandlers
                 OssClient client = new OssClient(groupInfo.ServerUrl, groupInfo.Key, groupInfo.Secret);
                 client.DeleteObject(groupInfo.GroupLocation, file.Path);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                CoreProgram.GetLogger("WtmOssFileHandler")?.LogWarning(ex, "OSS DeleteObject failed for bucket '{Bucket}', path '{Path}'", groupInfo.GroupLocation, file.Path);
+            }
             return;
         }
     }

--- a/src/WalkingTec.Mvvm.Core/Support/Quartz/QuartzHostService.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/Quartz/QuartzHostService.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Quartz;
 using Quartz.Impl;
 
@@ -96,7 +97,10 @@ namespace WalkingTec.Mvvm.Core.Support.Quartz
                         }
                     }
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    CoreProgram.GetLogger("QuartzHostService")?.LogWarning(ex, "QuartzHostService.StartAsync: scanning/scheduling jobs in assembly '{Asm}' threw; skipping", ass.FullName);
+                }
             }
             // 开始运行
             await _scheduler.Start(cancellationToken);

--- a/src/WalkingTec.Mvvm.Core/Support/WTMLogger.cs
+++ b/src/WalkingTec.Mvvm.Core/Support/WTMLogger.cs
@@ -143,10 +143,17 @@ namespace WalkingTec.Mvvm.Core
                                     dc.AddEntity<ActionLog>(log);
                                     dc.SaveChanges();
                                 }
+                                // Intentional: if writing an ActionLog row fails we cannot log that
+                                // failure via ILogger without re-entering this same logger and
+                                // recursing forever. Swallow silently — this is the one place in
+                                // the codebase where a bare catch is correct. (Issue #791)
                                 catch { }
                             }
                         }
                     }
+                    // Intentional: creating the DataContext inside a logger must not throw
+                    // upwards — any such failure here would recurse through this logger's Log()
+                    // again. Swallow silently. (Issue #791)
                     catch { }
                 }
             }

--- a/src/WalkingTec.Mvvm.Core/Utils.cs
+++ b/src/WalkingTec.Mvvm.Core/Utils.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using NPOI.HSSF.Util;
 using System;
 using System.Collections.Generic;
@@ -47,7 +48,10 @@ namespace WalkingTec.Mvvm.Core
                 {
                     path = Assembly.GetEntryAssembly()?.Location;
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    CoreProgram.GetLogger("Utils")?.LogDebug(ex, "GetEntryAssembly().Location failed (single-file publish?); falling back to process main module");
+                }
                 if (string.IsNullOrEmpty(path))
                 {
                     singlefile = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
@@ -89,8 +93,9 @@ namespace WalkingTec.Mvvm.Core
                     {
                         AssemblyLoadContext.Default.LoadFromAssemblyPath(dll.FullName);
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        CoreProgram.GetLogger("Utils")?.LogDebug(ex, "LoadFromAssemblyPath failed for '{Dll}'; skipping", dll.FullName);
                     }
                 }
                 List<Assembly> dlllist = [.. AssemblyLoadContext.Default.Assemblies.Where(x => systemdll.All(y => !(x.FullName ?? string.Empty).StartsWith(y)))];
@@ -128,7 +133,10 @@ namespace WalkingTec.Mvvm.Core
                             }
                         }
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        CoreProgram.GetLogger("Utils")?.LogDebug(ex, "GetAllModels: scanning assembly '{Asm}' threw; skipping", asm.FullName);
+                    }
                 }
                 _allModels = allTypes;
             }
@@ -150,7 +158,10 @@ namespace WalkingTec.Mvvm.Core
                         List<Type> dcModule = [.. asm.GetExportedTypes().Where(x => typeof(BaseVM).IsAssignableFrom(x))];
                         allTypes.AddRange(dcModule);
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        CoreProgram.GetLogger("Utils")?.LogDebug(ex, "GetAllVms: scanning assembly '{Asm}' threw; skipping", asm.FullName);
+                    }
                 }
                 _allVMs = allTypes;
             }
@@ -428,7 +439,10 @@ namespace WalkingTec.Mvvm.Core
             {
                 System.IO.File.Delete(path);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                CoreProgram.GetLogger("Utils")?.LogWarning(ex, "DeleteFile failed for '{Path}'", path);
+            }
         }
 
         #region 格式化文本  add by wuwh 2014.6.12

--- a/src/WalkingTec.Mvvm.Mvc/BaseController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/BaseController.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -421,7 +422,10 @@ namespace WalkingTec.Mvvm.Mvc
             {
                 rv.Controller.Response?.Headers?.Append("IsScript", "true");
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Wtm?.ServiceProvider?.GetService<ILoggerFactory>()?.CreateLogger("BaseController")?.LogDebug(ex, "FFResult: setting 'IsScript' response header failed (response may already be started)");
+            }
             return rv;
         }
 

--- a/src/WalkingTec.Mvvm.Mvc/Helper/ActionExecutingContextExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/ActionExecutingContextExtension.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using WalkingTec.Mvvm.Core;
 
 namespace WalkingTec.Mvvm.Mvc
@@ -26,7 +27,10 @@ namespace WalkingTec.Mvvm.Mvc
                 controller.Wtm.MSD = new ModelStateServiceProvider(self.ModelState);
                 controller.Wtm.Session = new SessionServiceProvider(self.HttpContext.Session);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                self.HttpContext.RequestServices.GetService<ILoggerFactory>()?.CreateLogger("ActionExecutingContextExtension")?.LogDebug(ex, "SetWtmContext: attaching ModelState/Session providers failed (session may be disabled)");
+            }
         }
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -32,6 +32,7 @@ using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.DependencyModel.Resolution;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
@@ -146,7 +147,10 @@ namespace WalkingTec.Mvvm.Mvc
                                 .ToList());
                     }
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Core.CoreProgram.GetLogger("FrameworkServiceExtension")?.LogWarning(ex, "GetAllMenus: failed to load FrameworkMenu from default connection; returning empty list");
+                }
             }
             return menus;
         }
@@ -881,6 +885,11 @@ namespace WalkingTec.Mvvm.Mvc
             var programLocalizer = localfactory.Create(programType);
             Core.CoreProgram._localizer = programLocalizer;
 
+            // Issue #791: give static utility classes (PropertyHelper, Utils, TypeExtension,
+            // CS, JSON converters, QuartzHostService, ...) a way to emit diagnostic logs
+            // instead of silently swallowing exceptions in bare catch blocks.
+            Core.CoreProgram._loggerFactory = app.ApplicationServices.GetService<ILoggerFactory>();
+
             var controllers = gd.GetTypesAssignableFrom<IBaseController>();
             var test = app.ApplicationServices.GetService<ISpaStaticFileProvider>();
             gd.IsSpa = isspa == true || test != null;
@@ -957,7 +966,10 @@ namespace WalkingTec.Mvvm.Mvc
                                             {
                                                 item.Attributes.Add(pro.Name, pro.GetValue(item));
                                             }
-                                            catch { }
+                                            catch (Exception ex)
+                                            {
+                                                Core.CoreProgram.GetLogger("FrameworkServiceExtension")?.LogDebug(ex, "Custom tenant attribute getter threw for property '{Property}'", pro.Name);
+                                            }
                                         }
                                     }
 

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmProblemDetailsExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmProblemDetailsExtension.cs
@@ -129,7 +129,10 @@ namespace WalkingTec.Mvvm.Mvc
                 if (wtm?.ConfigInfo != null)
                     return wtm.ConfigInfo.IsQuickDebug;
             }
-            catch { }
+            catch (Exception ex)
+            {
+                context.RequestServices.GetService<ILoggerFactory>()?.CreateLogger("WtmProblemDetailsExtension")?.LogDebug(ex, "ResolveIsQuickDebug: WTMContext lookup failed; falling back to Configs");
+            }
 
             try
             {
@@ -137,7 +140,10 @@ namespace WalkingTec.Mvvm.Mvc
                 if (configs != null)
                     return configs.IsQuickDebug;
             }
-            catch { }
+            catch (Exception ex)
+            {
+                context.RequestServices.GetService<ILoggerFactory>()?.CreateLogger("WtmProblemDetailsExtension")?.LogDebug(ex, "ResolveIsQuickDebug: Configs lookup failed; defaulting to false");
+            }
 
             return false;
         }


### PR DESCRIPTION
## Summary

Closes #791. Follow-up to #777.

#777 (released in 10.2.0) converted 13 of ~50 bare \`catch {}\` blocks to \`LogWarning\`. This PR clears the remaining **35 real sites** across the Core and Mvc projects so silent exception swallows no longer hide real bugs.

## Infrastructure

- \`CoreProgram\` gains a static \`ILoggerFactory\` and a \`GetLogger(category)\` helper. Wired in \`FrameworkServiceExtension\` next to the existing \`_localizer\` hookup. This gives pure static utility classes (\`PropertyHelper\`, \`Utils\`, \`TypeExtension\`, \`CS\`, JSON converters, \`QuartzHostService\`, \`DataContext\`, file handlers) a way to emit diagnostic logs without needing a \`Wtm\`/\`ServiceProvider\` reference.

## Sites fixed

**VM layer** (via \`Wtm.ServiceProvider.ILoggerFactory\`):
| File | Sites |
|---|---|
| \`BaseCRUDVM.DoEdit\` | 2 — UpdateProperty (FC field + UpdateTime/UpdateBy) |
| \`BaseImportVM\` | 2 — Excel formula fallback, duplicate-row UpdateProperty |
| \`BasePagedListVM\` | 2 — paging count parse, detail-grid BatchError index |

**Static utilities** (via \`CoreProgram.GetLogger\`):
| File | Sites |
|---|---|
| \`PropertyHelper\` | 6 — GetPropertyStringValues, SetPropertyValue list/array/outer, ConvertValue nullable/generic |
| \`Utils\` | 5 — GetEntryAssembly, LoadFromAssemblyPath, GetAllModels, GetAllVms, DeleteFile |
| \`TypeExtension\` | 2 — Range-attribute parse fallbacks |
| \`CS\` | 2 — DbContext ctor scans |
| \`RawStringConverter\`, \`DateRangeConverter\` | 2 — JSON read fallbacks |
| \`QuartzHostService\` | 1 — assembly-level job registration |
| \`DataContext.DataInit\` | 1 — FrameworkUserRole/FrameworkMenu probe |
| \`WtmFileProvider\`, \`WtmLocalFileHandler\`, \`WtmOssFileHandler\` | 3 — DeleteFile paths |

**MVC / middleware** (via injected / request-scoped \`ILoggerFactory\`):
| File | Sites |
|---|---|
| \`BaseController.FFResult\` | 1 |
| \`FrameworkServiceExtension\` | 2 — GetAllMenus DB fallback, custom tenant attribute getter |
| \`WtmProblemDetailsExtension.ResolveIsQuickDebug\` | 2 |
| \`WtmApiClient.CallAPI\` | 1 — 400-body ErrorObj deserialize |
| \`ActionExecutingContextExtension.SetWtmContext\` | 1 |
| \`WtmVmFactory.PopulateFormCollection\` | 1 |

**Total: 35 sites**.

## Intentional swallows (not converted)

\`WTMLogger.cs:146\` and \`:157\` are the **one place** where a bare catch is correct: logging inside the \`ActionLog\` sink must not recurse into this same \`ILogger\` implementation. Kept bare, now with explicit rationale comments referencing #791.

Four additional commented-out \`catch { }\` stubs (\`BaseImportVM:671\`, \`JwtRefreshJob:23\`, \`BaseController:136\`, \`BaseApiController:110\`) are dead code and untouched.

## Severity choice

- \`LogWarning\` for file deletion, API deserialization, DB-backed menu loading, assembly scheduling — places where silent failure is worth investigating in production.
- \`LogDebug\` for reflection / parse / Range-attribute fallbacks and config-probe paths where a missing value is an expected no-op and emitting at warning level would flood logs in normal operation.

## Compatibility

**Zero public API changes.** \`CoreProgram._loggerFactory\` and \`CoreProgram.GetLogger\` are **additive**. No existing types, signatures, or behaviors are modified. Silent swallows become diagnostic logs that emit only when the wired \`ILoggerFactory\` is present; a null factory means no-op, so apps that never called \`AddWtmContext\` (unlikely) still behave identically.

## Test plan

- [x] \`dotnet build WalkingTec.Mvvm.sln -c Release\` — 0 errors, 102 pre-existing warnings.
- [x] \`dotnet test test/WalkingTec.Mvvm.Core.Test -c Debug\` — **1205/1205 passed** (includes the #790 concurrency tests merged yesterday).
- [ ] CI green.