### PR TITLE
fix(security): pin System.Security.Cryptography.Xml to 10.0.6 — Closes #816

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Security: eliminate NU1903 from `System.Security.Cryptography.Xml 8.0.2` transitive** — NPOI 2.7.6 was pulling a vulnerable 8.0.2 version (GHSA-37gx-xxp4-5rgx + GHSA-w3x6-4m5h-cxqf, both HIGH severity) into every test/demo project in the solution. Add a direct `PackageReference` to `WalkingTec.Mvvm.Core.csproj` pinning to 10.0.6 via new `<SystemSecurityCryptographyXmlVersion>` variable in `common.props` (aligns with the rest of the central-version table). All downstream projects now inherit the patched version; `dotnet list package --vulnerable --include-transitive` returns zero NU1903 rows. NPOI unchanged. (#816)
+
 ## [10.3.0] - 2026-04-17
 
 Security hardening release. Issue #789 six-phase `framework_layui.js`

--- a/common.props
+++ b/common.props
@@ -55,6 +55,10 @@
     <SerilogAspNetCoreVersion>10.0.0</SerilogAspNetCoreVersion>
     <QuartzVersion>3.16.1</QuartzVersion>
     <NPOIVersion>2.7.6</NPOIVersion>
+    <!-- Issue #816: pin transitive System.Security.Cryptography.Xml to patched 10.0.6;
+         NPOI 2.7.6 pulls 8.0.2 which has 2 HIGH CVEs (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf).
+         Direct reference on WalkingTec.Mvvm.Core beats transitive. -->
+    <SystemSecurityCryptographyXmlVersion>10.0.6</SystemSecurityCryptographyXmlVersion>
     <ImageSharpVersion>3.1.12</ImageSharpVersion>
     <ImageSharpDrawingVersion>2.1.7</ImageSharpDrawingVersion>
     <AspVersioningVersion>8.1.1</AspVersioningVersion>

--- a/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
+++ b/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="NPOI" Version="$(NPOIVersion)" />
+    <!-- Issue #816: pin vulnerable transitive from NPOI (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf). -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageReference Include="Fare" Version="2.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EntityFrameworkCoreVersion)" />


### PR DESCRIPTION
## Summary

Closes #816. Pin transitive `System.Security.Cryptography.Xml` to 10.0.6 to clear HIGH-severity NU1903 warnings from the solution.

## Problem

`dotnet list package --vulnerable --include-transitive` produces HIGH warnings on every test/demo project:

```
> System.Security.Cryptography.Xml   8.0.2   High
    https://github.com/advisories/GHSA-37gx-xxp4-5rgx
    https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
```

Traced via `dotnet nuget why` to NPOI 2.7.6 → System.Security.Cryptography.Xml 8.0.2.

## Fix

Direct `PackageReference` on `WalkingTec.Mvvm.Core` at 10.0.6 (current latest, aligned with the .NET 10 runtime this project targets). Direct beats transitive in NuGet resolution — all downstream projects inherit the patched version.

Matching central-version variable in `common.props` (follows the existing `NPOIVersion`, `EntityFrameworkCoreVersion`, ... convention).

## Diff

| File | Change |
|---|---|
| `common.props` | +4 lines (comment + `<SystemSecurityCryptographyXmlVersion>10.0.6</...>`) |
| `src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj` | +2 lines (comment + `<PackageReference>`) |
| `CHANGELOG.md` | +3 lines (new `[Unreleased]` Fixed entry) |

## Result

- `dotnet list package --vulnerable --include-transitive` → **zero** NU1903 rows for `System.Security.Cryptography.Xml`.
- Only remaining is `NU1510` informational (ASP.NET Core 10 framework already includes this package) — that's the **positive signal**: framework resolution now wins, dropping NPOI's 8.0.2 from the closure. Exactly what we want.

## Verification

- `dotnet build -c Release` — 0 errors
- CI-scope tests: **1550/1550** (Core 1243, Mvc 38, Admin 75, Api 20, Etl 174)

## Non-goals

- **No NPOI upgrade** — 2.7.6 is the latest.
- **No source code changes** — pure dependency pin.
- **No CHANGELOG release bump** — this goes into `[Unreleased]`, next release picks it up.

Closes #816
