### PR TITLE
chore(ci): upgrade GitHub Actions to @v5 (Node 24 runtime) — Closes #820

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,7 +9,7 @@ jobs:
   release-tooling-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Validate release script syntax
       run: bash -n scripts/release-github-package.sh
     - name: Run release script smoke tests
@@ -17,8 +17,8 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
     - run: dotnet restore ci.slnf
@@ -69,14 +69,14 @@ jobs:
         fi
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: test-results
         path: "TestResults/**/*.trx"
 
     - name: Upload coverage report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: coverage-report
@@ -84,8 +84,8 @@ jobs:
   js-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
     - name: Install JS test dependencies
@@ -98,8 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release-tooling-test, build-and-test]
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
     - run: dotnet restore WalkingTec.Mvvm.sln

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -25,10 +25,10 @@ jobs:
       WTM_E2E_REPORT: test/e2e/results/junit.xml
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: e2e-screenshots
           path: test/e2e/screenshots/
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload JUnit XML report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: e2e-junit-report
           path: test/e2e/results/junit.xml

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -25,9 +25,9 @@ jobs:
           --health-timeout 5s
           --health-retries 3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -58,7 +58,7 @@ jobs:
           WTM_TEST_MSSQL: "Server=localhost,1433;Database=WtmIntegrationTest;User Id=sa;Password=YourStr0ng!Pass;TrustServerCertificate=True"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: integration-test-results

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -22,10 +22,10 @@ jobs:
       PACKAGE_SOURCE: https://nuget.pkg.github.com/cct08311github/index.json
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 


### PR DESCRIPTION
## Summary

Closes #820. Upgrade all GitHub Actions from `@v4` (Node 20) to `@v5` (Node 24) ahead of the Sep 2026 Node 20 runner removal.

## Problem

Every workflow run emits a deprecation annotation:

> Node.js 20 actions are deprecated. ... will be forced to run with Node.js 24 by default starting June 2, 2026. Node.js 20 will be removed from the runner on September 16, 2026.

At `v4` → `v5` we get the Node 24 runtime now, silence the annotation, and avoid the silent CI breakage window between June and September 2026.

## Upgrades

| Action | v4 → v5 occurrences |
|---|---|
| `actions/checkout` | 7 |
| `actions/setup-dotnet` | 5 |
| `actions/upload-artifact` | 5 |
| `actions/setup-node` | 1 |
| `actions/setup-python` | (already `@v5`, unchanged) |

**Files**: `.github/workflows/{ci-build,e2e-test,integration-test,publish-nuget}.yml` — **18 replacements total**, diff is a clean 1:1 substitution (18 insertions / 18 deletions).

## Non-goals

- **No `node-version` input changes**: `setup-node@v5` still installs Node 20 for the `js-test` job's `npm test` — that's the Node version installed FOR the job, not the runner Node. A Node LTS bump for Jest is a separate concern.
- **No third-party action touches**: WTM only uses `actions/*` officially published; zero cross-publisher version drift risk.
- **No dependabot config changes**: Dependabot still tracks these; we're just upgrading ahead of its next sweep.

## Verification

CI matrix on this PR exercises every upgraded action:

- `ci-build.yml` → checkout, setup-dotnet, upload-artifact, setup-node (build-and-test, js-test, release-tooling-test, security-scan, CodeQL Analyze ×4)
- `e2e-test.yml` → checkout, setup-dotnet, upload-artifact (Playwright full suite)
- `integration-test.yml` → checkout, setup-dotnet, upload-artifact (SQL Server service container)

**If any `@v5` has a breaking default**, CI fails with a clear error on this PR → pin back selectively. No repo state change required.

## Test plan (reviewer)

- [ ] All 11 CI checks pass.
- [ ] No "Node.js 20 actions are deprecated" annotation on the PR run.
- [ ] Artifact uploads still succeed (`upload-artifact@v5` has some subtle compression default changes — verify e2e artifacts and integration-test-results upload).

Closes #820
