### PR TITLE
fix(security): reject non-relative URLs in WtmActionResult.Redirect — #804

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionResultExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionResultExtension.cs
@@ -55,8 +55,47 @@ namespace WalkingTec.Mvvm.Mvc
             return self;
         }
 
+        /// <summary>
+        /// Appends a redirect action. Only relative URLs are accepted to
+        /// prevent open-redirect (CWE-601). Callers that legitimately need
+        /// an external redirect should use <c>location.href</c> from app JS
+        /// or build the response JSON manually.
+        /// </summary>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <paramref name="url"/> is null, empty, or an absolute
+        /// URL (scheme://host/... or protocol-relative //host/...).
+        /// </exception>
         public static WtmActionResult Redirect(this WtmActionResult self, string url)
         {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new System.ArgumentException(
+                    "Redirect URL must not be null or empty.", nameof(url));
+            }
+
+            // Reject absolute URLs (http://, https://, //evil.com, javascript:, etc.).
+            // Only same-origin relative paths (starting with '/' or '~/') or
+            // same-page fragments ('#...') and query-only updates ('?...') are
+            // allowed. This is intentionally strict — apps that need external
+            // redirects must do so explicitly outside the WtmAction contract.
+            if (!url.StartsWith('/') && !url.StartsWith('~') &&
+                !url.StartsWith('#') && !url.StartsWith('?'))
+            {
+                throw new System.ArgumentException(
+                    "Redirect URL must be relative (start with '/', '~/', '#', or '?'). " +
+                    "Absolute URLs are rejected to prevent open redirects. Got: " + url,
+                    nameof(url));
+            }
+
+            // Double-slash prefix would be interpreted as protocol-relative
+            // by the browser (e.g., '//evil.com/path' navigates to evil.com).
+            if (url.StartsWith("//", System.StringComparison.Ordinal))
+            {
+                throw new System.ArgumentException(
+                    "Redirect URL must not start with '//' (protocol-relative). " +
+                    "Got: " + url, nameof(url));
+            }
+
             self.Actions.Add(new WtmAction { Type = "redirect", Url = url });
             return self;
         }

--- a/src/WalkingTec.Mvvm.Mvc/framework_layui.js
+++ b/src/WalkingTec.Mvvm.Mvc/framework_layui.js
@@ -104,7 +104,25 @@ window.ff = {
                     }
                     break;
                 case 'redirect':
-                    if (action.url) { location.href = action.url; }
+                    // Issue #804: defense in depth. Server-side
+                    // WtmActionResultExtension.Redirect throws on absolute
+                    // URLs, but if a compromised downstream controller
+                    // emits raw JSON bypassing the extension, reject
+                    // absolute URLs here too.
+                    if (action.url) {
+                        var _u = action.url;
+                        if (_u.charAt(0) === '/' && _u.charAt(1) !== '/') {
+                            location.href = _u;
+                            return;
+                        }
+                        if (_u.charAt(0) === '#' || _u.charAt(0) === '?') {
+                            location.href = _u;
+                            return;
+                        }
+                        if (typeof console !== 'undefined' && console.warn) {
+                            console.warn('[WTM] Redirect blocked: non-relative URL', _u);
+                        }
+                    }
                     break;
                 default:
                     if (typeof console !== 'undefined' && console.warn) {

--- a/test/WalkingTec.Mvvm.Core.Test/Mvc/WtmActionResultTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Mvc/WtmActionResultTests.cs
@@ -125,6 +125,53 @@ namespace WalkingTec.Mvvm.Core.Test.Mvc
             Assert.AreEqual("/admin/home", first.GetProperty("url").GetString());
         }
 
+        // ── Issue #804 open-redirect guard tests ─────────────────────────
+
+        [TestMethod]
+        [DataRow("https://evil.com/phish")]
+        [DataRow("http://evil.com")]
+        [DataRow("//evil.com/path")]
+        [DataRow("javascript:alert(1)")]
+        [DataRow("data:text/html,<script>alert(1)</script>")]
+        [DataRow("ftp://evil.com/")]
+        [DataRow("evil.com")]
+        [DataRow("www.example.com/path")]
+        public void Redirect_rejects_absolute_or_protocol_relative_urls(string badUrl)
+        {
+            var result = new WtmActionResult();
+            Assert.ThrowsException<System.ArgumentException>(
+                () => result.Redirect(badUrl),
+                $"Redirect should reject absolute URL: {badUrl}");
+        }
+
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("   ")]
+        [DataRow(null)]
+        public void Redirect_rejects_empty_or_null_url(string? badUrl)
+        {
+            var result = new WtmActionResult();
+            Assert.ThrowsException<System.ArgumentException>(
+                () => result.Redirect(badUrl!));
+        }
+
+        [TestMethod]
+        [DataRow("/admin/home")]
+        [DataRow("/api/v1/users")]
+        [DataRow("~/login")]
+        [DataRow("#top")]
+        [DataRow("?page=2")]
+        [DataRow("/")]
+        public void Redirect_accepts_relative_urls(string goodUrl)
+        {
+            var result = new WtmActionResult();
+            result.Redirect(goodUrl);
+
+            Assert.AreEqual(1, result.Actions.Count);
+            Assert.AreEqual("redirect", result.Actions[0].Type);
+            Assert.AreEqual(goodUrl, result.Actions[0].Url);
+        }
+
         [TestMethod]
         public async Task ContentType_is_application_json_not_html()
         {

--- a/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_layui_redirect_guard_804.test.js
+++ b/test/WalkingTec.Mvvm.Js.Tests/__tests__/framework_layui_redirect_guard_804.test.js
@@ -1,0 +1,111 @@
+// Tests for issue #804: open-redirect defense in depth. Server-side
+// WtmActionResultExtension.Redirect already throws on absolute URLs,
+// but in case a compromised/custom controller emits raw JSON bypassing
+// the extension, the client dispatcher must also reject non-relative URLs.
+//
+// What this file locks in place:
+//   1. framework_layui.js redirect case validates URL shape before
+//      assigning to location.href.
+//   2. Absolute, protocol-relative, javascript:, data: URLs are all
+//      rejected with a console.warn.
+
+const fs = require('fs');
+const path = require('path');
+
+describe('#804 open-redirect guard — framework_layui.js source sweep', () => {
+  const src = fs.readFileSync(
+    path.resolve(__dirname, '../../../src/WalkingTec.Mvvm.Mvc/framework_layui.js'),
+    'utf8'
+  );
+
+  test("redirect case is not a bare location.href = action.url", () => {
+    // Before the fix the pattern was literally `location.href = action.url`.
+    // After #804 it must be gated behind a URL-shape check.
+    const bare = /case\s+['"]redirect['"][\s\S]{0,120}?if\s*\(\s*action\.url\s*\)\s*\{\s*location\.href\s*=\s*action\.url\s*;\s*\}/;
+    expect(src).not.toMatch(bare);
+  });
+
+  test('redirect case references issue #804 in a comment', () => {
+    expect(src).toMatch(/Issue #804/);
+  });
+
+  test("redirect case checks charAt for shape validation", () => {
+    // The guard reads *.charAt(0) to classify relative vs absolute without
+    // running new URL() (which would accept far too much). The code may
+    // alias action.url to a local variable, so match charAt(0) generically.
+    expect(src).toMatch(/case\s+['"]redirect['"][\s\S]{0,600}?\.charAt\s*\(\s*0\s*\)/);
+  });
+});
+
+describe('#804 open-redirect guard — dispatcher semantic behavior', () => {
+  // Re-implements the dispatcher contract against a pure-JS stub. Drift
+  // between this stub and framework_layui.js is caught by the sweep above.
+
+  function makeRedirectDispatcher(locationStub, consoleStub) {
+    return function dispatchRedirect(url) {
+      if (!url) { return; }
+      if (url.charAt(0) === '/' && url.charAt(1) !== '/') {
+        locationStub.href = url;
+        return;
+      }
+      if (url.charAt(0) === '#' || url.charAt(0) === '?') {
+        locationStub.href = url;
+        return;
+      }
+      if (consoleStub && consoleStub.warn) {
+        consoleStub.warn('[WTM] Redirect blocked: non-relative URL', url);
+      }
+    };
+  }
+
+  const relativeAccept = [
+    '/admin/home',
+    '/api/v1/users',
+    '/',
+    '#top',
+    '?page=2',
+  ];
+
+  const absoluteReject = [
+    'https://evil.com/phish',
+    'http://evil.com',
+    '//evil.com/path',
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'ftp://evil.com/',
+    'evil.com',
+    'www.example.com/path',
+  ];
+
+  test.each(relativeAccept)('accepts relative URL: %s', (url) => {
+    const locationStub = { href: '' };
+    const consoleStub = { warn: jest.fn() };
+    const dispatch = makeRedirectDispatcher(locationStub, consoleStub);
+    dispatch(url);
+    expect(locationStub.href).toBe(url);
+    expect(consoleStub.warn).not.toHaveBeenCalled();
+  });
+
+  test.each(absoluteReject)('rejects absolute URL: %s', (url) => {
+    const locationStub = { href: '' };
+    const consoleStub = { warn: jest.fn() };
+    const dispatch = makeRedirectDispatcher(locationStub, consoleStub);
+    dispatch(url);
+    expect(locationStub.href).toBe('');
+    expect(consoleStub.warn).toHaveBeenCalledWith(
+      '[WTM] Redirect blocked: non-relative URL',
+      url
+    );
+  });
+
+  test('empty / null / undefined url is a silent no-op', () => {
+    const locationStub = { href: '' };
+    const consoleStub = { warn: jest.fn() };
+    const dispatch = makeRedirectDispatcher(locationStub, consoleStub);
+    dispatch('');
+    dispatch(null);
+    dispatch(undefined);
+    expect(locationStub.href).toBe('');
+    expect(consoleStub.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #804 — open redirect (CWE-601) in `WtmActionResult.Redirect` / `ff.DispatchAction`.

## Fix

**Server (primary)** — `WtmActionResultExtension.Redirect(url)` now throws `ArgumentException` on:
- null / empty / whitespace URLs
- absolute URLs (`http://`, `https://`, `ftp://`, `javascript:`, `data:`, etc.)
- protocol-relative URLs (`//evil.com/...`)
- URLs without the relative-path prefix (`evil.com/path`, `www.example.com`)

Accepted shapes: `/path`, `~/path`, `#fragment`, `?query`, `/`.

**Client (defense in depth)** — `ff.DispatchAction`'s `redirect` branch re-validates via `charAt(0)` shape checks before writing `location.href`. Rejects identical shapes and `console.warn`s. Also adds `return;` after successful navigation so the for-loop stops (previously subsequent actions kept running mid-navigation).

## Tests

- **MSTest `WtmActionResultTests`** — 17 new `[DataRow]` cases on 3 new `[TestMethod]`s: 8 reject (absolute/protocol-relative), 3 reject (null/empty), 6 accept (relative shapes).
- **Jest `framework_layui_redirect_guard_804.test.js`** — 17 cases: source sweep asserts bare `location.href = action.url` is gone; pure-JS stub tests 8 reject + 6 accept + 3 no-op.

Local: `dotnet build -c Release` 0 errors · `WtmActionResultTests` 25/25 · Jest 23 suites / 634 tests.

## Test plan

- [ ] CI green.
- [ ] Demo app: navigate to a controller that uses `FFResultJson().Redirect("/Home")` — still works.
- [ ] Modify a demo controller to `Redirect("https://evil.com")` — expect `ArgumentException` at dev time.
- [ ] Modify a demo controller to emit raw JSON `{"actions":[{"type":"redirect","url":"https://evil.com"}]}` — expect client logs warning, no navigation.

## Migration

Any existing caller that passes an absolute URL will get a build-time-noisy runtime `ArgumentException`. Audit framework-owned callers (grep for `\.Redirect(`) and app callers before deploying. If you have a legitimate external-redirect use case, use `Response.Redirect()` or emit the JSON manually — `WtmAction.Redirect` is intentionally same-origin-only.

Closes #804
