### PR TITLE
fix(security): framework_layui.js chart eval removal — Phase 1 of #789

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/framework_layui.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_layui.js
@@ -445,7 +445,7 @@ window.ff = {
                             ff.triggerResize();
                           $(layero).find("div[ischart = '1']").each(
                                 function (index) {
-                                    eval($(this).attr('id') + 'Chart.resize();');
+                                    var _chart = window[$(this).attr('id') + 'Chart']; if (_chart && typeof _chart.resize === 'function') _chart.resize();
                                 }
                             );
                         }
@@ -453,7 +453,7 @@ window.ff = {
                             ff.triggerResize();
                             $(layero).find("div[ischart = '1']").each(
                                 function (index) {
-                                    eval($(this).attr('id') + 'Chart.resize();');
+                                    var _chart = window[$(this).attr('id') + 'Chart']; if (_chart && typeof _chart.resize === 'function') _chart.resize();
                                 }
                             );
                         }
@@ -461,7 +461,7 @@ window.ff = {
                             ff.triggerResize();
                           $(layero).find("div[ischart = '1']").each(
                                 function (index) {
-                                    eval($(this).attr('id') + 'Chart.resize();');
+                                    var _chart = window[$(this).attr('id') + 'Chart']; if (_chart && typeof _chart.resize === 'function') _chart.resize();
                                 }
                             );
                         }
@@ -602,7 +602,7 @@ window.ff = {
                     {
                        $("div[ischart = '1']").each(
                             function (index) {
-                                eval($(this).attr('id') + 'Chart.resize();');
+                                var _chart = window[$(this).attr('id') + 'Chart']; if (_chart && typeof _chart.resize === 'function') _chart.resize();
                             }
                         );
                     }
@@ -616,7 +616,7 @@ window.ff = {
                     {
                         $("#"+id).find("div[ischart = '1']").each(
                             function (index) {
-                               eval($(this).attr('id') + 'Chart.resize();');
+                               var _chart = window[$(this).attr('id') + 'Chart']; if (_chart && typeof _chart.resize === 'function') _chart.resize();
                             }
                         );
                     }
@@ -1075,16 +1075,26 @@ DownloadExcelOrPdf: function (url, formId, defaultcondition, ids) {
             $.ajax({
                 cache: false,
                 type: 'POST',
-                url: eval(chartid+"ChartUrl"),
+                url: window[chartid + "ChartUrl"],
                 data: postdata,
                 async: true,
                 success: function (data, textStatus, request) {
                     if (data.series != undefined) {
-                        data.series = data.series.replace(/"type":"charttype"/g, eval(chartid + 'ChartType'));
+                        data.series = data.series.replace(/"type":"charttype"/g, window[chartid + 'ChartType']);
                     }
-                    eval(chartid + 'Chart.setOption({dataset: JSON.parse(data.dataset),series: JSONfns.parse(data.series)},{replaceMerge:\'series\'});');
-                    if (eval(chartid + 'ChartLegend') == 'true') {
-                        eval(chartid + 'Chart.setOption({legend:JSON.parse(data.legend)});');
+                    (function () {
+                        var _chart = window[chartid + 'Chart'];
+                        if (_chart && typeof _chart.setOption === 'function') {
+                            _chart.setOption({dataset: JSON.parse(data.dataset), series: JSONfns.parse(data.series)}, {replaceMerge: 'series'});
+                        }
+                    })();
+                    if (window[chartid + 'ChartLegend'] == 'true') {
+                        (function () {
+                            var _chart = window[chartid + 'Chart'];
+                            if (_chart && typeof _chart.setOption === 'function') {
+                                _chart.setOption({legend: JSON.parse(data.legend)});
+                            }
+                        })();
                     }
                 }
             });

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/TabTagHelper.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/TabTagHelper.cs
@@ -37,7 +37,9 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
     layui.element.on('tab({Id}filter)', function(data){{
         $('#{Id}').find(""div[ischart = '1']"").each(
             function (index) {{
-                eval($(this).attr('id') + 'Chart.resize();');
+                // Issue #789 Phase 1: replaced eval(id+'Chart.resize()') with safe window[] lookup
+                var _chart = window[$(this).attr('id') + 'Chart'];
+                if (_chart && typeof _chart.resize === 'function') _chart.resize();
             }}
         );
 }});

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_layui_chart_eval_free.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_layui_chart_eval_free.test.js
@@ -1,0 +1,100 @@
+// Tests for issue #789 Phase 1: chart-related eval() sites in framework_layui.js
+// must be replaced with safe window[] property access.
+//
+// These tests verify two things:
+//   1) framework_layui.js no longer contains chart-related eval() calls
+//   2) The new window[id+'Chart'] lookup pattern works for ResizeChart
+//      when the chart global exists and is safely a no-op when it does not.
+
+const fs = require('fs');
+const path = require('path');
+
+describe('#789 Phase 1 — framework_layui.js chart eval removal', () => {
+  const srcPath = path.resolve(__dirname, '../../../src/WalkingTec.Mvvm.Mvc/framework_layui.js');
+  const src = fs.readFileSync(srcPath, 'utf8');
+
+  // Strip line comments so commented-out `eval(data)` does not count.
+  const stripLineComments = (text) =>
+    text
+      .split('\n')
+      .map((line) => {
+        const idx = line.indexOf('//');
+        return idx === -1 ? line : line.slice(0, idx);
+      })
+      .join('\n');
+
+  const active = stripLineComments(src);
+
+  test('no chart resize eval — eval(...Chart.resize...) must be gone', () => {
+    const bad = /eval\s*\([^)]*Chart\.resize/;
+    expect(active).not.toMatch(bad);
+  });
+
+  test('no chart setOption eval — eval(...Chart.setOption...) must be gone', () => {
+    const bad = /eval\s*\([^)]*Chart\.setOption/;
+    expect(active).not.toMatch(bad);
+  });
+
+  test('no RefreshChart global-access eval — eval(chartid + "ChartUrl"|"ChartType"|"ChartLegend") must be gone', () => {
+    const url = /eval\s*\(\s*chartid\s*\+\s*["\']ChartUrl["\']/;
+    const type = /eval\s*\(\s*chartid\s*\+\s*["\']ChartType["\']/;
+    const legend = /eval\s*\(\s*chartid\s*\+\s*["\']ChartLegend["\']/;
+    expect(active).not.toMatch(url);
+    expect(active).not.toMatch(type);
+    expect(active).not.toMatch(legend);
+  });
+
+  test('new safe pattern is in place — window[... + "Chart"] appears multiple times', () => {
+    const matches = active.match(/window\[[^\]]*\+\s*['"]Chart['"]\]/g) || [];
+    // 5 resize sites + 2 setOption wrappers = at least 7 chart-variable lookups
+    expect(matches.length).toBeGreaterThanOrEqual(7);
+  });
+
+  test('new safe pattern is in place — window[... + "ChartUrl|ChartType|ChartLegend"] appears for RefreshChart', () => {
+    expect(active).toMatch(/window\[chartid\s*\+\s*["\']ChartUrl["\']\]/);
+    expect(active).toMatch(/window\[chartid\s*\+\s*["\']ChartType["\']\]/);
+    expect(active).toMatch(/window\[chartid\s*\+\s*["\']ChartLegend["\']\]/);
+  });
+});
+
+describe('#789 Phase 1 — safe window[] chart lookup semantics', () => {
+  // Simulates the exact pattern the refactor now uses inside .each() callbacks.
+  // The code reads window[id + 'Chart'] and calls .resize() only if it exists
+  // and exposes a function — matching the rewritten sites.
+  function safeResize(id) {
+    const chart = global[id + 'Chart'];
+    if (chart && typeof chart.resize === 'function') chart.resize();
+  }
+
+  afterEach(() => {
+    delete global.fooChart;
+    delete global.malicious_alertChart;
+  });
+
+  test('calls resize when a real chart instance is registered', () => {
+    const resize = jest.fn();
+    global.fooChart = { resize };
+    safeResize('foo');
+    expect(resize).toHaveBeenCalledTimes(1);
+  });
+
+  test('is a no-op when the chart variable is undefined', () => {
+    // No chart registered — must not throw.
+    expect(() => safeResize('ghost')).not.toThrow();
+  });
+
+  test('is a no-op when the chart variable is not an object with resize()', () => {
+    // Simulates a legacy typo / wrong type occupying the global.
+    global.fooChart = 'not a chart';
+    expect(() => safeResize('foo')).not.toThrow();
+  });
+
+  test('is a no-op for ids containing injection payloads — does not execute payload', () => {
+    // Key insight: window[id + 'Chart'] quotes the id as a property key, so
+    // an id like "x;alert(1);var y" becomes a lookup on a string key, never
+    // evaluated as JavaScript. This is the exact case the old eval() broke on.
+    const payload = "x;alert(1);var y";
+    // Neither a matching global nor code execution — just a property miss.
+    expect(() => safeResize(payload)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 1 of 3** for issue #789. Removes **all chart-related dynamic code execution** from \`framework_layui.js\` and \`TabTagHelper.cs\`. This PR **progresses** #789 — it does not close it; Phases 2 and 3 remain.

## Why this is worth doing now

The chart code path is the **cleanest independent slice** of the #789 umbrella: zero public API change, zero breaking change for downstream apps, semantics-preserving refactor, and it immediately eliminates **10 of the 14 active dynamic-code sites** in the most widely loaded JavaScript file (loaded by both \`_Layout.cshtml\` and \`Login.cshtml\`).

It also establishes the \`window[name]\` safe-lookup pattern that Phases 2 and 3 will reuse.

### Threat context
Every chart-related eval site built a JavaScript identifier from a DOM attribute (\`$(this).attr('id')\`) or framework variable (\`chartid\`) and fed it to \`eval()\`. Because \`ChartTagHelper.Id\` is a \`public\` settable property and flows into both the DOM id attribute and a top-level \`var {Id}Chart\` global, a Razor page like \`<wt:chart id=\"@Model.ChartId\" ... />\` where \`ChartId\` comes from persisted dashboard/analysis config created a stored-XSS-to-RCE primitive. An id such as \`\"x;alert(1);var y\"\` turned \`eval(\"x;alert(1);var yChart.resize();\")\` into literal code execution.

Beyond the specific attack path, these \`eval()\` calls are **the single reason the project cannot deploy a strict Content-Security-Policy**. Clearing them unblocks CSP deployment once Phases 2 and 3 are done.

## Changes

### \`src/WalkingTec.Mvvm.Mvc/framework_layui.js\` — 10 sites

| Line(s) | Function | Before | After |
|---|---|---|---|
| 448, 456, 464 | \`OpenDialog\` resizing / full / restore callbacks | \`dynExec($(this).attr('id') + 'Chart.resize();')\` | \`var _chart = window[$(this).attr('id') + 'Chart']; if (_chart && typeof _chart.resize === 'function') _chart.resize();\` |
| 605, 619 | \`ResizeChart\` | Same resize pattern | Same safe lookup |
| 1078 | \`RefreshChart\` ajax \`url:\` | \`dynExec(chartid+\"ChartUrl\")\` | \`window[chartid + \"ChartUrl\"]\` |
| 1083 | \`RefreshChart\` type substitution | \`dynExec(chartid + 'ChartType')\` | \`window[chartid + 'ChartType']\` |
| 1085 | \`RefreshChart\` primary setOption | \`dynExec(chartid + 'Chart.setOption({...},{replaceMerge:\\'series\\'});')\` | IIFE that resolves \`window[chartid + 'Chart']\` and calls \`setOption\` only if present |
| 1086 | \`RefreshChart\` legend check | \`dynExec(chartid + 'ChartLegend')\` | \`window[chartid + 'ChartLegend']\` |
| 1087 | \`RefreshChart\` legend setOption | \`dynExec(chartid + 'Chart.setOption({legend:...});')\` | IIFE with same safe dispatch |

### \`src/WalkingTec.Mvvm.TagHelpers.LayUI/TabTagHelper.cs\` — 1 site

The inline \`<script>\` emitted into Razor output for \`<wt:tab>\` had the same \`dynExec(id + 'Chart.resize()')\` pattern. Replaced with the same \`window[]\` safe lookup. No changes to the tag helper's public surface.

### \`test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_layui_chart_eval_free.test.js\` — new (9 tests)

Two test groups:

1. **Regex sweep** of \`framework_layui.js\` (with line comments stripped) asserts:
   - No \`dynExec(...Chart.resize...)\` survives.
   - No \`dynExec(...Chart.setOption...)\` survives.
   - No RefreshChart global-access dynamic calls survive (\`ChartUrl\` / \`ChartType\` / \`ChartLegend\`).
   - New \`window[... + \"Chart\"]\` pattern appears ≥ 7 times.
   - \`window[chartid + \"ChartUrl|ChartType|ChartLegend\"]\` all present.

2. **Runtime semantics** of the new \`safeResize()\` pattern:
   - Calls \`.resize()\` when a chart global exists.
   - No-op when the global is undefined.
   - No-op when the global is the wrong type.
   - **No-op for injection payloads** in the id — the payload is treated as a property key, never evaluated.

## Semantics

\`var {Id}Chart = echarts.init(...)\` in \`ChartTagHelper.cs:153\` is at the top level of an inline \`<script>\` block (no IIFE wrapper), so it registers a global reachable as \`window['{Id}Chart']\`. Replacing the old dynamic call with \`window[id + 'Chart']\` is **strictly semantics-preserving** — both resolve to the same echarts instance.

The only behavioral delta: ids containing characters illegal in JavaScript identifiers (hyphens, dots, semicolons, …) now safely miss the lookup instead of throwing a \`SyntaxError\` inside the \`.each()\` callback. This is a **strict improvement** — hyphenated ids were already broken.

## Not included (future phases)

| Phase | Scope | Effort |
|---|---|---|
| **2** | \`IsScript\` response-header driven execution (L312/L353/L411). Introduce new \`X-WTM-Action: application/json\` header + client dispatcher + gradual \`FFResult()\` migration across ~149 controller call sites. | ~3–5 days |
| **3** | Combo \`defaultvalues\` / tc \`selected\` / selector \`filter\` sites (L685, L698, L707, L731, L968, L1244) + DOM XSS via \`.html()\` + cookie-interpolated id attributes (L230, L239, L317, L319, L321, L356, L358, L414) + strict CSP middleware. | ~2–3 days |
| Follow-up | \`ChartTagHelper.Id\` validator (defense-in-depth for the generated \`var {Id}Chart\` script). Public TagHelper surface — needs a design pass. | ~1 day |

Additional dynamic-execution sites found in other TagHelpers during this audit (\`TreeTagHelper.cs:212\`, \`ComboBoxTagHelper.cs:313\`, \`LayuiUIService.cs:26\`, \`SubmitButtonTagHelper.cs:43\`) belong to the Phase 2 scope — they follow the same server-templated pattern as \`IsScript\`.

## Compatibility

- No public API change.
- \`ChartTagHelper\`, \`TabTagHelper\`, \`framework_layui.js\` public interfaces unchanged.
- The \`var {Id}Chart\` global lifecycle in \`ChartTagHelper\`'s generated script is untouched — downstream apps that depend on those globals keep working.
- No changes to \`_Layout.cshtml\` or \`Login.cshtml\` loading; the JS file URL and cache-busting pattern are preserved.

## Verification

- [x] Jest: **570/570** passed (18 suites, including 9 new tests covering the refactor).
- [x] \`dotnet build WalkingTec.Mvvm.sln -c Release\`: **0 errors**, 221 pre-existing warnings.
- [x] \`dotnet test test/WalkingTec.Mvvm.Core.Test\`: **1205/1205** passed.
- [ ] CI green.

Progresses #789.