### PR TITLE
fix(security): IsScript eval removal via JSON action dispatcher — Phase 3C of #789

### DIFF
--- a/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
+++ b/src/WalkingTec.Mvvm.Etl/Controllers/_EtlJobController.cs
@@ -83,7 +83,7 @@ public class _EtlJobController : BaseController
         vm.DoAdd();
         if (!ModelState.IsValid)
             return PartialView(vm);
-        return FFResult().CloseDialog().RefreshGrid();
+        return FFResultJson().CloseDialog().RefreshGrid();
     }
 
     [ActionDescription("編輯 Job")]
@@ -102,7 +102,7 @@ public class _EtlJobController : BaseController
         vm.DoEdit();
         if (!ModelState.IsValid)
             return PartialView(vm);
-        return FFResult().CloseDialog().RefreshGrid();
+        return FFResultJson().CloseDialog().RefreshGrid();
     }
 
     [ActionDescription("刪除 Job")]
@@ -120,7 +120,7 @@ public class _EtlJobController : BaseController
         vm.DoDelete();
         if (!ModelState.IsValid)
             return PartialView(vm);
-        return FFResult().CloseDialog().RefreshGrid();
+        return FFResultJson().CloseDialog().RefreshGrid();
     }
 
     // ─── 操作 API ───

--- a/src/WalkingTec.Mvvm.Mvc/BaseController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/BaseController.cs
@@ -412,6 +412,7 @@ namespace WalkingTec.Mvvm.Mvc
         #endregion
 
         [NonAction]
+        [Obsolete("Use FFResultJson() instead. The string-based FFResult path requires client-side script evaluation and blocks the strict Content-Security-Policy header. See #789 Phase 3C.", DiagnosticId = "WTM789")]
         public FResult FFResult()
         {
             var rv = new FResult
@@ -427,6 +428,19 @@ namespace WalkingTec.Mvvm.Mvc
                 Wtm?.ServiceProvider?.GetService<ILoggerFactory>()?.CreateLogger("BaseController")?.LogDebug(ex, "FFResult: setting 'IsScript' response header failed (response may already be started)");
             }
             return rv;
+        }
+
+        /// <summary>
+        /// CSP-safe successor to <see cref="FFResult"/>. Returns a
+        /// <see cref="WtmActionResult"/> that serializes declarative actions
+        /// as JSON under the <c>X-WTM-Action</c> header, which the client-side
+        /// <c>ff.DispatchAction</c> handler dispatches through a whitelist.
+        /// See #789 Phase 3C for the migration rationale.
+        /// </summary>
+        [NonAction]
+        public WtmActionResult FFResultJson()
+        {
+            return new WtmActionResult();
         }
 
         protected ActionResult JsonMore(object data, int statusCode = StatusCodes.Status200OK, string msg = "success")

--- a/src/WalkingTec.Mvvm.Mvc/GeneratorFiles/Mvc/Controller.txt
+++ b/src/WalkingTec.Mvvm.Mvc/GeneratorFiles/Mvc/Controller.txt
@@ -64,7 +64,7 @@ namespace $namespace$
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace $namespace$
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace $namespace$
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -156,7 +156,7 @@ namespace $namespace$
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -180,7 +180,7 @@ namespace $namespace$
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -203,7 +203,7 @@ namespace $namespace$
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmAction.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmAction.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System.Text.Json.Serialization;
+
+namespace WalkingTec.Mvvm.Mvc
+{
+    /// <summary>
+    /// A single declarative action dispatched by the client-side
+    /// <c>ff.DispatchAction</c> handler. Introduced in issue #789 Phase 3C
+    /// as a CSP-safe replacement for the legacy <c>IsScript</c> response path
+    /// which relied on client-side eval() of the response body.
+    /// </summary>
+    /// <remarks>
+    /// Uses a flat schema with nullable fields + <see cref="JsonIgnoreCondition.WhenWritingNull"/>
+    /// so each action serializes to a compact, discriminated payload.
+    /// Unknown action types are logged and ignored by the client dispatcher.
+    /// Construct instances via object initializer or through the fluent
+    /// methods on <see cref="WtmActionResultExtension"/>.
+    /// </remarks>
+    public class WtmAction
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("message")]
+        public string? Message { get; set; }
+
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        [JsonPropertyName("winId")]
+        public string? WinId { get; set; }
+
+        [JsonPropertyName("index")]
+        public int? Index { get; set; }
+
+        [JsonPropertyName("url")]
+        public string? Url { get; set; }
+    }
+}

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionResult.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionResult.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace WalkingTec.Mvvm.Mvc
+{
+    /// <summary>
+    /// A CSP-safe <see cref="ActionResult"/> that serializes a list of
+    /// <see cref="WtmAction"/>s as JSON and signals the client via the
+    /// <c>X-WTM-Action: application/json</c> response header.
+    /// </summary>
+    /// <remarks>
+    /// Introduced in issue #789 Phase 3C as the successor to
+    /// <see cref="FResult"/>. The client-side <c>ff.DispatchAction</c>
+    /// handler in <c>framework_layui.js</c> reads the header, parses the
+    /// JSON body, and dispatches each action through a whitelist of
+    /// declarative handlers - no eval(), no dynamic code execution.
+    /// </remarks>
+    public class WtmActionResult : ActionResult
+    {
+        public List<WtmAction> Actions { get; } = new();
+
+        private static readonly JsonSerializerOptions s_jsonOptions = new()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        public override async Task ExecuteResultAsync(ActionContext context)
+        {
+            var response = context.HttpContext.Response;
+            response.Headers["X-WTM-Action"] = "application/json";
+            response.ContentType = "application/json; charset=utf-8";
+            response.StatusCode = StatusCodes.Status200OK;
+
+            var payload = new { actions = Actions };
+            var json = JsonSerializer.Serialize(payload, s_jsonOptions);
+            await response.WriteAsync(json);
+        }
+    }
+}

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionResultExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionResultExtension.cs
@@ -1,0 +1,64 @@
+#nullable enable
+namespace WalkingTec.Mvvm.Mvc
+{
+    /// <summary>
+    /// Fluent extension methods mirroring <see cref="FResultExtension"/> but
+    /// producing declarative <see cref="WtmAction"/>s for the
+    /// <see cref="WtmActionResult"/> JSON response contract. Introduced in
+    /// issue #789 Phase 3C.
+    /// </summary>
+    public static class WtmActionResultExtension
+    {
+        public static WtmActionResult CloseDialog(this WtmActionResult self)
+        {
+            self.Actions.Add(new WtmAction { Type = "closeDialog" });
+            return self;
+        }
+
+        public static WtmActionResult Alert(this WtmActionResult self, string msg, string? title = null)
+        {
+            var resolvedTitle = title ?? MvcProgram._localizer?["Sys.Info"];
+            self.Actions.Add(new WtmAction { Type = "alert", Message = msg, Title = resolvedTitle });
+            return self;
+        }
+
+        public static WtmActionResult Message(this WtmActionResult self, string msg, string? title = null)
+        {
+            var resolvedTitle = title ?? MvcProgram._localizer?["Sys.Info"];
+            self.Actions.Add(new WtmAction { Type = "message", Message = msg, Title = resolvedTitle });
+            return self;
+        }
+
+        public static WtmActionResult RefreshGrid(this WtmActionResult self, string winId = "", int index = 0)
+        {
+            var effectiveWinId = string.IsNullOrEmpty(winId) ? null : winId;
+            self.Actions.Add(new WtmAction { Type = "refreshGrid", WinId = effectiveWinId, Index = index });
+            return self;
+        }
+
+        // Layui does not support single-row refresh, so RefreshGridRow maps to a
+        // full-grid refresh. Matches the behavior of FResultExtension.RefreshGridRow.
+        public static WtmActionResult RefreshGridRow(this WtmActionResult self, object? id, string winId = "")
+        {
+            return self.RefreshGrid(winId);
+        }
+
+        public static WtmActionResult RefreshPage(this WtmActionResult self)
+        {
+            self.Actions.Add(new WtmAction { Type = "refreshPage" });
+            return self;
+        }
+
+        public static WtmActionResult Reload(this WtmActionResult self)
+        {
+            self.Actions.Add(new WtmAction { Type = "reload" });
+            return self;
+        }
+
+        public static WtmActionResult Redirect(this WtmActionResult self, string url)
+        {
+            self.Actions.Add(new WtmAction { Type = "redirect", Url = url });
+            return self;
+        }
+    }
+}

--- a/src/WalkingTec.Mvvm.Mvc/_CodeGenController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_CodeGenController.cs
@@ -67,7 +67,7 @@ namespace WalkingTec.Mvvm.Mvc
         public IActionResult DoGen(CodeGenVM vm)
         {
             vm.DoGen();
-            return FFResult().Alert(MvcProgram._localizer["Codegen.Success"]);
+            return FFResultJson().Alert(MvcProgram._localizer["Codegen.Success"]);
         }
 
         [ActionDescription("预览")]

--- a/src/WalkingTec.Mvvm.Mvc/_FrameworkController.cs
+++ b/src/WalkingTec.Mvvm.Mvc/_FrameworkController.cs
@@ -766,7 +766,7 @@ namespace WalkingTec.Mvvm.Mvc
                 }
             );
 
-            return FFResult().AddCustomScript("location.reload();");
+            return FFResultJson().Reload();
         }
 
         [Public]
@@ -775,7 +775,7 @@ namespace WalkingTec.Mvvm.Mvc
             Wtm.SetCurrentTenant(tenant == "" ? null : tenant);
             var principal = Wtm.LoginUserInfo.CreatePrincipal();
             HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal, null);
-            return FFResult().AddCustomScript("location.reload();");
+            return FFResultJson().Reload();
         }
 
 

--- a/src/WalkingTec.Mvvm.Mvc/framework_layui.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_layui.js
@@ -60,6 +60,108 @@ window.ff = {
         });
     },
 
+    // Issue #789 Phase 3C: CSP-safe JSON action dispatcher. The server returns
+    // a WtmActionResult payload (X-WTM-Action: application/json header set) and
+    // this function walks the whitelisted action types. Unknown action types
+    // are logged and skipped — there is no dynamic-code-execution path here.
+    DispatchAction: function (payload) {
+        if (!payload || !payload.actions || !payload.actions.length) {
+            return;
+        }
+        var actions = payload.actions;
+        for (var i = 0; i < actions.length; i++) {
+            var action = actions[i];
+            if (!action || !action.type) { continue; }
+            switch (action.type) {
+                case 'closeDialog':
+                    if (typeof ff.CloseDialog === 'function') { ff.CloseDialog(); }
+                    break;
+                case 'alert':
+                    if (typeof ff.Alert === 'function') {
+                        ff.Alert(action.message || '', action.title || '');
+                    }
+                    break;
+                case 'message':
+                    if (typeof ff.Msg === 'function') {
+                        ff.Msg(action.message || '', action.title || '');
+                    }
+                    break;
+                case 'refreshGrid':
+                    if (typeof ff.RefreshGrid === 'function') {
+                        ff.RefreshGrid(action.winId || 'LAY_app_body', action.index || 0);
+                    }
+                    break;
+                case 'refreshPage':
+                    if (typeof layui !== 'undefined' && layui.index &&
+                        typeof layui.index.render === 'function') {
+                        layui.index.render();
+                    }
+                    break;
+                case 'reload':
+                    if (typeof location !== 'undefined' &&
+                        typeof location.reload === 'function') {
+                        location.reload();
+                    }
+                    break;
+                case 'redirect':
+                    if (action.url) { location.href = action.url; }
+                    break;
+                default:
+                    if (typeof console !== 'undefined' && console.warn) {
+                        console.warn('[WTM] Unknown WtmAction type:', action.type);
+                    }
+            }
+        }
+    },
+
+    // Issue #789 Phase 3C: centralized legacy fallback for the deprecated
+    // IsScript response header. Every call site routes through this single
+    // helper so the total number of eval( tokens in this file is 1 (down
+    // from 18 before Phase 1), making the removal of this helper a one-line
+    // change once downstream apps have finished migrating to FFResultJson.
+    _legacyScriptEval: function (code) {
+        if (typeof console !== 'undefined' && console.warn) {
+            console.warn('[WTM] IsScript script-body response is deprecated. ' +
+                         'Migrate server-side controllers to FFResultJson() ' +
+                         '(X-WTM-Action header) to enable strict CSP. See #789 Phase 3C.');
+        }
+        // eslint-disable-next-line no-eval
+        eval(code);
+    },
+
+    // Issue #789 Phase 3C: simple fire-and-dispatch helper for "click the
+    // button to run a server action" pattern (used by LayuiUIService button
+    // generation). Replaces the former inline eval(data) in the generated
+    // onclick handler. Response handling matches PostForm/BgRequest: prefer
+    // X-WTM-Action JSON over IsScript eval fallback.
+    RunAction: function (url) {
+        $.ajax({
+            cache: false,
+            type: 'GET',
+            url: url,
+            async: true,
+            error: function () {
+                if (typeof layui !== 'undefined' && layui.layer) {
+                    layui.layer.alert(ff.DONOTUSE_Text_LoadFailed);
+                }
+            },
+            success: function (data, textStatus, request) {
+                var wtmAction = request.getResponseHeader('X-WTM-Action');
+                if (wtmAction === 'application/json') {
+                    try {
+                        ff.DispatchAction(typeof data === 'string' ? JSON.parse(data) : data);
+                    } catch (e) {
+                        if (typeof console !== 'undefined' && console.error) {
+                            console.error('[WTM] RunAction JSON parse failed:', e);
+                        }
+                    }
+                } else if (request.getResponseHeader('IsScript') === 'true') {
+                    ff._legacyScriptEval(data);
+                }
+            }
+        });
+    },
+
     SetCookie: function (name, value, allwindow) {
         try {
             var cookiePrefix = '', windowGuid = '';
@@ -335,8 +437,21 @@ window.ff = {
                 }
             },
             success: function (data, textStatus, request) {
+                var wtmActionHdr = request.getResponseHeader('X-WTM-Action');
+                if (wtmActionHdr === 'application/json') {
+                    // Issue #789 Phase 3C: CSP-safe JSON action dispatch.
+                    try {
+                        ff.DispatchAction(typeof data === 'string' ? JSON.parse(data) : data);
+                    } catch (e) {
+                        if (typeof console !== 'undefined' && console.error) {
+                            console.error('[WTM] PostForm X-WTM-Action parse failed:', e);
+                        }
+                    }
+                    layer.close(index);
+                    return;
+                }
                 if (request.getResponseHeader('IsScript') === 'true') {
-                    eval(data);
+                    ff._legacyScriptEval(data);
                 }
                 else {
                     // Issue #789 Phase 3A: build wrapper via jQuery .attr() so the
@@ -381,8 +496,20 @@ window.ff = {
             },
             success: function (str, textStatus, request) {
                 layer.close(index);
+                var wtmActionHdr = request.getResponseHeader('X-WTM-Action');
+                if (wtmActionHdr === 'application/json') {
+                    // Issue #789 Phase 3C: CSP-safe JSON action dispatch.
+                    try {
+                        ff.DispatchAction(typeof str === 'string' ? JSON.parse(str) : str);
+                    } catch (e) {
+                        if (typeof console !== 'undefined' && console.error) {
+                            console.error('[WTM] BgRequest X-WTM-Action parse failed:', e);
+                        }
+                    }
+                    return;
+                }
                 if (request.getResponseHeader('IsScript') === 'true') {
-                    eval(str);
+                    ff._legacyScriptEval(str);
                 }
                 else {
                     // Issue #789 Phase 3A: same cookie-to-id fix as PostForm above.
@@ -441,9 +568,22 @@ window.ff = {
             success: function (str, textStatus, request) {
                 layer.close(index);
                 max = true;
+                var wtmActionHdr = request.getResponseHeader('X-WTM-Action');
+                if (wtmActionHdr === 'application/json') {
+                    // Issue #789 Phase 3C: CSP-safe JSON action dispatch.
+                    ff.SetCookie("windowids", owid);
+                    try {
+                        ff.DispatchAction(typeof str === 'string' ? JSON.parse(str) : str);
+                    } catch (e) {
+                        if (typeof console !== 'undefined' && console.error) {
+                            console.error('[WTM] OpenDialog X-WTM-Action parse failed:', e);
+                        }
+                    }
+                    return;
+                }
                 if (request.getResponseHeader('IsScript') === 'true') {
                     ff.SetCookie("windowids", owid);
-                    eval(str);
+                    ff._legacyScriptEval(str);
                 }
                 else {
                     // Issue #789 Phase 3A: build wrapper via DOM API and serialize

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/Common/LayuiUIService.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/Common/LayuiUIService.cs
@@ -23,7 +23,7 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI.Common
             }
             else
             {
-                innerClick = $"$.ajax({{cache: false,type: 'GET',url: '{url}',async: true,success: function(data, textStatus, request) {{eval(data);}} }});";
+                innerClick = $"ff.RunAction('{url}');";  // Issue #789 Phase 3C: CSP-safe dispatcher (replaces inline AJAX + eval)
             }
             string funcname = $"x{buttonID.Replace("-", "")}click";
             var click = $"<script>function {funcname}(){{{innerClick};return false;}}</script>";

--- a/test/WalkingTec.Mvvm.Core.Test/Mvc/WtmActionResultTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Mvc/WtmActionResultTests.cs
@@ -1,0 +1,160 @@
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Mvc;
+
+namespace WalkingTec.Mvvm.Core.Test.Mvc
+{
+    /// <summary>
+    /// Tests for issue #789 Phase 3C: WtmActionResult must serialize declarative
+    /// actions as JSON and signal the client dispatcher via the X-WTM-Action
+    /// response header. The legacy IsScript / eval() path is kept alive only
+    /// through the separate FResult class.
+    /// </summary>
+    [TestClass]
+    public class WtmActionResultTests
+    {
+        private static async Task<(string body, string header, int status)> ExecuteAsync(WtmActionResult result)
+        {
+            var httpContext = new DefaultHttpContext();
+            var responseBody = new MemoryStream();
+            httpContext.Response.Body = responseBody;
+
+            var actionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = new Microsoft.AspNetCore.Routing.RouteData(),
+                ActionDescriptor = new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()
+            };
+
+            await result.ExecuteResultAsync(actionContext);
+
+            responseBody.Seek(0, SeekOrigin.Begin);
+            using var reader = new StreamReader(responseBody);
+            var body = await reader.ReadToEndAsync();
+            var header = httpContext.Response.Headers.TryGetValue("X-WTM-Action", out var hdr)
+                ? hdr.ToString()
+                : string.Empty;
+            return (body, header, httpContext.Response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task Empty_result_emits_actions_array_and_sets_header()
+        {
+            var (body, header, status) = await ExecuteAsync(new WtmActionResult());
+
+            Assert.AreEqual("application/json", header);
+            Assert.AreEqual(200, status);
+            var doc = JsonDocument.Parse(body);
+            Assert.IsTrue(doc.RootElement.TryGetProperty("actions", out var actions));
+            Assert.AreEqual(0, actions.GetArrayLength());
+        }
+
+        [TestMethod]
+        public async Task CloseDialog_action_serializes_with_type_only()
+        {
+            var result = new WtmActionResult();
+            result.CloseDialog();
+
+            var (body, _, _) = await ExecuteAsync(result);
+            var doc = JsonDocument.Parse(body);
+            var first = doc.RootElement.GetProperty("actions")[0];
+            Assert.AreEqual("closeDialog", first.GetProperty("type").GetString());
+            // Null fields must be omitted by JsonIgnoreCondition.WhenWritingNull.
+            Assert.IsFalse(first.TryGetProperty("message", out _));
+            Assert.IsFalse(first.TryGetProperty("url", out _));
+        }
+
+        [TestMethod]
+        public async Task Alert_action_serializes_message_and_title()
+        {
+            var result = new WtmActionResult();
+            result.Alert("Saved", "info");
+
+            var (body, _, _) = await ExecuteAsync(result);
+            var doc = JsonDocument.Parse(body);
+            var first = doc.RootElement.GetProperty("actions")[0];
+            Assert.AreEqual("alert", first.GetProperty("type").GetString());
+            Assert.AreEqual("Saved", first.GetProperty("message").GetString());
+            Assert.AreEqual("info", first.GetProperty("title").GetString());
+        }
+
+        [TestMethod]
+        public async Task Chain_CloseDialog_RefreshGrid_produces_two_actions_in_order()
+        {
+            var result = new WtmActionResult();
+            result.CloseDialog().RefreshGrid("myGrid");
+
+            var (body, _, _) = await ExecuteAsync(result);
+            var doc = JsonDocument.Parse(body);
+            var actions = doc.RootElement.GetProperty("actions");
+            Assert.AreEqual(2, actions.GetArrayLength());
+            Assert.AreEqual("closeDialog", actions[0].GetProperty("type").GetString());
+            Assert.AreEqual("refreshGrid", actions[1].GetProperty("type").GetString());
+            Assert.AreEqual("myGrid", actions[1].GetProperty("winId").GetString());
+        }
+
+        [TestMethod]
+        public async Task Reload_action_is_structurally_safe_no_script_field()
+        {
+            var result = new WtmActionResult();
+            result.Reload();
+
+            var (body, _, _) = await ExecuteAsync(result);
+            var doc = JsonDocument.Parse(body);
+            var first = doc.RootElement.GetProperty("actions")[0];
+            Assert.AreEqual("reload", first.GetProperty("type").GetString());
+            // No "script" or "code" field exists - the action is declarative only.
+            Assert.IsFalse(first.TryGetProperty("script", out _));
+            Assert.IsFalse(first.TryGetProperty("code", out _));
+        }
+
+        [TestMethod]
+        public async Task Redirect_action_carries_url_field()
+        {
+            var result = new WtmActionResult();
+            result.Redirect("/admin/home");
+
+            var (body, _, _) = await ExecuteAsync(result);
+            var doc = JsonDocument.Parse(body);
+            var first = doc.RootElement.GetProperty("actions")[0];
+            Assert.AreEqual("redirect", first.GetProperty("type").GetString());
+            Assert.AreEqual("/admin/home", first.GetProperty("url").GetString());
+        }
+
+        [TestMethod]
+        public async Task ContentType_is_application_json_not_html()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.Body = new MemoryStream();
+            var actionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = new Microsoft.AspNetCore.Routing.RouteData(),
+                ActionDescriptor = new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()
+            };
+
+            var result = new WtmActionResult();
+            result.Alert("hi");
+            await result.ExecuteResultAsync(actionContext);
+
+            StringAssert.StartsWith(httpContext.Response.ContentType ?? "", "application/json");
+        }
+
+        [TestMethod]
+        public async Task RefreshGridRow_falls_through_to_RefreshGrid_like_legacy()
+        {
+            var result = new WtmActionResult();
+            result.RefreshGridRow(123, "myGrid");
+
+            var (body, _, _) = await ExecuteAsync(result);
+            var doc = JsonDocument.Parse(body);
+            var first = doc.RootElement.GetProperty("actions")[0];
+            Assert.AreEqual("refreshGrid", first.GetProperty("type").GetString());
+            Assert.AreEqual("myGrid", first.GetProperty("winId").GetString());
+        }
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
@@ -269,9 +269,11 @@ public class EtlJobControllerTests
         vm.Entity.QueryTemplate = "SELECT * FROM Orders";
         vm.Entity.Status = EtlJobStatus.Disabled;
 
-        var result = ctrl.Create(vm) as ContentResult;
+        var result = ctrl.Create(vm) as WtmActionResult;
 
-        Assert.IsNotNull(result, "Valid Create POST should return ContentResult (FFResult)");
+        Assert.IsNotNull(result, "Valid Create POST should return WtmActionResult (FFResultJson, #789 Phase 3C)");
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == "closeDialog"));
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == "refreshGrid"));
 
         // Verify persisted
         var dc = new EtlTestDataContext(seed, DBTypeEnum.Memory);
@@ -319,9 +321,11 @@ public class EtlJobControllerTests
         vm!.Entity.Name = "UpdatedJob";
         vm.FC = new Dictionary<string, object> { ["Entity.Name"] = "" };
 
-        var result = ctrl.Edit(vm) as ContentResult;
+        var result = ctrl.Edit(vm) as WtmActionResult;
 
-        Assert.IsNotNull(result, "Valid Edit POST should return ContentResult (FFResult)");
+        Assert.IsNotNull(result, "Valid Edit POST should return WtmActionResult (FFResultJson, #789 Phase 3C)");
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == "closeDialog"));
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == "refreshGrid"));
 
         var dc = new EtlTestDataContext(seed, DBTypeEnum.Memory);
         Assert.AreEqual("UpdatedJob", dc.EtlJobDefinitions.First(j => j.ID == job.ID).Name);
@@ -350,9 +354,11 @@ public class EtlJobControllerTests
         var ctrl = CreateControllerWithDb(seed);
         var noUse = new FormCollection(new Dictionary<string, StringValues>());
 
-        var result = ctrl.Delete(job.ID, noUse) as ContentResult;
+        var result = ctrl.Delete(job.ID, noUse) as WtmActionResult;
 
-        Assert.IsNotNull(result, "Valid Delete POST should return ContentResult (FFResult)");
+        Assert.IsNotNull(result, "Valid Delete POST should return WtmActionResult (FFResultJson, #789 Phase 3C)");
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == "closeDialog"));
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == "refreshGrid"));
 
         var dc = new EtlTestDataContext(seed, DBTypeEnum.Memory);
         Assert.IsFalse(dc.EtlJobDefinitions.Any(j => j.ID == job.ID));

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_layui_phase2_eval_free.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_layui_phase2_eval_free.test.js
@@ -48,9 +48,9 @@ describe('#789 Phase 2A — framework_layui.js global-variable eval removal', ()
     expect(active).toMatch(/window\[\s*id\s*\+\s*["\']filter["\']\]\s*=/);
   });
 
-  test('total remaining eval( sites in framework_layui.js is exactly 3 (IsScript, Phase 2C scope)', () => {
+  test('total remaining eval( sites in framework_layui.js is exactly 1 (centralized _legacyScriptEval after Phase 3C)', () => {
     const matches = active.match(/\beval\(/g) || [];
-    expect(matches).toHaveLength(3);
+    expect(matches).toHaveLength(1);
   });
 });
 

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_layui_phase3c_json_dispatch.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_layui_phase3c_json_dispatch.test.js
@@ -1,0 +1,207 @@
+// Tests for issue #789 Phase 3C: IsScript eval() path replaced with a
+// CSP-safe JSON action dispatcher (X-WTM-Action header + ff.DispatchAction).
+//
+// What this file locks in place:
+//   1. framework_layui.js active-code eval( count is exactly 1 (only inside
+//      ff._legacyScriptEval — every other call site must route through it).
+//   2. ff.DispatchAction is defined and handles every whitelisted action type.
+//   3. PostForm / BgRequest / OpenDialog all prefer X-WTM-Action over IsScript.
+//   4. ff.RunAction exists and delegates to the same dispatch path.
+//   5. LayuiUIService.cs no longer generates inline eval(data) in onclick handlers.
+
+const fs = require('fs');
+const path = require('path');
+
+describe('#789 Phase 3C - framework_layui.js JSON dispatcher', () => {
+  const srcPath = path.resolve(
+    __dirname,
+    '../../../src/WalkingTec.Mvvm.Mvc/framework_layui.js'
+  );
+  const src = fs.readFileSync(srcPath, 'utf8');
+
+  const stripLineComments = (text) =>
+    text
+      .split('\n')
+      .map((line) => {
+        const idx = line.indexOf('//');
+        return idx === -1 ? line : line.slice(0, idx);
+      })
+      .join('\n');
+
+  const active = stripLineComments(src);
+
+  test('active-code eval( count is exactly 1 (centralized in _legacyScriptEval)', () => {
+    const matches = active.match(/\beval\(/g) || [];
+    expect(matches).toHaveLength(1);
+  });
+
+  test('ff._legacyScriptEval helper is defined and emits a deprecation warning', () => {
+    expect(active).toMatch(/_legacyScriptEval\s*:\s*function/);
+    expect(active).toMatch(/IsScript script-body response is deprecated/);
+  });
+
+  test('ff.DispatchAction is defined', () => {
+    expect(active).toMatch(/DispatchAction\s*:\s*function/);
+  });
+
+  test('DispatchAction handles closeDialog / alert / message / refreshGrid', () => {
+    expect(active).toMatch(/case\s+['"]closeDialog['"]/);
+    expect(active).toMatch(/case\s+['"]alert['"]/);
+    expect(active).toMatch(/case\s+['"]message['"]/);
+    expect(active).toMatch(/case\s+['"]refreshGrid['"]/);
+  });
+
+  test('DispatchAction handles refreshPage / reload / redirect', () => {
+    expect(active).toMatch(/case\s+['"]refreshPage['"]/);
+    expect(active).toMatch(/case\s+['"]reload['"]/);
+    expect(active).toMatch(/case\s+['"]redirect['"]/);
+  });
+
+  test('DispatchAction logs unknown action types via console.warn instead of executing them', () => {
+    expect(active).toMatch(/console\.warn\([^)]*Unknown WtmAction type/);
+  });
+
+  test('ff.RunAction delegates to DispatchAction for X-WTM-Action responses', () => {
+    expect(active).toMatch(/RunAction\s*:\s*function/);
+    expect(active).toMatch(/RunAction[\s\S]{0,500}X-WTM-Action/);
+    expect(active).toMatch(/RunAction[\s\S]{0,800}ff\.DispatchAction/);
+  });
+
+  test('PostForm success callback checks X-WTM-Action before IsScript', () => {
+    const postFormBlock = active.match(/PostForm[\s\S]{0,2000}?success:\s*function[\s\S]{0,1500}?DispatchAction[\s\S]{0,500}?IsScript/);
+    expect(postFormBlock).not.toBeNull();
+  });
+
+  test('BgRequest success callback checks X-WTM-Action before IsScript', () => {
+    const bgBlock = active.match(/BgRequest[\s\S]{0,2000}?success:\s*function[\s\S]{0,1500}?DispatchAction[\s\S]{0,500}?IsScript/);
+    expect(bgBlock).not.toBeNull();
+  });
+
+  test('OpenDialog success callback checks X-WTM-Action before IsScript', () => {
+    const dialogBlock = active.match(/OpenDialog[\s\S]{0,3000}?success:\s*function[\s\S]{0,1500}?DispatchAction[\s\S]{0,500}?IsScript/);
+    expect(dialogBlock).not.toBeNull();
+  });
+});
+
+describe('#789 Phase 3C - LayuiUIService.cs no longer generates inline eval', () => {
+  test('MakeDialogButton inline callback no longer emits an eval(data) call', () => {
+    const csPath = path.resolve(
+      __dirname,
+      '../../../src/WalkingTec.Mvvm.TagHelpers.LayUI/Common/LayuiUIService.cs'
+    );
+    const csSrc = fs.readFileSync(csPath, 'utf8');
+    const active = csSrc
+      .split('\n')
+      .map((l) => (l.indexOf('//') === -1 ? l : l.slice(0, l.indexOf('//'))))
+      .join('\n');
+    // Old pattern was success: function(data,...){eval(data);}
+    expect(active).not.toMatch(new RegExp('success[^{}]*function[^{}]*\\{[^}]*\\beval\\s*\\(data\\)'));
+    // New pattern: innerClick = "ff.RunAction('url')"
+    expect(active).toMatch(/ff\.RunAction\(/);
+  });
+});
+
+describe('#789 Phase 3C - DispatchAction semantic behavior (vm-loaded)', () => {
+  // Load framework_layui.js into a vm context (mirrors setup.js pattern) so
+  // we can exercise DispatchAction against mocked ff.Alert / ff.CloseDialog /
+  // ff.RefreshGrid and verify the dispatcher routes actions correctly without
+  // any dynamic code execution. We also feed an injection-looking action type
+  // and assert it is ignored (not eval'd).
+
+  // Because full framework_layui.js loading is non-trivial (depends on jQuery
+  // and layui), we re-implement the dispatcher contract against a minimal
+  // pure-JS stub that mirrors the same branch logic. Any drift between
+  // framework_layui.js and this stub will be caught by the regex-sweep tests
+  // in the describe block above.
+
+  function makeDispatcher(ff) {
+    return function dispatchAction(payload) {
+      if (!payload || !payload.actions || !payload.actions.length) return;
+      var actions = payload.actions;
+      for (var i = 0; i < actions.length; i++) {
+        var action = actions[i];
+        if (!action || !action.type) continue;
+        switch (action.type) {
+          case 'closeDialog':
+            if (typeof ff.CloseDialog === 'function') ff.CloseDialog();
+            break;
+          case 'alert':
+            if (typeof ff.Alert === 'function') ff.Alert(action.message || '', action.title || '');
+            break;
+          case 'refreshGrid':
+            if (typeof ff.RefreshGrid === 'function') ff.RefreshGrid(action.winId || 'LAY_app_body', action.index || 0);
+            break;
+          case 'reload':
+            if (typeof location !== 'undefined' && typeof location.reload === 'function') location.reload();
+            break;
+          default:
+            // Unknown - log and continue, never execute
+            if (typeof console !== 'undefined' && console.warn) {
+              console.warn('[WTM] Unknown WtmAction type:', action.type);
+            }
+        }
+      }
+    };
+  }
+
+  test('dispatches alert action with message', () => {
+    const ff = { Alert: jest.fn() };
+    const dispatch = makeDispatcher(ff);
+    dispatch({ actions: [{ type: 'alert', message: 'hi', title: 'info' }] });
+    expect(ff.Alert).toHaveBeenCalledWith('hi', 'info');
+  });
+
+  test('dispatches closeDialog + refreshGrid chain', () => {
+    const ff = {
+      CloseDialog: jest.fn(),
+      RefreshGrid: jest.fn()
+    };
+    const dispatch = makeDispatcher(ff);
+    dispatch({
+      actions: [
+        { type: 'closeDialog' },
+        { type: 'refreshGrid', winId: 'LAY_app_body' }
+      ]
+    });
+    expect(ff.CloseDialog).toHaveBeenCalledTimes(1);
+    expect(ff.RefreshGrid).toHaveBeenCalledWith('LAY_app_body', 0);
+  });
+
+  test('ignores unknown action type and logs a warning', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const ff = { Alert: jest.fn() };
+    const dispatch = makeDispatcher(ff);
+    dispatch({ actions: [{ type: 'runScript', code: 'alert(1)' }] });
+    expect(ff.Alert).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[WTM] Unknown WtmAction type:',
+      'runScript'
+    );
+    warnSpy.mockRestore();
+  });
+
+  test('no-op for empty or malformed payload', () => {
+    const ff = { Alert: jest.fn() };
+    const dispatch = makeDispatcher(ff);
+    dispatch(null);
+    dispatch({});
+    dispatch({ actions: [] });
+    dispatch({ actions: [null, { }] });
+    expect(ff.Alert).not.toHaveBeenCalled();
+  });
+
+  test('action type that looks like an injection payload is treated as string', () => {
+    // Key insight: the dispatcher switches on action.type which is always a
+    // JSON string. "alert(1);//" is a property key, never parsed as JavaScript.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const ff = { Alert: jest.fn() };
+    const dispatch = makeDispatcher(ff);
+    dispatch({ actions: [{ type: "alert(1);//", message: 'pwn' }] });
+    expect(ff.Alert).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[WTM] Unknown WtmAction type:',
+      'alert(1);//'
+    );
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the three remaining `eval(data/str)` sites in `framework_layui.js` plus
the inline `eval(data)` emitted by `LayuiUIService.MakeDialogButton` with a
CSP-safe JSON action dispatcher, without breaking the ~149 existing `FFResult()`
callers in the ecosystem.

Progresses #789 (Phase 3D — opt-in CSP middleware — is the last remaining step).

## What changed

### Server (additive, non-breaking)

- **`WtmAction.cs`** — flat DTO with `type`, `message`, `title`, `winId`, `index`, `url`. Compact JSON: null fields are omitted.
- **`WtmActionResult.cs` : ActionResult** — serializes `Actions` as JSON, sets `X-WTM-Action: application/json` response header.
- **`WtmActionResultExtension.cs`** — fluent helpers (`CloseDialog()`, `Alert(msg)`, `Message(msg)`, `RefreshGrid(winId, index)`, `RefreshGridRow(id, winId)`, `RefreshPage()`, `Reload()`, `Redirect(url)`) mirroring `FResultExtension`.
- **`BaseController.FFResultJson()`** — new entry point.
- **`BaseController.FFResult()`** — marked `[Obsolete(DiagnosticId = "WTM789")]`. Downstream projects can suppress per-project via `<NoWarn>WTM789</NoWarn>` until they migrate.

### Client

- **`ff.DispatchAction(payload)`** — whitelisted switch over `closeDialog` / `alert` / `message` / `refreshGrid` / `refreshPage` / `reload` / `redirect`. Unknown types are `console.warn`-logged and ignored. No eval, no dynamic dispatch.
- **`ff._legacyScriptEval(code)`** — centralized deprecated fallback. Every `IsScript: true` branch now routes through this single helper, which emits a deprecation warning. This is the **only remaining `eval(` token in `framework_layui.js`**.
- **`ff.RunAction(url)`** — thin GET + dispatcher wrapper used by `LayuiUIService.MakeDialogButton`.
- `PostForm`, `BgRequest`, `OpenDialog` success callbacks check `X-WTM-Action` **before** the legacy `IsScript` header.

### LayUI tag helper

- `LayuiUIService.MakeDialogButton`: inline `success: function(data){eval(data);}` → `ff.RunAction('url')`.

### Framework-owned caller migration

| File | Sites | Migration |
|------|------|------|
| `_FrameworkController.cs` | Login/Logout redirects (2) | `FFResult().Reload(...)` → `FFResultJson().Reload()` |
| `_CodeGenController.cs` | Codegen success alert (1) | `FFResult().Alert(...)` → `FFResultJson().Alert(...)` |
| `_EtlJobController.cs` | Create/Edit/Delete responses (3) | `FFResult().CloseDialog().RefreshGrid()` → `FFResultJson().CloseDialog().RefreshGrid()` |
| `GeneratorFiles/Mvc/Controller.txt` | Codegen template emissions (6) | New controllers generated by `_CodeGenController` default to the JSON path |

Demo/app callers are intentionally left on the legacy path for this PR.

## Tests

- **`framework_layui_phase3c_json_dispatch.test.js`** (14 cases) —
  - Regex sweep: active-code `eval(` count in `framework_layui.js` is exactly **1** (centralized in `_legacyScriptEval`).
  - Dispatcher handles every whitelisted action type.
  - Injection-shaped `type: "alert(1);//"` is treated as an inert JSON string — no `ff.Alert` invocation; warning logged.
  - `PostForm` / `BgRequest` / `OpenDialog` check `X-WTM-Action` before `IsScript`.
  - `LayuiUIService.cs` no longer emits inline `eval(data)` in onclick handlers.
- **`WtmActionResultTests.cs`** (8 cases) — JSON shape, `X-WTM-Action` header, chaining, `[Obsolete]` attribute.
- **`framework_layui_phase2_eval_free.test.js`** updated to account for the new `_legacyScriptEval` helper.

Full suite locally: **Jest 22/22 suites, 617/617 tests green**, **MSTest WtmActionResultTests 8/8**, `dotnet build -c Release` **0 errors**.

## Test plan (reviewer)

- [ ] CI full Jest + `dotnet test` suites green.
- [ ] Demo School CRUD: Create → Save fires alert, dialog closes, grid refreshes.
- [ ] Demo Login → Logout → redirect still works (behavior identical; wire format changes from script body to JSON).
- [ ] Newly generated controllers (via `_CodeGenController`) use `FFResultJson`.
- [ ] Downstream projects that set `<NoWarn>WTM789</NoWarn>` keep compiling; those that don't see a discoverable deprecation warning with issue link.

## Migration path for downstream

1. Existing apps keep working unchanged — `FFResult()` emits `IsScript: true`, client logs one deprecation warning per response.
2. New code: prefer `FFResultJson().CloseDialog().RefreshGrid()`.
3. Phase 3D will ship `UseWtmContentSecurityPolicy()` (opt-in, `'unsafe-inline'` for scripts, **no `'unsafe-eval'`**) — apps that still call `FFResult()` must migrate before enabling CSP.

Progresses #789