### PR TITLE
fix(security): make CookieOption.SecurePolicy configurable — Closes #813

### DIFF
--- a/src/WalkingTec.Mvvm.Core/ConfigOptions/CookieOptions.cs
+++ b/src/WalkingTec.Mvvm.Core/ConfigOptions/CookieOptions.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Microsoft.AspNetCore.Http;
 
 namespace WalkingTec.Mvvm.Core
 {
@@ -13,5 +14,26 @@ namespace WalkingTec.Mvvm.Core
         public string AccessDeniedPath { get; set; } = "/Login/Login";
         public string Domain { get; set; } = "";
         public string ReturnUrlParameter { get; set; } = "ReturnUrl";
+
+        /// <summary>
+        /// Controls the <c>Secure</c> flag on session and authentication cookies.
+        /// Default is <see cref="CookieSecurePolicy.SameAsRequest"/> for
+        /// backwards compatibility (the flag is set when the incoming request
+        /// was HTTPS, not set otherwise).
+        /// <para>
+        /// <b>Production recommendation</b>: set to
+        /// <see cref="CookieSecurePolicy.Always"/> to force the <c>Secure</c>
+        /// flag regardless of request scheme. This is especially important
+        /// behind a TLS-terminating reverse proxy (nginx, Azure App Service,
+        /// IIS ARR, Cloudflare) where the app server sees HTTP from the proxy
+        /// — with <c>SameAsRequest</c>, cookies would be emitted without
+        /// <c>Secure</c> in that topology, and a browser would re-send them
+        /// to any accidentally-exposed HTTP endpoint on the same origin.
+        /// </para>
+        /// <para>
+        /// Issue #813 / #789 security hardening.
+        /// </para>
+        /// </summary>
+        public CookieSecurePolicy SecurePolicy { get; set; } = CookieSecurePolicy.SameAsRequest;
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -661,13 +661,17 @@ namespace WalkingTec.Mvvm.Mvc
         public static IServiceCollection AddWtmSession(this IServiceCollection services, int timeout, IConfiguration config)
         {
             var conf = config.Get<Configs>();
+            // Issue #813: honor CookieOptions.SecurePolicy so operators can
+            // force 'Secure' in production (e.g., behind a TLS-terminating
+            // reverse proxy). Default preserved as SameAsRequest.
+            var securePolicy = conf.CookieOptions?.SecurePolicy ?? CookieSecurePolicy.SameAsRequest;
             services.AddSession(options =>
             {
                 options.Cookie.Name = conf.CookiePre + ".Session";
                 options.IdleTimeout = TimeSpan.FromSeconds(timeout);
                 options.Cookie.HttpOnly = true;
                 options.Cookie.SameSite = SameSiteMode.Lax;
-                options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+                options.Cookie.SecurePolicy = securePolicy;
             });
             return services;
         }
@@ -745,7 +749,8 @@ namespace WalkingTec.Mvvm.Mvc
                         options.Cookie.Name = CookieAuthenticationDefaults.CookiePrefix + conf.CookiePre + "." + AuthConstants.CookieAuthName;
                         options.Cookie.HttpOnly = true;
                         options.Cookie.SameSite = SameSiteMode.Strict;
-                        options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+                        // Issue #813: honor CookieOptions.SecurePolicy. Default preserved as SameAsRequest.
+                        options.Cookie.SecurePolicy = cookieOptions.SecurePolicy;
                         options.Cookie.Domain = string.IsNullOrEmpty(cookieOptions.Domain) ? null : cookieOptions.Domain;
                         options.ClaimsIssuer = cookieOptions.Issuer;
                         options.SlidingExpiration = cookieOptions.SlidingExpiration;

--- a/test/WalkingTec.Mvvm.Core.Test/ConfigOptions/CookieOptionTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/ConfigOptions/CookieOptionTests.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core;
+
+namespace WalkingTec.Mvvm.Core.Test.ConfigOptions
+{
+    /// <summary>
+    /// Tests for issue #813: CookieOption.SecurePolicy must be a configurable
+    /// property (not a hardcoded framework default) so production deployments
+    /// behind TLS-terminating reverse proxies can force the Secure flag.
+    /// </summary>
+    [TestClass]
+    public class CookieOptionTests
+    {
+        [TestMethod]
+        public void SecurePolicy_defaults_to_SameAsRequest_for_backwards_compatibility()
+        {
+            var options = new CookieOption();
+            Assert.AreEqual(CookieSecurePolicy.SameAsRequest, options.SecurePolicy,
+                "Default must remain SameAsRequest so upgrading WTM does not silently change cookie behavior " +
+                "for existing deployments that work over plain HTTP locally.");
+        }
+
+        [TestMethod]
+        public void SecurePolicy_can_be_set_to_Always_for_production()
+        {
+            var options = new CookieOption
+            {
+                SecurePolicy = CookieSecurePolicy.Always
+            };
+            Assert.AreEqual(CookieSecurePolicy.Always, options.SecurePolicy);
+        }
+
+        [TestMethod]
+        public void SecurePolicy_can_be_set_to_None_for_local_HTTP_development()
+        {
+            var options = new CookieOption
+            {
+                SecurePolicy = CookieSecurePolicy.None
+            };
+            Assert.AreEqual(CookieSecurePolicy.None, options.SecurePolicy);
+        }
+
+        [TestMethod]
+        public void Other_existing_properties_retain_their_defaults_after_SecurePolicy_addition()
+        {
+            // Regression guard: adding SecurePolicy did not shift or break
+            // any existing CookieOption field default.
+            var options = new CookieOption();
+            Assert.AreEqual("http://localhost", options.Issuer);
+            Assert.AreEqual("http://localhost", options.Audience);
+            Assert.AreEqual(3600, options.Expires);
+            Assert.IsTrue(options.SlidingExpiration);
+            Assert.AreEqual("/Login/Login", options.LoginPath);
+            Assert.AreEqual("/Login/Logout", options.LogoutPath);
+            Assert.AreEqual("/Login/Login", options.AccessDeniedPath);
+            Assert.AreEqual(string.Empty, options.Domain);
+            Assert.AreEqual("ReturnUrl", options.ReturnUrlParameter);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #813. Make `CookieOption.SecurePolicy` configurable — previously hardcoded to `CookieSecurePolicy.SameAsRequest` at two sites in `FrameworkServiceExtension.cs`.

## Problem

Both `AddWtmSession` (line 670) and `AddWtmAuthentication` (line 748) hardcoded the cookie `SecurePolicy`. In production behind a TLS-terminating reverse proxy (nginx, Azure App Service, IIS ARR, Cloudflare), the app server sees HTTP from the proxy — so `SameAsRequest` emits cookies WITHOUT the `Secure` flag. An accidentally-exposed HTTP endpoint on the same origin could then receive the cookie, creating a session-hijack vector. Operators who understood the correct setting had **no config-level path** to override — only forking WTM.

## Fix

Add `CookieOption.SecurePolicy` (type `CookieSecurePolicy`, default `SameAsRequest` preserved for backwards compatibility) and route both sites through it.

```csharp
// appsettings.json
"CookieOptions": {
  "SecurePolicy": "Always",   // ← new
  "LoginPath": "/Login/Login",
  ...
}
```

Or via the service registration callback. XML doc on the property explicitly calls out the reverse-proxy concern and the production recommendation.

## Default stays `SameAsRequest`

Zero breaking change. Local HTTP dev keeps working. Existing direct-HTTPS deployments unchanged. Only apps that opt in to `Always` get the hardened behavior.

## Files

| File | Change |
|---|---|
| `src/WalkingTec.Mvvm.Core/ConfigOptions/CookieOptions.cs` | New `SecurePolicy` property + `using Microsoft.AspNetCore.Http` (Core already has `FrameworkReference` to `Microsoft.AspNetCore.App`) + XML doc |
| `src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs` | Session path reads `conf.CookieOptions?.SecurePolicy ?? SameAsRequest`; auth path reads `cookieOptions.SecurePolicy` |
| `test/WalkingTec.Mvvm.Core.Test/ConfigOptions/CookieOptionTests.cs` | 4 MSTest cases: default, Always, None, regression guard for other fields |

## Verification

- `dotnet build -c Release` — **0 errors**
- CI-scope tests: Core.Test **1243/1243** (+4 new), Mvc.Tests 38/38, Admin.Test 75/75, Api.Test 20/20, Etl.Test 174/174 = **1550/1550**

## Migration for users wanting the hardening

Add to `appsettings.json`:

```json
{
  "CookieOptions": {
    "SecurePolicy": "Always"
  }
}
```

Only relevant for HTTPS-everywhere production deployments. Apps that serve plain HTTP anywhere (including dev) should keep the default `SameAsRequest` or explicitly `None`.

## Test plan (reviewer)

- [ ] CI green.
- [ ] Demo app without config change — session/auth cookies still use `SameAsRequest` in browser devtools.
- [ ] Demo app with `"SecurePolicy": "Always"` in appsettings.json — cookies show `Secure` flag even over HTTP.
- [ ] `"SecurePolicy": "None"` — cookies omit the `Secure` flag regardless of scheme (regression path).

Closes #813
