### PR TITLE
chore(demo): migrate FFResult() → FFResultJson() (123 sites) — Closes #818

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Demo: migrate `FFResult()` → `FFResultJson()` across all demo Controllers** — 123 call sites across 21 files in `demo/WalkingTec.Mvvm.Demo/Controllers/` + `demo/.../Areas/_Admin/Controllers/` updated to the CSP-safe JSON dispatcher path introduced in 10.3.0 (#789 Phase 3C). Demo is now the canonical reference implementation for downstream WTM apps — copy-paste starter code uses the non-deprecated API. Zero `WTM789` obsolete warnings from the demo project (was 123). Build warning count drops 340 → 218. No behavior change: `Alert/Message/CloseDialog/RefreshGrid/RefreshGridRow` have identical wire semantics between `FResult` and `WtmActionResult`. (#818)
+
 ### Fixed
 - **Security: eliminate NU1903 from `System.Security.Cryptography.Xml 8.0.2` transitive** — NPOI 2.7.6 was pulling a vulnerable 8.0.2 version (GHSA-37gx-xxp4-5rgx + GHSA-w3x6-4m5h-cxqf, both HIGH severity) into every test/demo project in the solution. Add a direct `PackageReference` to `WalkingTec.Mvvm.Core.csproj` pinning to 10.0.6 via new `<SystemSecurityCryptographyXmlVersion>` variable in `common.props` (aligns with the rest of the central-version table). All downstream projects now inherit the patched version; `dotnet list package --vulnerable --include-transitive` returns zero NU1903 rows. NPOI unchanged. (#816)
 

--- a/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/ActionLogController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/ActionLogController.cs
@@ -71,7 +71,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
 

--- a/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/DataPrivilegeController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/DataPrivilegeController.cs
@@ -64,7 +64,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             else
             {
                 await vm.DoAddAsync();
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -94,7 +94,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             else
             {
                 await vm.DoEditAsync();
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -111,7 +111,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 vm = Wtm.CreateVM<DataPrivilegeVM>(values: x => x.Entity.TableName == ModelName && x.Entity.GroupCode == Id && x.DpType == Type);
             }
             await vm.DoDeleteAsync();
-            return FFResult().RefreshGrid();
+            return FFResultJson().RefreshGrid();
         }
 
         [AllRights]

--- a/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/FrameworkGroupController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/FrameworkGroupController.cs
@@ -72,7 +72,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             else
             {
                 vm.DoAdd();
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -103,7 +103,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             else
             {
                 vm.DoEdit();
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -134,7 +134,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -171,7 +171,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 DC.SaveChanges();
                 await Wtm.RemoveUserCacheByGroup(GroupCode.ToArray());
                 await Wtm.RemoveGroupCache(Wtm.LoginUserInfo?.CurrentTenant);
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.OprationSuccess"]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.OprationSuccess"]);
             }
         }
 
@@ -201,7 +201,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             else
             {
                 await Wtm.RemoveGroupCache(Wtm.LoginUserInfo.CurrentTenant);
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
 
@@ -217,7 +217,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
         public ActionResult DataFunction(FrameworkGroupMDVM vm, IFormCollection noUse)
         {
             vm.DoChange();
-            return FFResult().CloseDialog().Alert(Localizer["Sys.OprationSuccess"]);
+            return FFResultJson().CloseDialog().Alert(Localizer["Sys.OprationSuccess"]);
         }
 
         [ActionDescription("Sys.Export")]

--- a/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/FrameworkMenuController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/FrameworkMenuController.cs
@@ -75,7 +75,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -130,7 +130,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -154,7 +154,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -176,7 +176,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
         public ActionResult RefreshMenu()
         {
             Cache.Delete(nameof(GlobalData.AllMenus));
-            return FFResult().Alert(Localizer["Sys.OprationSuccess"]);
+            return FFResultJson().Alert(Localizer["Sys.OprationSuccess"]);
         }
 
         [ActionDescription("GetActionsByModelId")]

--- a/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/FrameworkRoleController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/FrameworkRoleController.cs
@@ -68,7 +68,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             else
             {
                 vm.DoAdd();
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -99,7 +99,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             else
             {
                 vm.DoEdit();
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -130,7 +130,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -167,7 +167,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 DC.SaveChanges();
                 await Wtm.RemoveUserCacheByRole(RoleCode.ToArray());
                 await Wtm.RemoveRoleCache(Wtm.LoginUserInfo.CurrentTenant);
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -197,7 +197,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             else
             {
                 await Wtm.RemoveRoleCache(Wtm.LoginUserInfo.CurrentTenant);
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
 
@@ -224,9 +224,9 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             await vm.DoChangeAsync();
             //if(vm.MSD.IsValid == false)
             //{
-            //    return FFResult().CloseDialog().Alert(vm.MSD.GetFirstError());
+            //    return FFResultJson().CloseDialog().Alert(vm.MSD.GetFirstError());
             //}
-            return FFResult().CloseDialog().Alert(Localizer["Sys.OprationSuccess"]);
+            return FFResultJson().CloseDialog().Alert(Localizer["Sys.OprationSuccess"]);
         }
 
         [ActionDescription("Sys.Export")]

--- a/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/FrameworkTenantController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/FrameworkTenantController.cs
@@ -82,7 +82,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -157,7 +157,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -202,7 +202,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -235,7 +235,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             else
             {
                 Cache.Delete(nameof(GlobalData.AllTenant));
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -266,7 +266,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/FrameworkUserController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/FrameworkUserController.cs
@@ -82,7 +82,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -156,7 +156,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -204,7 +204,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -236,7 +236,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
 
@@ -273,7 +273,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
 
@@ -323,7 +323,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
                 }
 
                 await Wtm.RemoveUserCache(itcode.ToArray());
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.OprationSuccess"]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.OprationSuccess"]);
             }
         }
 
@@ -352,7 +352,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
 
@@ -367,7 +367,7 @@ namespace WalkingTec.Mvvm.Mvc.Admin.Controllers
             user.IsValid = enable;
             DC.UpdateProperty(user, x => x.IsValid);
             DC.SaveChanges();
-            return FFResult().RefreshGrid(CurrentWindowId);
+            return FFResultJson().RefreshGrid(CurrentWindowId);
         }
 
         [AllRights]

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/CityController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/CityController.cs
@@ -99,7 +99,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -129,7 +129,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -172,7 +172,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -196,7 +196,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -223,7 +223,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -256,7 +256,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -280,7 +280,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -303,7 +303,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/HospitalController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/HospitalController.cs
@@ -64,7 +64,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -156,7 +156,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -180,7 +180,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -203,7 +203,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/ISOTypeController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/ISOTypeController.cs
@@ -64,7 +64,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -156,7 +156,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -180,7 +180,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -203,7 +203,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/LinkTest2Controller.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/LinkTest2Controller.cs
@@ -64,7 +64,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -156,7 +156,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -180,7 +180,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -203,7 +203,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/LinkTestController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/LinkTestController.cs
@@ -67,7 +67,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -100,7 +100,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -126,7 +126,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -159,7 +159,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -183,7 +183,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -206,7 +206,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/LoginController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/LoginController.cs
@@ -108,7 +108,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
 
                 if (rv == true && ModelState.IsValid)
                 {
-                    return FFResult().CloseDialog().Message(Localizer["Reg.Success"]);
+                    return FFResultJson().CloseDialog().Message(Localizer["Reg.Success"]);
                 }
                 else
                 {
@@ -153,7 +153,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 var result = await Wtm.CallAPI<string>("mainhost", "/api/_account/ChangePassword", HttpMethodEnum.POST, vm, 10);
                 if (result.StatusCode == System.Net.HttpStatusCode.OK)
                 {
-                    return FFResult().CloseDialog().Alert(Localizer["Login.ChangePasswordSuccess"]);
+                    return FFResultJson().CloseDialog().Alert(Localizer["Login.ChangePasswordSuccess"]);
                 }
                 else if (result.StatusCode == System.Net.HttpStatusCode.BadRequest)
                 {
@@ -170,7 +170,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().Alert(Localizer["Sys.Error"]);
+                    return FFResultJson().CloseDialog().Alert(Localizer["Sys.Error"]);
                 }
             }
             else
@@ -182,7 +182,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 else
                 {
                     vm.DoChange();
-                    return FFResult().CloseDialog().Alert(Localizer["Login.ChangePasswordSuccess"]);
+                    return FFResultJson().CloseDialog().Alert(Localizer["Login.ChangePasswordSuccess"]);
                 }
             }
         }

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/MajorController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/MajorController.cs
@@ -75,7 +75,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -108,7 +108,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -134,7 +134,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -167,7 +167,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -191,7 +191,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -214,7 +214,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/PatientController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/PatientController.cs
@@ -64,7 +64,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -156,7 +156,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -180,7 +180,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -203,7 +203,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/SchoolController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/SchoolController.cs
@@ -99,7 +99,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -131,7 +131,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -157,7 +157,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -190,7 +190,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().RefreshGrid().CloseDialog().Alert("操作成功，共有" + vm.Ids.Length + "条数据被修改");
+                return FFResultJson().RefreshGrid().CloseDialog().Alert("操作成功，共有" + vm.Ids.Length + "条数据被修改");
             }
         }
         #endregion
@@ -211,11 +211,11 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             if (!ModelState.IsValid || !vm.DoBatchDelete())
             {
-                return FFResult().Alert(ModelState.GetErrorJson().GetFirstError());
+                return FFResultJson().Alert(ModelState.GetErrorJson().GetFirstError());
             }
             else
             {
-                return FFResult().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess",vm.Ids.Length]);
+                return FFResultJson().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess",vm.Ids.Length]);
             }
         }
 
@@ -239,7 +239,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().RefreshGrid().CloseDialog().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().RefreshGrid().CloseDialog().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion
@@ -278,7 +278,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -319,7 +319,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/SoftFacInfoController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/SoftFacInfoController.cs
@@ -64,7 +64,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -156,7 +156,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -180,7 +180,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -203,7 +203,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/StudentController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/StudentController.cs
@@ -65,7 +65,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -98,7 +98,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -124,7 +124,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -157,7 +157,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -181,7 +181,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -204,7 +204,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/TreeTestController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/TreeTestController.cs
@@ -64,7 +64,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -156,7 +156,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -180,7 +180,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -203,7 +203,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/WxReportDataController.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/WxReportDataController.cs
@@ -64,7 +64,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -156,7 +156,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchEditSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -180,7 +180,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.BatchDeleteSuccess", vm.Ids.Length]);
             }
         }
         #endregion
@@ -203,7 +203,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
+                return FFResultJson().CloseDialog().RefreshGrid().Alert(Localizer["Sys.ImportSuccess", vm.EntityList.Count.ToString()]);
             }
         }
         #endregion

--- a/demo/WalkingTec.Mvvm.Demo/Controllers/不要用中文模型名Controller.cs
+++ b/demo/WalkingTec.Mvvm.Demo/Controllers/不要用中文模型名Controller.cs
@@ -55,7 +55,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGrid();
+                    return FFResultJson().CloseDialog().RefreshGrid();
                 }
             }
         }
@@ -88,7 +88,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
                 }
                 else
                 {
-                    return FFResult().CloseDialog().RefreshGridRow(vm.Entity.ID);
+                    return FFResultJson().CloseDialog().RefreshGridRow(vm.Entity.ID);
                 }
             }
         }
@@ -114,7 +114,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid();
+                return FFResultJson().CloseDialog().RefreshGrid();
             }
         }
         #endregion
@@ -147,7 +147,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert("操作成功，共有"+vm.Ids.Length+"条数据被修改");
+                return FFResultJson().CloseDialog().RefreshGrid().Alert("操作成功，共有"+vm.Ids.Length+"条数据被修改");
             }
         }
         #endregion
@@ -171,7 +171,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert("操作成功，共有"+vm.Ids.Length+"条数据被删除");
+                return FFResultJson().CloseDialog().RefreshGrid().Alert("操作成功，共有"+vm.Ids.Length+"条数据被删除");
             }
         }
         #endregion
@@ -194,7 +194,7 @@ namespace WalkingTec.Mvvm.Demo.Controllers
             }
             else
             {
-                return FFResult().CloseDialog().RefreshGrid().Alert("成功导入 " + vm.EntityList.Count.ToString() + " 行数据");
+                return FFResultJson().CloseDialog().RefreshGrid().Alert("成功导入 " + vm.EntityList.Count.ToString() + " 行数据");
             }
         }
         #endregion


### PR DESCRIPTION
## Summary

Closes #818. Demo is now the canonical reference implementation for downstream WTM apps using the 10.3.0 JSON dispatcher (`FFResultJson()` + `WtmActionResult`).

## Before / after

| | Before | After |
|---|---|---|
| `FFResult()` in demo | **123** | **0** |
| `WTM789` obsolete warnings | **123** | **0** |
| Build warning count (solution) | 340 | **218** |
| Behavior | — | Identical (wire-compatible fluent chain) |

## Fix

Mechanical `FFResult()` → `FFResultJson()` substitution across:

- `demo/WalkingTec.Mvvm.Demo/Controllers/*.cs` — 14 files, 87 sites
- `demo/WalkingTec.Mvvm.Demo/Areas/_Admin/Controllers/*.cs` — 7 files, 36 sites

Pre-audit confirmed safety:

| Check | Result |
|---|---|
| Only uses `Alert / Message / CloseDialog / RefreshGrid / RefreshGridRow` | ✅ (all identical on `WtmActionResultExtension`) |
| No `AddCustomScript` (would break — intentionally absent from JSON dispatcher) | ✅ zero matches |
| No `FFResult().Redirect("absolute")` (would throw per #804) | ✅ zero matches; only `HttpContext.Response.Redirect("/")` in LoginController line 128 (different API, unchanged) |

## Why this matters (PM/SA)

- **Migration signal clarity**: 10.3.0 recommended `FFResultJson()` but the official demo still emitted 123 WTM789 warnings from its own code. Downstream forks saw the contradiction first.
- **End-to-end validation**: Phase 3C's JSON dispatcher was validated only through framework-internal callers. Student / Major / Patient / ISO / Hospital / City / Tenant / Role / User CRUD paths now exercise the dispatcher in a live demo.
- **Copy-paste seed**: every new WTM app starts by forking demo controllers. Migrating now prevents the legacy API from propagating into new downstream projects.

## Verification

- `dotnet build -c Release` — **0 errors**, 122 fewer warnings.
- CI-scope tests: **1550/1550** (Core 1243, Mvc 38, Admin 75, Api 20, Etl 174).
- Manual E2E plan: run demo app, exercise Student Create / Edit / Delete — dialogs close, grid refreshes, identical UX (pre-migration user flow).

## Test plan (reviewer)

- [ ] CI green.
- [ ] Demo School CRUD (Create → Save → Edit → Save → Delete) — all dialogs + grid interactions identical.
- [ ] Demo Admin Tenant / Role / User CRUD — identical.
- [ ] Spot-check network tab: response body is `{"actions":[...]}` JSON (not script body) + `X-WTM-Action: application/json` header.

## Non-goals

- NOT removing `FResult` / `FResultExtension` classes — remain `[Obsolete]` and compilable for the next release cycle. Apps that directly depend on these classes still work.
- NOT touching `Controller.txt` codegen template — already migrated in #806 (PR #810).
- NOT migrating other demos — Vue / React / Vue3 / Blazor / Console have zero `FFResult()` usage (SPA frontends bypass the dispatcher entirely).

Closes #818
