### PR TITLE
chore(test): migrate Mvc.Tests from xunit to MSTest — Closes #822

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- **Tests: migrate `WalkingTec.Mvvm.Mvc.Tests` from deprecated xunit 2.9.3 to MSTest** — The only test project still on xunit is now unified with the rest of the WTM test suite (Core/Admin/Api/Etl/Integration all MSTest). Removes the last `dotnet list package --deprecated` hit. 38 tests unchanged; `FluentAssertions` style preserved (framework-agnostic). `[Fact]` → `[TestMethod]`, `[Theory]` + `[InlineData]` → `[TestMethod]` + `[DataRow]`, constructor → `[TestInitialize]`, `IDisposable.Dispose` → `[TestCleanup]`. (#822)
 - **Demo: migrate `FFResult()` → `FFResultJson()` across all demo Controllers** — 123 call sites across 21 files in `demo/WalkingTec.Mvvm.Demo/Controllers/` + `demo/.../Areas/_Admin/Controllers/` updated to the CSP-safe JSON dispatcher path introduced in 10.3.0 (#789 Phase 3C). Demo is now the canonical reference implementation for downstream WTM apps — copy-paste starter code uses the non-deprecated API. Zero `WTM789` obsolete warnings from the demo project (was 123). Build warning count drops 340 → 218. No behavior change: `Alert/Message/CloseDialog/RefreshGrid/RefreshGridRow` have identical wire semantics between `FResult` and `WtmActionResult`. (#818)
 
 ### Fixed

--- a/src/WalkingTec.Mvvm.Mvc.Tests/Integration/TokenServiceIntegrationTests.cs
+++ b/src/WalkingTec.Mvvm.Mvc.Tests/Integration/TokenServiceIntegrationTests.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Auth;
 using WalkingTec.Mvvm.Mvc.Tests.Fixtures;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace WalkingTec.Mvvm.Mvc.Tests.Integration
 {
@@ -14,18 +14,20 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
     /// Integration tests for TokenService.
     /// Each test class instance gets its own isolated InMemory DB via TokenTestFixture.
     /// </summary>
-    public class TokenServiceIntegrationTests : IDisposable
+    [TestClass]
+    public class TokenServiceIntegrationTests
     {
-        private readonly TokenTestFixture _fx;
+        private TokenTestFixture _fx = null!;
 
-        public TokenServiceIntegrationTests()
+        [TestInitialize]
+        public void Setup()
         {
             _fx = new TokenTestFixture();
         }
 
         // ─── IssueTokenAsync ───────────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task IssueTokenAsync_ValidUser_ReturnsAccessAndRefreshToken()
         {
             var user = new LoginUserInfo { ITCode = "alice", TenantCode = null };
@@ -39,7 +41,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
             token.ExpiresIn.Should().BeGreaterThan(0);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssueTokenAsync_PersistsRefreshTokenInDb()
         {
             var user = new LoginUserInfo { ITCode = "bob" };
@@ -54,7 +56,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
             stored.IsActive.Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssueTokenAsync_NullUser_ThrowsArgumentNullException()
         {
             var act = () => _fx.TokenService.IssueTokenAsync(null!);
@@ -62,7 +64,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
             await act.Should().ThrowAsync<ArgumentNullException>();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssueTokenAsync_TwoIssues_ProduceDistinctRefreshTokens()
         {
             var user = new LoginUserInfo { ITCode = "charlie" };
@@ -74,7 +76,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
                 "each issue produces a cryptographically unique token");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssueTokenAsync_PreservesTenantCode()
         {
             var user = new LoginUserInfo { ITCode = "tenant_user", TenantCode = "tenant_a" };
@@ -89,7 +91,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
 
         // ─── RefreshTokenAsync ─────────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task RefreshTokenAsync_ValidToken_ReturnsNewTokenPairAndRotatesOld()
         {
             var user = new LoginUserInfo { ITCode = "dave" };
@@ -111,7 +113,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
             old.ReplacedByToken.Should().Be(refreshed.RefreshToken);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task RefreshTokenAsync_ExpiredToken_ReturnsNull()
         {
             var expired = new RefreshTokenEntity
@@ -128,7 +130,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
             result.Should().BeNull();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task RefreshTokenAsync_RevokedToken_ReturnsNull()
         {
             var revoked = new RefreshTokenEntity
@@ -146,16 +148,16 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
             result.Should().BeNull();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task RefreshTokenAsync_NonexistentToken_ReturnsNull()
         {
             var result = await _fx.TokenService.RefreshTokenAsync("does_not_exist_token");
             result.Should().BeNull();
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
         public async Task RefreshTokenAsync_NullOrEmpty_ReturnsNull(string? token)
         {
             var result = await _fx.TokenService.RefreshTokenAsync(token!);
@@ -164,7 +166,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
 
         // ─── Reuse Detection ───────────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task RefreshTokenAsync_ReusedToken_RevokesDescendantChain()
         {
             // Issue T1
@@ -192,7 +194,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
 
         // ─── RevokeTokenAsync ──────────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task RevokeTokenAsync_ActiveToken_SetsRevokedUtcAndReason()
         {
             var user = new LoginUserInfo { ITCode = "helen" };
@@ -209,7 +211,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
             entity.RevokedByIp.Should().Be("127.0.0.1");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task RevokeTokenAsync_AlreadyRevoked_IsNoOp()
         {
             var revoked = new RefreshTokenEntity
@@ -234,9 +236,9 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
                 "already-revoked token is not modified");
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
         public async Task RevokeTokenAsync_NullOrEmpty_DoesNotThrow(string? token)
         {
             var act = () => _fx.TokenService.RevokeTokenAsync(token!);
@@ -245,7 +247,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
 
         // ─── Tenant Isolation ──────────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task IssueTokenAsync_DifferentTenants_TokensHaveDifferentTenantCodes()
         {
             var userA = new LoginUserInfo { ITCode = "judy", TenantCode = "tenant_a" };
@@ -265,6 +267,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Integration
             tokenA.RefreshToken.Should().NotBe(tokenB.RefreshToken);
         }
 
-        public void Dispose() => _fx.Dispose();
+        [TestCleanup]
+        public void Cleanup() => _fx?.Dispose();
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc.Tests/Security/JwtClaimsValidationTests.cs
+++ b/src/WalkingTec.Mvvm.Mvc.Tests/Security/JwtClaimsValidationTests.cs
@@ -7,7 +7,7 @@ using FluentAssertions;
 using Microsoft.IdentityModel.Tokens;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Mvc.Tests.Fixtures;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace WalkingTec.Mvvm.Mvc.Tests.Security
 {
@@ -20,7 +20,8 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
     /// - Validate permission claims boundaries (itcode, tenant, jti present)
     /// - Validate expired tokens (expiration matches config)
     /// </summary>
-    public class JwtClaimsValidationTests : IDisposable
+    [TestClass]
+    public class JwtClaimsValidationTests
     {
         private readonly TokenTestFixture _fixture = new();
         private const string TestSecurityKey = "WTM_Test_Key_AtLeast_32_Characters!!";
@@ -29,7 +30,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
 
         // ─── Claims Content ─────────────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_ContainsItCodeClaim()
         {
             var user = CreateUser("alice");
@@ -39,7 +40,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             jwt.Claims.Should().Contain(c => c.Type == "itcode" && c.Value == "alice");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_ContainsJtiClaim()
         {
             var user = CreateUser("bob");
@@ -51,7 +52,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             jti.Should().NotBeNullOrEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_JtiIsUniquePerIssuance()
         {
             var user = CreateUser("charlie");
@@ -63,7 +64,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             jti1.Should().NotBe(jti2, "each issuance must have a unique JTI to prevent replay");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_WithTenant_ContainsTenantClaim()
         {
             var user = CreateUser("dave", tenantCode: "tenant_a");
@@ -73,7 +74,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             jwt.Claims.Should().Contain(c => c.Type == "tenant" && c.Value == "tenant_a");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_WithoutTenant_OmitsTenantClaim()
         {
             var user = CreateUser("eve");
@@ -85,7 +86,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
 
         // ─── Expiration Boundaries ──────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_ExpirationMatchesConfiguredLifetime()
         {
             var before = DateTime.UtcNow;
@@ -98,7 +99,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             jwt.ValidTo.Should().BeBefore(after.AddSeconds(3601));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_ExpiresInMatchesConfiguredSeconds()
         {
             var user = CreateUser("grace");
@@ -110,7 +111,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
 
         // ─── Signature Validation ───────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_ValidatesWithCorrectKey()
         {
             var user = CreateUser("heidi");
@@ -134,7 +135,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             validatedToken.Should().NotBeNull();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_FailsValidationWithWrongKey()
         {
             var user = CreateUser("ivan");
@@ -157,7 +158,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             act.Should().Throw<SecurityTokenSignatureKeyNotFoundException>();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_FailsValidationWithWrongIssuer()
         {
             var user = CreateUser("judy");
@@ -178,7 +179,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             act.Should().Throw<SecurityTokenInvalidIssuerException>();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_FailsValidationWithWrongAudience()
         {
             var user = CreateUser("karl");
@@ -199,7 +200,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             act.Should().Throw<SecurityTokenInvalidAudienceException>();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task TamperedToken_FailsSignatureValidation()
         {
             var user = CreateUser("lisa");
@@ -230,7 +231,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
 
         // ─── Token Structure ────────────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_HasBearerTypeAndRefreshToken()
         {
             var user = CreateUser("mike");
@@ -242,7 +243,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             token.ExpiresIn.Should().BeGreaterThan(0);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task IssuedToken_AccessTokenIsThreePartJwt()
         {
             var user = CreateUser("nina");
@@ -270,6 +271,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             return handler.ReadJwtToken(token);
         }
 
-        public void Dispose() => _fixture.Dispose();
+        [TestCleanup]
+        public void Cleanup() => _fixture?.Dispose();
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc.Tests/Security/TokenChainSecurityTests.cs
+++ b/src/WalkingTec.Mvvm.Mvc.Tests/Security/TokenChainSecurityTests.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using WalkingTec.Mvvm.Core;
 using WalkingTec.Mvvm.Core.Auth;
 using WalkingTec.Mvvm.Mvc.Tests.Fixtures;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace WalkingTec.Mvvm.Mvc.Tests.Security
 {
@@ -14,18 +14,20 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
     /// Verifies theft-detection, chain revocation, and token uniqueness properties
     /// that go beyond basic happy-path coverage in TokenServiceIntegrationTests.
     /// </summary>
-    public class TokenChainSecurityTests : IDisposable
+    [TestClass]
+    public class TokenChainSecurityTests
     {
-        private readonly TokenTestFixture _fx;
+        private TokenTestFixture _fx = null!;
 
-        public TokenChainSecurityTests()
+        [TestInitialize]
+        public void Setup()
         {
             _fx = new TokenTestFixture();
         }
 
         // ─── Reuse Detection — Multi-Hop Chain ──────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task RefreshChain_ThreeHops_EachPriorTokenRevoked()
         {
             // Issue T1, refresh → T2, refresh → T3
@@ -54,7 +56,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             e3.IsActive.Should().BeTrue("T3 is the live token at the end of the chain");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task RefreshChain_ReuseAtMidpoint_RevokesAllDescendants()
         {
             // Issue T1 → T2 → T3
@@ -81,7 +83,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
 
         // ─── Token Uniqueness ────────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task IssueTokenAsync_RepeatedCalls_AlwaysProduceUniqueTokens()
         {
             const int count = 20;
@@ -98,7 +100,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
                 $"each of {count} issue calls must produce a cryptographically unique refresh token");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task RefreshTokenAsync_Consecutive_NewTokenDiffersFromOld()
         {
             var user = new LoginUserInfo { ITCode = "rotate_user" };
@@ -115,7 +117,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
 
         // ─── Revoke Propagation ──────────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task RevokedToken_ImmediatelyInactive_CannotRefresh()
         {
             var user = new LoginUserInfo { ITCode = "revoke_user" };
@@ -128,7 +130,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             result.Should().BeNull("explicitly revoked token must be rejected on refresh");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task ManualRevoke_DoesNotAffectOtherUsersTokens()
         {
             var userA = new LoginUserInfo { ITCode = "user_a" };
@@ -148,7 +150,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
 
         // ─── Expired Token Boundary ──────────────────────────────────────────
 
-        [Fact]
+        [TestMethod]
         public async Task ExpiredToken_CannotBeRefreshed_EvenIfNotExplicitlyRevoked()
         {
             var expired = new RefreshTokenEntity
@@ -164,6 +166,7 @@ namespace WalkingTec.Mvvm.Mvc.Tests.Security
             result.Should().BeNull("expired tokens must be rejected regardless of revocation state");
         }
 
-        public void Dispose() => _fx.Dispose();
+        [TestCleanup]
+        public void Cleanup() => _fx?.Dispose();
     }
 }

--- a/src/WalkingTec.Mvvm.Mvc.Tests/WalkingTec.Mvvm.Mvc.Tests.csproj
+++ b/src/WalkingTec.Mvvm.Mvc.Tests/WalkingTec.Mvvm.Mvc.Tests.csproj
@@ -9,11 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.4" />


### PR DESCRIPTION
## Summary

Closes #822. Migrates `src/WalkingTec.Mvvm.Mvc.Tests` from deprecated xunit 2.9.3 to MSTest, eliminating the last `dotnet list package --deprecated` hit in the solution and unifying the test tooling across WTM.

## Why

- WTM's other five test projects (Core, Admin, Api, Etl, Integration) all use MSTest. `Mvc.Tests` was the sole outlier.
- `xunit 2.9.3` is flagged "Legacy → xunit.v3" by NuGet — compliance scanners pick it up.
- Downstream contributors had to context-switch between assertion styles and runner conventions.

## Mapping

| xunit | MSTest |
|---|---|
| `using Xunit;` | `using Microsoft.VisualStudio.TestTools.UnitTesting;` |
| `[Fact]` | `[TestMethod]` |
| `[Theory]` + `[InlineData(...)]` | `[TestMethod]` + `[DataRow(...)]` |
| class ctor body (implicit setup) | `[TestInitialize]` method |
| `IDisposable` + `Dispose()` | `[TestCleanup]` method |
| (no class attribute) | `[TestClass]` |

**FluentAssertions preserved** — framework-agnostic, zero assertion changes. **TokenTestFixture** untouched (has no xunit deps).

## csproj swap

```diff
- <PackageReference Include="xunit" Version="2.9.3" />
- <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
-   <IncludeAssets>...</IncludeAssets>
-   <PrivateAssets>all</PrivateAssets>
- </PackageReference>
+ <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+ <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
```

Version `3.6.4` matches `test/Directory.Build.props`'s `MSTestVersion` (Mvc.Tests is under `src/` so the props file doesn't inherit; version is hardcoded like the other PackageReferences in this csproj).

## Scope

- 4 files: `TokenChainSecurityTests.cs`, `JwtClaimsValidationTests.cs`, `TokenServiceIntegrationTests.cs`, plus the csproj itself. `Fixtures/TokenTestFixture.cs` unchanged.
- 38 tests total — identical count before/after.
- 34 `[Fact]` + 2 `[Theory]` + 4 `[InlineData]` → `[TestMethod]` + `[DataRow]`.
- Diff: 5 files, +64 / −58 lines (net +6 for `[TestClass]` + `[TestInitialize]` + `[TestCleanup]` scaffolding).

## Verification

- `dotnet build WalkingTec.Mvvm.sln -c Release` — 0 errors.
- `dotnet list package --deprecated` — **0 hits** (was 2 rows on xunit).
- `Mvc.Tests`: **38/38 pass** on MSTest (same as xunit baseline, 1s runtime).
- Full CI-scope suite: Core 1243, Mvc 38, Admin 75, Api 20, Etl 174 = **1550/1550**.

## Non-goals

- **Not migrating to xunit.v3** — would defeat the consistency goal (all other WTM test projects are MSTest).
- **Not touching assertion patterns** — FluentAssertions stays, works with both.
- **Not touching `Fixtures/TokenTestFixture.cs`** — it's plain C# setup code with no xunit dependencies.

Closes #822
