### PR TITLE
chore(quality): #789 tidy-up bundle — obsolete FResult class, WtmActionType enum, RefreshGrid index, CSP docs

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Helper/FResult.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FResult.cs
@@ -1,9 +1,11 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
 namespace WalkingTec.Mvvm.Mvc
 {
+    [Obsolete("Use WtmActionResult (via BaseController.FFResultJson()) instead. The FResult class emits a JavaScript response body that requires client-side script evaluation and blocks strict Content-Security-Policy. See issue #789 Phase 3C.", DiagnosticId = "WTM789")]
     public class FResult : ContentResult
     {
         public StringBuilder ContentBuilder { get; set; }

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FResultExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FResultExtension.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace WalkingTec.Mvvm.Mvc
 {
+    [Obsolete("Use WtmActionResultExtension (via BaseController.FFResultJson()) instead. The FResult-based helpers emit JavaScript response bodies that require client-side script evaluation and block strict Content-Security-Policy. See issue #789 Phase 3C.", DiagnosticId = "WTM789")]
     public static class FResultExtension
     {
         /// <summary>

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmAction.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmAction.cs
@@ -19,7 +19,7 @@ namespace WalkingTec.Mvvm.Mvc
     public class WtmAction
     {
         [JsonPropertyName("type")]
-        public string Type { get; set; } = string.Empty;
+        public WtmActionType Type { get; set; } = WtmActionType.None;
 
         [JsonPropertyName("message")]
         public string? Message { get; set; }

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionResult.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionResult.cs
@@ -27,7 +27,11 @@ namespace WalkingTec.Mvvm.Mvc
         private static readonly JsonSerializerOptions s_jsonOptions = new()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            // Issue #806: WtmActionType serializes as camelCase strings
+            // ("alert", "closeDialog", "refreshGrid", ...) matching the
+            // literals in framework_layui.js's dispatcher switch.
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
         };
 
         public override async Task ExecuteResultAsync(ActionContext context)

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionResultExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionResultExtension.cs
@@ -11,28 +11,32 @@ namespace WalkingTec.Mvvm.Mvc
     {
         public static WtmActionResult CloseDialog(this WtmActionResult self)
         {
-            self.Actions.Add(new WtmAction { Type = "closeDialog" });
+            self.Actions.Add(new WtmAction { Type = WtmActionType.CloseDialog });
             return self;
         }
 
         public static WtmActionResult Alert(this WtmActionResult self, string msg, string? title = null)
         {
             var resolvedTitle = title ?? MvcProgram._localizer?["Sys.Info"];
-            self.Actions.Add(new WtmAction { Type = "alert", Message = msg, Title = resolvedTitle });
+            self.Actions.Add(new WtmAction { Type = WtmActionType.Alert, Message = msg, Title = resolvedTitle });
             return self;
         }
 
         public static WtmActionResult Message(this WtmActionResult self, string msg, string? title = null)
         {
             var resolvedTitle = title ?? MvcProgram._localizer?["Sys.Info"];
-            self.Actions.Add(new WtmAction { Type = "message", Message = msg, Title = resolvedTitle });
+            self.Actions.Add(new WtmAction { Type = WtmActionType.Message, Message = msg, Title = resolvedTitle });
             return self;
         }
 
         public static WtmActionResult RefreshGrid(this WtmActionResult self, string winId = "", int index = 0)
         {
             var effectiveWinId = string.IsNullOrEmpty(winId) ? null : winId;
-            self.Actions.Add(new WtmAction { Type = "refreshGrid", WinId = effectiveWinId, Index = index });
+            // Issue #806: emit index only when non-zero to honor the
+            // WhenWritingNull contract — a plain .RefreshGrid() should
+            // serialize as {"type":"refreshGrid"}, not {"type":"refreshGrid","index":0}.
+            int? effectiveIndex = index == 0 ? null : index;
+            self.Actions.Add(new WtmAction { Type = WtmActionType.RefreshGrid, WinId = effectiveWinId, Index = effectiveIndex });
             return self;
         }
 
@@ -45,13 +49,13 @@ namespace WalkingTec.Mvvm.Mvc
 
         public static WtmActionResult RefreshPage(this WtmActionResult self)
         {
-            self.Actions.Add(new WtmAction { Type = "refreshPage" });
+            self.Actions.Add(new WtmAction { Type = WtmActionType.RefreshPage });
             return self;
         }
 
         public static WtmActionResult Reload(this WtmActionResult self)
         {
-            self.Actions.Add(new WtmAction { Type = "reload" });
+            self.Actions.Add(new WtmAction { Type = WtmActionType.Reload });
             return self;
         }
 
@@ -96,7 +100,7 @@ namespace WalkingTec.Mvvm.Mvc
                     "Got: " + url, nameof(url));
             }
 
-            self.Actions.Add(new WtmAction { Type = "redirect", Url = url });
+            self.Actions.Add(new WtmAction { Type = WtmActionType.Redirect, Url = url });
             return self;
         }
     }

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionType.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmActionType.cs
@@ -1,0 +1,32 @@
+#nullable enable
+namespace WalkingTec.Mvvm.Mvc
+{
+    /// <summary>
+    /// Closed enumeration of declarative action types understood by the
+    /// client-side <c>ff.DispatchAction</c> whitelist. Introduced in issue
+    /// #806 as the typed successor to the raw-string <c>WtmAction.Type</c>
+    /// from #789 Phase 3C — unknown types are rejected at serialization
+    /// time instead of silently logged by the JS dispatcher.
+    /// </summary>
+    /// <remarks>
+    /// Serialized to JSON as camelCase strings — the serializer options on
+    /// <see cref="WtmActionResult"/> register a
+    /// <see cref="System.Text.Json.Serialization.JsonStringEnumConverter"/>
+    /// with <see cref="System.Text.Json.JsonNamingPolicy.CamelCase"/> that
+    /// maps these PascalCase members to the literal strings the JS
+    /// dispatcher in <c>framework_layui.js</c> switches on.
+    /// </remarks>
+    public enum WtmActionType
+    {
+        /// <summary>Unset — indicates a WtmAction constructed but not populated. Serializes to "none" and is ignored by the client dispatcher.</summary>
+        None = 0,
+
+        Alert,
+        Message,
+        CloseDialog,
+        RefreshGrid,
+        RefreshPage,
+        Reload,
+        Redirect,
+    }
+}

--- a/src/WalkingTec.Mvvm.Mvc/Helper/WtmCspOptions.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/WtmCspOptions.cs
@@ -36,8 +36,10 @@ namespace WalkingTec.Mvvm.Mvc
         public bool ReportOnly { get; set; } = false;
 
         /// <summary>
-        /// Optional <c>report-uri</c> / <c>report-to</c> endpoint appended to
-        /// the policy string. When null the directive is omitted.
+        /// Optional <c>report-uri</c> endpoint appended to the policy string.
+        /// When null the directive is omitted. See issue #807 for tracking
+        /// <c>report-to</c> + <c>Reporting-Endpoints</c> support (separate
+        /// modern directive with different wire format; not wired here).
         /// </summary>
         public string? ReportUri { get; set; } = null;
     }

--- a/test/WalkingTec.Mvvm.Core.Test/Mvc/WtmActionResultTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Mvc/WtmActionResultTests.cs
@@ -168,7 +168,7 @@ namespace WalkingTec.Mvvm.Core.Test.Mvc
             result.Redirect(goodUrl);
 
             Assert.AreEqual(1, result.Actions.Count);
-            Assert.AreEqual("redirect", result.Actions[0].Type);
+            Assert.AreEqual(WtmActionType.Redirect, result.Actions[0].Type);
             Assert.AreEqual(goodUrl, result.Actions[0].Url);
         }
 

--- a/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Controllers/EtlJobControllerTests.cs
@@ -272,8 +272,8 @@ public class EtlJobControllerTests
         var result = ctrl.Create(vm) as WtmActionResult;
 
         Assert.IsNotNull(result, "Valid Create POST should return WtmActionResult (FFResultJson, #789 Phase 3C)");
-        Assert.IsTrue(result!.Actions.Any(a => a.Type == "closeDialog"));
-        Assert.IsTrue(result!.Actions.Any(a => a.Type == "refreshGrid"));
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == WtmActionType.CloseDialog));
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == WtmActionType.RefreshGrid));
 
         // Verify persisted
         var dc = new EtlTestDataContext(seed, DBTypeEnum.Memory);
@@ -324,8 +324,8 @@ public class EtlJobControllerTests
         var result = ctrl.Edit(vm) as WtmActionResult;
 
         Assert.IsNotNull(result, "Valid Edit POST should return WtmActionResult (FFResultJson, #789 Phase 3C)");
-        Assert.IsTrue(result!.Actions.Any(a => a.Type == "closeDialog"));
-        Assert.IsTrue(result!.Actions.Any(a => a.Type == "refreshGrid"));
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == WtmActionType.CloseDialog));
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == WtmActionType.RefreshGrid));
 
         var dc = new EtlTestDataContext(seed, DBTypeEnum.Memory);
         Assert.AreEqual("UpdatedJob", dc.EtlJobDefinitions.First(j => j.ID == job.ID).Name);
@@ -357,8 +357,8 @@ public class EtlJobControllerTests
         var result = ctrl.Delete(job.ID, noUse) as WtmActionResult;
 
         Assert.IsNotNull(result, "Valid Delete POST should return WtmActionResult (FFResultJson, #789 Phase 3C)");
-        Assert.IsTrue(result!.Actions.Any(a => a.Type == "closeDialog"));
-        Assert.IsTrue(result!.Actions.Any(a => a.Type == "refreshGrid"));
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == WtmActionType.CloseDialog));
+        Assert.IsTrue(result!.Actions.Any(a => a.Type == WtmActionType.RefreshGrid));
 
         var dc = new EtlTestDataContext(seed, DBTypeEnum.Memory);
         Assert.IsFalse(dc.EtlJobDefinitions.Any(j => j.ID == job.ID));


### PR DESCRIPTION
## Summary

Closes #806. Bundles 5 small quality items from the post-merge review of #789 PRs #802/#803. No behavior change except RefreshGrid's compact JSON.

## Items

| # | Scope | Change |
|---|---|---|
| (a) | `FResult.cs` + `FResultExtension.cs` | Add `[Obsolete("...", DiagnosticId = "WTM789")]` to class declarations. Previously only `BaseController.FFResult()` was obsolete; callers that typed the variable `FResult` or extended the class silently escaped the migration signal. |
| (b) | `WtmAction.cs` + new `WtmActionType.cs` + `WtmActionResult.cs` | Convert `Type` from `string` to typed enum `WtmActionType { None, Alert, Message, CloseDialog, RefreshGrid, RefreshPage, Reload, Redirect }`. `WtmActionResult.s_jsonOptions` registers `JsonStringEnumConverter(JsonNamingPolicy.CamelCase)` so the JSON wire format stays identical — `"alert"`, `"closeDialog"`, `"refreshGrid"` — matching the JS dispatcher switch literals. Zero Jest changes required. |
| (c) | `WtmActionResultExtension.RefreshGrid` | `Index = index == 0 ? null : index`. Honors `WhenWritingNull`: plain `.RefreshGrid()` now emits `{"type":"refreshGrid"}` instead of `{"type":"refreshGrid","index":0}`. Client `action.index \|\| 0` already tolerates both. |
| (d) | `WtmCspOptions.ReportUri` XML doc | Drop the confusing "/ report-to" from the comment (Chrome ignores `report-uri` in favor of `report-to`; they are distinct directives). Add pointer to epic #807 where `report-to` + `Reporting-Endpoints` is tracked. |
| (e) | `framework_layui.js` redirect case | Already has `return;` after successful navigation — landed in #804 via PR #808. Verified, nothing to do. |

## Compiler cascade

Marking `FResult` obsolete could have propagated warnings into `BaseController.FFResult()`'s body (`new FResult {...}`). The C# compiler suppresses obsolete warnings **inside the body of an obsolete method**, so since `FFResult()` is itself `[Obsolete]`, no new warnings fire. Verified: **0** new `WTM789` / `CS0618` warnings from this PR.

## Tests

- `WtmActionResultTests.cs` — one existing assertion now uses `WtmActionType.Redirect` instead of the literal `"redirect"`. The 22 JSON-shape assertions (`GetProperty("type").GetString() == "alert"` etc.) all still pass because the `JsonStringEnumConverter` with CamelCase produces the identical wire strings.
- `EtlJobControllerTests.cs` — 6 CRUD assertions now compare `a.Type == WtmActionType.CloseDialog` / `RefreshGrid` instead of string literals.

## Verification

- `dotnet build -c Release` — **0 errors**, 16 pre-existing NU1903 warnings (unrelated Dependabot).
- CI-scope tests: **Core 1239/1239, Mvc 38/38, Admin 75/75, Api 20/20, Etl 174/174 (+17 pre-existing skipped)** = 1546/1546.
- `npm test` in `test/WalkingTec.Mvvm.Js.Tests`: **24 suites / 648 tests** green.

## Test plan (reviewer)

- [ ] CI green.
- [ ] Existing apps that do `FResult rv = controller.FFResult()` now see a WTM789 obsolete warning (was hidden before).
- [ ] JSON payload shape for all action types unchanged (spot-check via browser Network tab).
- [ ] Plain `FFResultJson().RefreshGrid()` response body is `{"actions":[{"type":"refreshGrid"}]}` (no trailing `"index":0`).

Closes #806
