### PR TITLE
feat: Analysis Forecast + ETL QualityRules + 10.5.0 manual

### DIFF
--- a/docs/wtm-developer-manual.md
+++ b/docs/wtm-developer-manual.md
@@ -1,8 +1,10 @@
 # WTM 開發與使用手冊
 
-> **版本**：10.4.0 | **目標框架**：.NET 10 (LTS) | **最後更新**：2026-04-18
+> **版本**：10.5.0 | **目標框架**：.NET 10 (LTS) | **最後更新**：2026-04-26
 
-WalkingTec MVVM Framework (WTM) 是一套 ASP.NET Core 快速開發框架，以四種 ViewModel 類型為核心，搭配內建代碼生成器、LayUI TagHelper、Analysis Mode、ETL 模組與 Dashboard，提供完整的企業級 CRUD 開發體驗。
+WalkingTec MVVM Framework (WTM) 是一套 ASP.NET Core 快速開發框架，以四種 ViewModel 類型為核心，搭配內建代碼生成器、LayUI TagHelper、Analysis Mode、ETL 模組（含可視化儀表板）與 Dashboard，提供完整的企業級 CRUD 開發體驗。
+
+10.5.0 一次帶來 31 個新增能力 — 涵蓋 10 個可選 middleware/attribute（維運、可靠度、頻寬、API lifecycle、可觀測性、功能旗標、IP allow-list、cache 控制）、11 個 Analysis Mode 進階 BI 功能（Sort/TopN、相對日期 token、DistinctCount、HavingFilters、GrandTotal、可調 Limits、CompareWith、自動洞察、drill-through、CSV/Excel 總計列）、7 個 ETL 模組強化（Replace 載入模式、欄位對應、Schema 自動探勘、批次重試、表單驗證、3 步驟精靈、可視化儀表板）、3 個安全強化（CSP 三態、frame-ancestors、CSP 違規回報端點）。所有新功能均為**加值式 / 預設關閉**，零行為破壞。
 
 ---
 
@@ -1407,6 +1409,217 @@ services.AddSingleton<IAnalysisFieldPolicy, MyFieldPolicy>();
 
 使用者可手動切換圖表類型，不受自動偵測限制。
 
+### 7.11 結果排序與 TopN（10.5.0+）
+
+兩個欄位讓 dashboard 直接表達「銷售額 DESC 取前 5 名」的查詢，不必 fetch 10,000 列再前端排序：
+
+```csharp
+var req = new AnalysisQueryRequest
+{
+    VmType   = typeof(SalesAnalysisVM).AssemblyQualifiedName,
+    Dimensions = new() { new() { Field = "Region" } },
+    Measures   = new() { new() { Field = "Amount", Func = AggregateFunc.Sum } },
+    Sort = new()
+    {
+        new() { Field = "Amount_Sum", Descending = true },     // 多鍵排序：再加一筆即可
+    },
+    TopN = 5,
+};
+```
+
+- `Sort.Field` 必須是已請求的維度或度量結果欄（命名格式 `{Field}_{Func}`，例 `Amount_Sum`），白名單外直接 reject
+- `TopN` 範圍：`1..AnalysisLimits.MaxResultRows`（預設 10,000）
+- `TopN` 只裁 `Rows`，**`TotalCount` 仍報全量 group 數** — 前端可顯示「showing 5 of 47」
+- `SortValueComparer` 處理混型：數值統一到 `decimal`、日期直接比、混型 fallback ordinal — 保證可決定論不丟例外
+- 預設不排序（保持向後相容）
+
+### 7.12 9 個新增相對日期 token（10.5.0+）
+
+filter UI 預設集合在 10.5.0 從 8 個擴到 17 個：
+
+| 新 token | 涵義 |
+|--------|------|
+| `@yesterday` | 今日 − 1（單日） |
+| `@nextWeek` / `@nextMonth` | 預測窗口（運維 dashboard / 排程 job） |
+| `@last7days` / `@last90days` / `@last365days` | 滾動窗口 |
+| `@lastQuarter` | 完整上一個自然季 |
+| `@thisYear` | 1/1 至 12/31（與 `@ytd` 不同：`@ytd` 截止今天） |
+| `@lastYear` | 完整上一個自然年 |
+
+token 大小寫不敏感、展開為 `(Gte, Lte)` filter pair，server side 型別轉換與 expression tree 組裝完全沿用既有路徑。**沒動到** 8 個舊 token 行為。
+
+```csharp
+new FilterSpec { Field = "OrderDate", Operator = FilterOperator.RelativeDate, Value = "@last90days" }
+```
+
+### 7.13 DistinctCount 聚合函數（10.5.0+）
+
+回答「每區獨立客戶數」/「每分類獨立商品數」這類經典 BI 問題：
+
+```csharp
+[Measure(AllowedFuncs = AggregateFunc.Sum | AggregateFunc.DistinctCount)]
+public Guid CustomerId { get; set; }
+
+// 請求：
+new MeasureSpec { Field = "CustomerId", Func = AggregateFunc.DistinctCount }
+```
+
+| 路徑 | 行為 |
+|------|------|
+| `InProcessGroupByStrategy` | `g.Select(propGet).Where(non-null).Distinct().Count()` — 處理非數值（FK id 字串）也安全 |
+| `ServerSideGroupByStrategy` | `g.Select(e => e.Prop).Distinct().Count()` → EF Core 翻譯為 SQL `COUNT(DISTINCT col)` 整批下推 |
+
+NULL 排除（符合 ANSI-SQL `COUNT(DISTINCT)` 語意），結果欄命名 `CustomerId_DistinctCount` 可直接放進 `Sort.Field`。
+
+### 7.14 HavingFilters 後聚合過濾（10.5.0+）
+
+10.4 之前 Analysis 只有 `Filters`（pre-aggregation, SQL `WHERE`）+ Sort/TopN（post-aggregation），**沒有** 後聚合篩選。10.5 補上：
+
+```csharp
+var req = new AnalysisQueryRequest
+{
+    Measures = new() { new() { Field = "Amount", Func = AggregateFunc.Sum } },
+    HavingFilters = new()
+    {
+        new() { Field = "Amount_Sum", Operator = FilterOperator.Gte, Value = "1000000" },  // 月銷售 >= 1M 的區
+    },
+};
+```
+
+- `HavingFilter.Operator` 限數值子集：`Eq`/`NotEq`/`Gt`/`Gte`/`Lt`/`Lte`（`Contains`/`In` 對標量聚合無意義）
+- `Value` 用 `InvariantCulture` 解析為 `decimal`；**無法解析則保守過濾掉所有 group**（不靜默放行）
+- 多筆 AND
+- 執行管線：`GROUP BY → HAVING → ORDER BY → LIMIT`（match SQL 標準）
+- `TotalCount` 反映 **post-having** 的 group 基數，所以「showing 3 of 5」是針對使用者過濾後的世界
+
+### 7.15 GrandTotal 總計列（10.5.0+）
+
+dashboard 想要「合計」footer 不必前端再算一遍：
+
+```csharp
+var req = new AnalysisQueryRequest
+{
+    Measures = new() {
+        new() { Field = "Amount", Func = AggregateFunc.Sum },
+        new() { Field = "OrderId", Func = AggregateFunc.Count },
+    },
+    IncludeGrandTotal = true,
+};
+var resp = engine.Execute(req);
+// resp.GrandTotalRow != null
+```
+
+**聚合規則：**
+
+| 度量 Func | GrandTotalRow 行為 |
+|------|------|
+| `Sum` / `Count` | 群組值的總和 |
+| `Max` / `Min` | 群組的 Max / Min |
+| `Avg` / `DistinctCount` | **`null`** — 加權平均需要 per-group sample count（GroupBy 結果丟掉了），distinct 不能直接相加 — 靜默錯誤比 null 更糟 |
+
+- 維度欄統一輸出 `null`（client 自由標 "總計"）
+- 範圍：**post-HAVING / pre-TopN**（與 `TotalCount` 同一宇宙，`TopN` 不影響合計）
+- 空結果仍輸出 `GrandTotalRow`（度量欄 `null` 而非 `0`，避免「平均為零」誤導）
+- Excel exporter 自動加一列底色淡黃 + 粗體底列；CSV exporter 加 footer line（`null` 維度欄輸出 "總計" 標籤、後續 `null` 維度欄留白；數值維持 `.ToString()` + RFC 4180 escape；首字元為 `=` `+` `-` `@` 仍走 CSV-formula-injection escape — 縱深防禦）
+
+### 7.16 AnalysisLimits 可調列數上限（10.5.0+）
+
+把硬編碼的 `10,000`（group result）/ `50,000`（raw materialize）拉成 static class，不必 fork 框架：
+
+```csharp
+// Program.cs（一次設定）
+WalkingTec.Mvvm.Core.Analysis.AnalysisLimits.MaxResultRows     = 50_000;
+WalkingTec.Mvvm.Core.Analysis.AnalysisLimits.MaxMaterializeRows = 200_000;
+```
+
+- `MaxResultRows` 同時作為 `TopN` 驗證上限 — 兩者永遠對齊同一維度
+- 預設值（10,000 / 50,000）= 10.4.x 行為，沒動程式碼就完全相同
+- 測試裡用 `try / finally` 在單測逐筆 override
+
+### 7.17 CompareWith 期間對比（10.5.0+）
+
+「本月 vs 上月」/「本年 vs 去年」/「A 通路 vs B 通路」一發請求搞定：
+
+```csharp
+var req = new AnalysisQueryRequest
+{
+    Filters = new()
+    {
+        new() { Field = "OrderDate", Operator = FilterOperator.RelativeDate, Value = "@thisMonth" },
+    },
+    Measures = new() { new() { Field = "Amount", Func = AggregateFunc.Sum } },
+    CompareWith = new ComparisonRequest
+    {
+        Label = "上月",
+        Filters = new()
+        {
+            new() { Field = "OrderDate", Operator = FilterOperator.RelativeDate, Value = "@lastMonth" },
+        },
+    },
+    Sort = new() { new() { Field = "Amount_Sum_ChangePct", Descending = true } },  // 漲幅榜
+    TopN = 5,
+};
+```
+
+每個度量自動派生 3 欄：
+
+| 派生欄 | 涵義 |
+|------|------|
+| `{Field}_{Func}_Compare` | 對比期值 |
+| `{Field}_{Func}_Delta` | 當期 − 對比期 |
+| `{Field}_{Func}_ChangePct` | 變化百分比（`0.25` = +25%）；對比期為 0 時為 `null`（避免 `Infinity` 序列化） |
+
+- 對比期才有的 row 會以主度量 `null` 加入 — 失去全部營收的區也看得見
+- `Sort.Field` 自動白名單派生欄，「漲幅 / 跌幅榜」一行 query 完成
+- 自動加上 `ColumnDisplayNames`：`金額 合計 (上期)` / `金額 合計 差值` / `金額 合計 變化%`
+- 內部 sub-request **drop** 掉 `Sort` / `TopN` / `IncludeGrandTotal` / `HavingFilters` / `CompareWith` — 不會無窮遞迴、不會 shape 錯位
+
+### 7.18 自動洞察（Insights）BI 敘事（10.5.0+）
+
+把 `Rows` 從「光秃秃的數字」升級成「數字 + 可貼進 callout 的 2~5 行中文短句」：
+
+```csharp
+req.IncludeInsights = true;
+var resp = engine.Execute(req);
+// resp.Insights = [
+//   "本期最高: 北 (金額 合計 = 1,000)，為平均的 2.31 倍",
+//   "本期最低: 西 (金額 合計 = 200)",
+//   "與對比期相比，北 漲幅最大 (+25.0%)，南 跌幅最大 (-20.0%)",
+//   "Top 1 群組佔總計的 86.6%（Pareto 集中度高）",
+//   "1 個群組為異常離群值（|z| > 2.0）：Outlier (金額 合計, z = 2.66)"
+// ]
+```
+
+5 條啟發式（heuristic）依序套在第一個 measure：top performer + ratio、bottom performer（單一群組會 skip 避免重複）、period-over-period 漲跌冠軍（需 `CompareWith`）、Pareto 集中度（N≥5 且 top 20% ≥ 80% 總計）、z-score 離群值（N≥4 且 |z|>2）。
+
+- 每條獨立 try/catch — 一條炸不影響其他
+- 空結果 / 單列 / 全 null measure → 空 list（UI 隱藏 callout）
+- 計算發生在 **Sort+TopN 之後**，敘事反映使用者實際看到的內容
+- **輸出字串跨版本不穩定**，prog 取值請用底層數值欄
+
+### 7.19 Drill-through 點選下鑽（10.5.0+）
+
+dashboard 的「點 group → 看背後原始列」終於有官方 helper：
+
+```csharp
+var raw = AnalysisDrillThrough.BuildQuery<Order>(
+    baseQuery: dc.Set<Order>(),
+    originalReq: req,                       // dashboard 當前請求（保留 Filters）
+    groupValues: new Dictionary<string, string?>
+    {
+        ["Region"]      = "北",              // dashboard 點到的 cell
+        ["OrderDate"]   = "2026 Q1",         // 日期階層自動反查為 [start, endExclusive)
+    },
+    whitelist: AnalysisDrillThrough.BuildWhitelistFor<Order>());
+// raw 是過濾後的 IQueryable<Order> — 可直接 Take(50).ToList() 成 detail grid
+```
+
+- 重用 engine 的 `ApplyFilters`（已 `public`）— 白名單 / 型別轉換 / 相對日期語意一致
+- 保留 `originalReq.Filters`（drill 仍在 dashboard 既有 scope 內）
+- 日期階層維度（`Year` / `Quarter` / `Month` / `Day`）的人類標籤（"2026 Q1"）由 `DateTruncator.TryParseLabel` 反查為半開區間 `[start, endExclusive)`；Eq 比對毫秒精度永遠 0 列
+- 標籤無法 parse → `Take(0)` 優雅退化（dashboard 顯示「無資料」），不丟例外、也不傳回未過濾結果
+- 缺維度值 → 該維度不過濾（drill 自動放寬）；多維度 AND
+
 ---
 
 ## 8. ETL 模組
@@ -1704,6 +1917,203 @@ POST /_EtlRunLog/Rerun?runLogId=X → 從某次執行的水印快照重跑
 - **失敗處理**：水印不更新（`DiscardPendingValue`），下次自動從上次成功點重跑
 - **`OperationCanceledException`**：標記為 `Aborted`（手動中斷或逾時）
 - **重跑機制**：每次 RunLog 保存 `WatermarkSnapshot`，可從任何歷史時間點重跑
+
+### 8.11 載入模式：Merge vs Replace（10.5.0+）
+
+10.4 之前 ETL 的 BulkLoad 階段只有 Merge（依主鍵 upsert）。10.5 補上 Replace（先刪後插），用於 dimension table 完整重建、或「按月份覆寫銷售報表分區」這類場景。
+
+```csharp
+public enum EtlLoadMode { Merge, Replace }
+
+var config = new EtlPipelineConfig
+{
+    LoadMode = EtlLoadMode.Replace,
+    ReplaceWhereClause = "OrderDate >= '2026-01-01' AND OrderDate < '2026-02-01'",
+    // null = 整表清空後重灌；非 null = 只清符合 WHERE 的列
+    ColumnMappings = new()
+    {
+        ["src_cust_id"] = "CustomerID",      // rename：source 欄 → target 欄
+        ["raw_blob"]    = null,              // null/empty = drop（不要寫入 target）
+    },
+};
+```
+
+**`IBulkLoader.ReplaceAsync`：**
+- `MssqlBulkLoader`：開 transaction → `DELETE FROM target WHERE <clause>` → `SqlBulkCopy.WriteToServer` → commit
+- `OracleBulkLoader`：同上但用 `ManagedDataAccess` + array-binding insert
+- `IsSafeWhereClause` 公開工具：拒絕含 `;` / `--` / `xp_` / DML keyword 的字串。VM 層在 save 時就跑這個檢查，**不安全的 WHERE 在保存就被擋下，不會等到第一次跑 job**
+
+### 8.12 ColumnMappings 欄位對應 / drop（10.5.0+）
+
+跨資料庫遷移最常見痛點：source 與 target 欄名不一致 / 部分欄不要灌入。`EtlPipelineConfig.ColumnMappings: Dictionary<string, string?>?`：
+
+```csharp
+config.ColumnMappings = new()
+{
+    ["cust_id"]       = "CustomerID",        // rename
+    ["order_no"]      = "OrderNumber",
+    ["raw_payload"]   = null,                // drop（任何 null/empty 都當 drop）
+    ["debug_flag"]    = "",                  // drop
+};
+```
+
+執行階段：`EtlPipelineExecutor.ApplyColumnMappings(table, mappings)`（已 public 供測）— 改寫 `DataTable.Columns` 名稱、刪掉 drop 欄。`null`/沒設 = 沿用 source 欄名（向後相容）。
+
+ColumnMappings 也支援 JSON 表示，存於 `EtlJobDefinition.ColumnMappingJson`（VM 驗證會解析、檢查 key/value 非空）：
+
+```json
+{ "cust_id": "CustomerID", "order_no": "OrderNumber", "raw_payload": "" }
+```
+
+### 8.13 IEtlSchemaService DB 自動探勘（10.5.0+）
+
+3 步驟精靈裡「下一步」要列出 source DB 有哪些 table、target DB 有哪些 column — 由 `IEtlSchemaService` + `_EtlSchemaController` 提供：
+
+```csharp
+public interface IEtlSchemaService
+{
+    Task<IReadOnlyList<string>> ListTablesAsync(string csKey, string? schema = null, CancellationToken ct = default);
+    Task<IReadOnlyList<EtlColumnInfo>> ListColumnsAsync(string csKey, string table, string? schema = null, CancellationToken ct = default);
+}
+
+public sealed record EtlColumnInfo(string Name, string DataType, bool IsNullable, int? MaxLength);
+```
+
+實作：
+- `MssqlEtlSchemaService` — `INFORMATION_SCHEMA.TABLES` / `.COLUMNS`
+- `OracleEtlSchemaService` — `ALL_TABLES` / `ALL_TAB_COLUMNS`
+- `EtlSchemaServiceFactory.For(dbType)` 根據 `DBTypeEnum` 取對應實作
+
+**Controller endpoints：**
+
+```
+GET /_EtlSchema/Tables?csKey=src&dbType=SqlServer
+GET /_EtlSchema/Columns?csKey=src&dbType=SqlServer&table=Orders
+```
+
+RBAC 與 `_EtlJobController` 同一把鑰匙（Admin / ETLAdmin / IsQuickDebug bypass）。
+
+### 8.14 批次重試與指數退避（10.5.0+）
+
+任一個 BulkLoad 批次的 transient 失敗（DB lock timeout、network jitter、deadlock）以前會炸掉整個 job。10.5 補上 per-batch retry：
+
+```csharp
+var config = new EtlPipelineConfig
+{
+    MaxBatchRetries        = 5,                   // 預設 0（向後相容）；clamp 到 [0, 50]
+    BatchRetryBaseDelayMs  = 200,
+    BatchRetryMaxDelayMs   = 30_000,
+};
+```
+
+退避公式：`delay = random(0, BaseDelay × 2^attempt)`（full-jitter exponential backoff），上限 `BatchRetryMaxDelayMs`。Cancellation 在等待中被尊重 — token 取消會以 `Aborted = true` 結束。
+
+**水印契約不變**：耗盡重試預算 → 整個 job 失敗 + watermark 不 commit；其中一批 recover 成功 → watermark 正常 commit。
+
+`EtlExecutionResult.RetryAttemptsTotal`（10.5.0+）報出本次執行所有批次的累計重試次數，可拉長條圖看「我的 ETL 多 flaky」。
+
+`MockBulkLoader.TransientFailuresBeforeSuccess` 模擬 flaky bulk-load — 用來在自家 pipeline 寫 unit test：
+
+```csharp
+var loader = new MockBulkLoader { TransientFailuresBeforeSuccess = 2 };
+// 前 2 次 BulkLoad 丟 transient exception，第 3 次成功
+```
+
+### 8.15 EtlJobDefinitionVM 表單驗證（10.5.0+）
+
+`EtlJobDefinitionVM.Validate()` 的新增規則（save 時就抓，不等 first run 才炸）：
+
+| 規則 | 條件 | 訊息欄位 |
+|------|------|------|
+| Merge 模式必填 MergeKeyColumn | `LoadMode == Merge && string.IsNullOrEmpty(MergeKeyColumn)` | `Entity.MergeKeyColumn` |
+| Replace 模式 WHERE 安全檢查 | `LoadMode == Replace && !IsSafeWhereClause(ReplaceWhereClause)` | `Entity.ReplaceWhereClause` |
+| ColumnMappingJson 必須是合法 JSON object | parse fail / 非 object | `Entity.ColumnMappingJson` |
+| ColumnMappingJson key/value 不可為空白 | 任一鍵為空白 / 任一值為空白 | `Entity.ColumnMappingJson` |
+
+```csharp
+// Replace + null/empty WHERE = 「整表重灌」；操作員自負其責，validator 接受
+vm.Entity.LoadMode           = EtlLoadMode.Replace;
+vm.Entity.ReplaceWhereClause = null;
+vm.Validate();   // 不 raise error
+
+// Replace + 含 SQL injection 的 WHERE = 拒
+vm.Entity.ReplaceWhereClause = "1=1; DROP TABLE Users";
+vm.Validate();   // MSD["Entity.ReplaceWhereClause"] 出現
+
+// Merge + 不安全 WHERE = 不檢查（WHERE 在 Merge 模式根本沒用）
+vm.Entity.LoadMode = EtlLoadMode.Merge;
+vm.Validate();   // 不 raise error
+```
+
+### 8.16 三步驟 Job 精靈 UI（10.5.0+）
+
+`Views/_EtlJob/Create.cshtml` + `Edit.cshtml` 提供 wizard：
+
+1. **Step 1 — Source**：填 `SourceCsKey` / `SourceDbType` → 點「探勘」呼叫 `_EtlSchema/Tables` → table 下拉自動填入 → 選表後 `_EtlSchema/Columns` 自動填出來、勾選想抽取的欄位
+2. **Step 2 — Target**：填 `TargetCsKey` / `TargetTableName` → 同樣探勘 target schema → UI 用 left-right list 拉欄位對應（rename / drop）→ 自動序列化為 `ColumnMappingJson`
+3. **Step 3 — Schedule + Mode**：cron 表達式視覺化解析、`LoadMode` 切換、`ReplaceWhereClause` / `MergeKeyColumn` 條件式顯示對應欄位
+
+JS 命名空間 `EtlWizard`，AJAX 注入文字一律走 `escapeHtml()`（XSS 防禦）。Razor 中的字面 `@watermark_clause` 用 `@@watermark_clause` 雙 `@` 跳脫（不要被當識別字符）。
+
+> **後端必須註冊 schema 服務：** `services.AddSingleton<MssqlEtlSchemaService>(); services.AddSingleton<OracleEtlSchemaService>();`（demo 已預註冊）
+
+### 8.17 ETL 可視化儀表板（10.5.0+）
+
+ETL 模組單頁總覽，view 路徑 `/_EtlDashboard/Index`：
+
+```
+┌─────────────── 7 個 KPI 卡 ────────────────┐
+│ TotalJobs / ActiveJobs / DisabledJobs       │
+│ RunningNow / RunsInWindow / SuccessRate     │
+│ TotalRowsLoadedInWindow                     │
+└─────────────────────────────────────────────┘
+┌── 結果分布 donut ───┬── 每日 stacked-bar ──┐
+│ Success/Failed/      │ 過去 N 天 4 種狀態   │
+│ Aborted/Skipped      │ 疊圖 + RowsLoaded    │
+└─────────────────────┴──────────────────────┘
+┌── 進行中（live） ────┬── 最近失敗（topN）──┐
+│ JobName/Phase/進度   │ JobName/StartedAt/   │
+│ Bar/RowsPerSec       │ ElapsedMs/ErrorMsg   │
+└─────────────────────┴──────────────────────┘
+        ┌── 最慢 jobs（topN）──┐
+        │ JobName/Avg/Max/Run #│
+        └──────────────────────┘
+```
+
+**Backend：**
+
+```csharp
+public class EtlDashboardService
+{
+    public EtlDashboardSummary BuildSummary(IDataContext dc, int windowDays = 7, int topN = 10);
+}
+```
+
+```csharp
+services.AddSingleton<EtlDashboardService>();   // AddWtmEtl() 已內建
+```
+
+- `windowDays` clamp 到 `[1, 90]`、`topN` clamp 到 `[1, 100]`
+- `DailyTrend` 永遠輸出 `windowDays` 個資料點（oldest first）— front-end 圖表 x 軸密度恆定，零 run 的天 fall back 到 0 0 0 0
+- `SlowestJobs` **只計** `Result == Success` 的 run — 失敗常 abort early 會把均值偏快、結果誤導
+- 進行中的 `JobName` 從 `EtlProgressTracker` 取，空字串時從 DB 反查 `EtlJobDefinition.Name` 補上
+- UTC 桶（避免 timezone bug）
+
+**Endpoints：**
+
+| Method | Path | 用途 |
+|------|------|------|
+| GET | `/_EtlDashboard/Index` | 渲染 partial view |
+| GET | `/_EtlDashboard/Stats?days=N&topN=M` | 回 JSON snapshot（front-end polling） |
+
+RBAC 與 `_EtlJobController` 同一把鑰匙（Admin / ETLAdmin / IsQuickDebug bypass）。
+
+**Front-end（demo Razor + ECharts 5）：**
+- 載 ECharts 5 from CDN（`<script>` 直接加，不必動 `_Layout`）
+- 每 10 秒 polling `/Stats`；window-range select 變更觸發即時 refresh
+- `window.addEventListener("resize")` → 圖表 resize
+- 所有 AJAX 注入文字過 `escapeHtml()` — 連錯誤訊息都不洩 XSS sink
+- SuccessRate 顯色：`<80%` 紅 / `80–95%` 琥珀 / `≥95%` 藍
 
 ---
 
@@ -2777,6 +3187,311 @@ log aggregator（Loki / Seq / Elastic）按 `Path` / `Method` / `User` 分組就
 - 不做 per-endpoint 門檻 — v1 只支援一個 global threshold；app 應設為最嚴 SLA 的值
 - 不做 sampled full-request tracing — 是另一個 surface
 
+### 10.13 CSP 三態模式 + frame-ancestors（10.5.0+，#843–#846）
+
+10.3.0 引入 `UseWtmContentSecurityPolicy()` 時用了 `bool ReportOnly` 表達兩種狀態。10.5.0 升級為 `WtmCspMode` 三態 enum，並補上 `frame-ancestors`（取代過時的 `X-Frame-Options`）與 server-side 違規回報端點。
+
+**三種模式：**
+
+```csharp
+public enum WtmCspMode { Disabled, ReportOnly, Enforce }
+```
+
+| 值 | header | 適用情境 |
+|------|------|------|
+| `Disabled` | 不寫 | 維運切回（不必動程式碼）、本地除錯、灰度回滾 |
+| `ReportOnly` | `Content-Security-Policy-Report-Only` | 上線前評估規則對使用者影響 |
+| `Enforce` | `Content-Security-Policy` | 正式啟用（預設） |
+
+**完整啟用：**
+
+```csharp
+app.UseWtmCspReport();                  // 接收瀏覽器回報，必須在 CSP 之前
+app.UseWtmContentSecurityPolicy(opt =>
+{
+    opt.Mode = WtmCspMode.Enforce;       // 取代舊 ReportOnly bool
+    opt.FrameAncestors = "'self'";       // 反 clickjacking — 預設 'none'
+    opt.DefaultPolicy =
+        "default-src 'self'; " +
+        "script-src 'self' 'unsafe-inline'; " +
+        "style-src 'self' 'unsafe-inline'; " +
+        "img-src 'self' data:; " +
+        "connect-src 'self'";
+    opt.ReportUri = "/_csp/report";      // 與 UseWtmCspReport() 配對
+});
+```
+
+**舊 `ReportOnly` 仍向下相容**（標 `[Obsolete]`），但不要再在新程式碼裡用 — `Mode` 設了非預設值就以 `Mode` 為準。
+
+**回報端點 `_CspReportMiddleware`：**
+
+```csharp
+app.UseWtmCspReport(opt =>
+{
+    opt.RatePerMinute = 10;              // 每 IP 每分鐘上限（防 amplification）；0 = 關閉
+    opt.MaxBodyBytes  = 8 * 1024;
+    opt.OnReport      = report =>
+    {
+        // 自訂回報處理 — 例如轉送至 Sentry
+        sentryClient.CaptureMessage($"CSP violation: {report.ViolatedDirective}");
+    };
+});
+```
+
+預設行為：違規以 Serilog Warning 寫成 `CspViolation Document=… Directive=… Blocked=… Source=…:…` — 既有 log pipeline 直接變成 CSP 違規可觀測介面，不必再接 Sentry / Datadog。
+
+| 回應碼 | 條件 |
+|------|------|
+| 204 | 成功收下 |
+| 400 | body 解析失敗 |
+| 413 | body > MaxBodyBytes |
+| 429 | 同 IP 超過 RatePerMinute |
+
+### 10.14 SecureHeaders Overwrite（10.5.0+，#843）
+
+10.4 的 `UseWtmSecureHeaders()` 採 first-writer-wins（避免覆蓋上游 reverse proxy 設定）；10.5 新增 `Overwrite = true` 給金融/醫療等需要保證 header 出現的場景：
+
+```csharp
+app.UseWtmSecureHeaders(opt =>
+{
+    opt.XFrameOptions = "DENY";         // 想保證一定是 DENY，不接受 proxy 改成 SAMEORIGIN
+    opt.Overwrite     = true;
+});
+```
+
+`Overwrite = true` **不會**繞過 HSTS 的 HTTPS gate（HSTS 仍需 `Request.IsHttps`），也不會啟用設成 `null` 的 header — 它只翻轉「先寫者贏 vs 後寫者贏」的順序。
+
+### 10.15 [WtmIpAllowList] CIDR 白名單（10.5.0+）
+
+把 controller / action 鎖在內網或特定 IP 段：
+
+```csharp
+[WtmIpAllowList("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12")]
+public class AdminApiController : BaseApiController { ... }
+
+[HttpPost]
+[WtmIpAllowList("203.0.113.0/24",
+                FallbackStatusCode = 404)]   // 404 隱藏端點存在
+public ActionResult<int> Webhook([FromBody] Payload p) { ... }
+```
+
+- 多個 CIDR OR 起來；單一 host 用 `/32`（IPv4）/ `/128`（IPv6）
+- 由 `System.Net.IPNetwork` 解析，IPv4 / IPv6 同樣支援
+- `IAsyncAuthorizationFilter` 自動發現，**無需 Program.cs 註冊**
+- 拒絕日誌：Warning 級含 client IP + CIDR 列表
+- CIDR 字串在 attribute 建構時驗證（typo 在啟動時就 throw，不會等到第一次請求）
+- 容忍 `X-Forwarded-For: addr1, addr2` 的 comma list（取第一個）— 但 X-Forwarded-For 容易偽造，**正式公網部署必須結合 nginx/Cloudflare/ALB 邊緣防線**，本 attribute 是「縱深防禦的最後一層」
+
+### 10.16 [WtmNoCache] / [WtmCacheControl] 回應快取控制（10.5.0+）
+
+**`[WtmNoCache]`** — 一行修掉「登出後按上一頁仍看得到 profile」的經典問題：
+
+```csharp
+[WtmNoCache]
+public class ProfileController : BaseController { ... }
+```
+
+自動寫出三段防禦：
+- `Cache-Control: no-store, no-cache, must-revalidate, max-age=0, private`
+- `Pragma: no-cache`（HTTP/1.0 fallback，企業內網 proxy 仍見得到）
+- `Expires: 0`
+
+**`[WtmCacheControl(...)]`** — 顯式宣告快取策略：
+
+```csharp
+[WtmCacheControl("public, max-age=300", Vary = "Accept-Encoding, Authorization")]
+public ActionResult<List<Region>> Regions() => _regions;
+```
+
+- 字串原樣寫入（caller 自負 RFC 7234 正確性）
+- `Vary` 寫到對應 header，告訴 CDN/proxy 用哪些 request header 當 cache key
+- First-writer-wins：上游 reverse proxy 已寫 `Cache-Control` 就尊重不覆蓋
+- ctor 對 null/whitespace 直接 throw，typo 啟動就抓
+
+### 10.17 UseWtmMaintenanceMode 計畫性停機 kill-switch（10.5.0+）
+
+正式運維場景：「半夜 2:00 要做 schema migration，10 分鐘窗口期間擋掉所有外部流量、留下 healthz 給 k8s probe、留下 admin plane 給操作者切回」。
+
+```csharp
+app.UseWtmMaintenanceMode(opt =>
+{
+    opt.Enabled              = false;     // 預設不啟，靠 IsEnabled 動態決定
+    opt.IsEnabled            = ctx => featureFlags.IsOn("maintenance-mode");
+    opt.AllowedPathPrefixes  = new[] { "/healthz", "/_admin", "/_framework", "/_js", "/_content" };
+    opt.AllowedClientIps     = new[] { "10.0.0.0/8" };  // bastion / jump host
+    opt.RetryAfterSeconds    = 60;
+    opt.ContentType          = "application/problem+json";  // 也支援 text/html + HtmlBodyFactory
+});
+```
+
+**運作：**
+- 不在白名單 → 503 + `Retry-After: 60` + `application/problem+json` body
+- `IsEnabled` 例外被吞並 fallback 到 `Enabled` 旗標 — flag 服務當機不會把 production 弄爛
+- `Enabled = false` 且沒設 `IsEnabled` → 等同單一 bool 檢查，幾乎零成本
+
+**位置：** 放 `UseRouting` 之後、auth/MVC 之前 — 503 在 expensive middleware 之前 short-circuit。
+
+### 10.18 [WtmDeprecated] API 退役旗標（10.5.0+）
+
+對舊 API 加上 IETF 標準的 `Deprecation: true` / RFC 8594 `Sunset` / RFC 8288 `Link`，告訴 client SDK 該升級了：
+
+```csharp
+[WtmDeprecated(
+    Message = "Use /api/v2/orders instead",
+    Sunset  = "2026-12-31",
+    Link    = "</api/v2/orders>; rel=\"successor-version\"")]
+public ActionResult<Order> GetOrderV1(Guid id) => _svc.Get(id);
+```
+
+每次被呼叫多帶三組 header + 一筆 `Information` 級 Serilog（`DeprecatedEndpointHit Path=… Method=… Message=… Since=…`）— 用日誌 pipeline 直接答得出「誰還在打 v1」。`LogHit = false` 可關。Sunset 字串不合法時不寫該 header，warning 只記一次。
+
+### 10.19 UseWtmServerTiming W3C Server-Timing（10.5.0+）
+
+每個非排除路徑回應掛 `Server-Timing: app;dur=<ms>` — Chrome DevTools → Network → Timing 自動秀後端 latency，**不必接 APM**：
+
+```csharp
+app.UseWtmServerTiming(opt =>
+{
+    opt.MetricName     = "app";
+    opt.Description    = "WTM backend";
+    opt.MinDurationMs  = 200;            // 0=每筆都送；200=只標慢的
+    opt.PathExclusions = new[] { "/healthz", "/_framework", "/_js", "/_content" };
+});
+```
+
+排除路徑 short-circuit 在 stopwatch 之前，**零成本**。多層 `Server-Timing` 用 W3C 規定的 comma list 共存（CDN/proxy 寫的不會被蓋）。Metric 名做 RFC 7230 token 過濾（含空白/控制字元就靜默不寫）；數字用 invariant culture 格式化（不會在 de-DE locale 變成 `12,34`）。
+
+### 10.20 IWtmFeatureFlags 功能旗標（10.5.0+）
+
+不必引 `Microsoft.FeatureManagement` 或 LaunchDarkly：
+
+```csharp
+services.AddWtmFeatureFlags(opt =>
+{
+    opt.Defaults["new-checkout"] = false;
+    opt.Defaults["beta-search"]  = true;
+
+    // 自訂 resolver — 灰度 / 租戶 / user-id rollout / 外部 SDK adapter
+    opt.Resolver = (httpCtx, name) =>
+    {
+        var tenant = httpCtx?.User.FindFirst("tenant")?.Value;
+        if (tenant == "early-access") return true;
+        return null;                      // null 代表「沒意見、繼續往下找」
+    };
+});
+```
+
+**解析順序**（決定論、可單元測）：
+1. `Resolver` delegate（per-request 動態，return null = 沒意見）
+2. `IConfiguration` 的 `FeatureFlags:<name>`（每次都 re-read，`appsettings.json` 改了不必重啟）
+3. `Options.Defaults`（大小寫不敏感）
+4. `false` — 沒宣告就視為關閉（fail-closed，避免忘記註冊就洩漏 pre-release endpoint）
+
+**用法：** 注入 `IWtmFeatureFlags`，或 attribute 守門：
+
+```csharp
+[WtmFeatureGate("new-checkout")]                       // 預設 disabled→404（隱藏存在）
+public ActionResult<Order> CheckoutV2([FromBody] CartDto c) { ... }
+
+[WtmFeatureGate("beta-search", FallbackStatusCode = 503)]
+public IActionResult Search() { ... }
+```
+
+`Snapshot()` 列出所有已知旗標 + 當前值 — admin diagnostic 頁直接吃。Resolver 例外被 catch + Warning，**flag 服務 outage 不會把 production 拖垮**。
+
+### 10.21 [WtmIdempotent] + UseWtmIdempotency 重試安全（10.5.0+）
+
+讓 mutating endpoint 有 retry-safe 能力，不必在 action 內手動防重複提交。遵循 Stripe / PayPal / AWS 的 `Idempotency-Key` 慣例（draft-ietf-httpapi-idempotency-key-header） — 多數現代 API SDK 已預設帶這個 header。
+
+```csharp
+services.AddMemoryCache();
+app.UseWtmIdempotency(opt =>
+{
+    opt.HeaderName            = "Idempotency-Key";
+    opt.DefaultWindowSeconds  = 300;
+    opt.MaxKeyLength          = 128;
+    opt.MaxCachedBodyBytes    = 1 * 1024 * 1024;
+});
+```
+
+```csharp
+[HttpPost]
+[WtmIdempotent(WindowSeconds = 600, RequireKey = true)]
+public ActionResult<Order> Place([FromBody] PlaceOrderDto dto) => _svc.Place(dto);
+```
+
+- 同一個 `Idempotency-Key` 在 600 秒內重打：原樣回放上次 2xx 回應，並加 `Idempotency-Replay: true` header 讓 client/test 區分 cache hit
+- Cache key = `method + path + key`，被偷的 key 不能跨 endpoint 重放
+- 只快取 2xx — 4xx/5xx 直通（暫時失敗不會毒化 slot）
+- 只回放 `Content-Type`，**不回放 `Set-Cookie`** — 防止前一次的 session 被別人撿到
+- Key 只允許 `[A-Za-z0-9\-_.:]`（拒控制字元 / UTF-8 / log injection）；長度 > 128 / `RequireKey = true` 卻沒帶 → 400 + `application/problem+json`
+- `GET` / `HEAD` 故意排除（已 RFC-9110 safe，快取會掩蓋 bug）
+- backing store 是 `IMemoryCache`（in-process）— 多實例部署需要 sticky LB 或自己包 distributed wrapper
+
+### 10.22 UseWtmETag 條件請求頻寬節省（10.5.0+）
+
+對 GET/HEAD 計算 SHA-256 → base64url 截 22 字元（132 bits 熵）作 ETag，client 帶對的 `If-None-Match` 就回 `304 Not Modified`（無 body）。**省的是頻寬不是 server 計算** — 但 dashboard / reference data / 後台 list 通常變動少，每筆 304 從幾 KB 降到 ~300 bytes header。
+
+```csharp
+app.UseWtmETag(opt =>
+{
+    opt.EligibleMethods    = new[] { HttpMethods.Get, HttpMethods.Head };  // POST/PUT 故意不支援
+    opt.MaxBufferedBytes   = 2 * 1024 * 1024;     // 超過直通不算 ETag，避免變記憶體炸彈
+    opt.EmitWeakETag       = false;               // 啟動 → 用 W/"..."
+    opt.PathExclusions     = new[] { "/healthz", "/_framework", "/_js", "/_content" };
+});
+```
+
+- RFC 9110 §13.1.2 / §8.8.3.2 比對：通配 `*`、comma list、`W/` 前綴弱比對都支援
+- 上游已寫 ETag → first-writer-wins
+- 放在 `UseRouting` 之後、compression 之前 — 雜湊算在未壓縮表示上
+
+### 10.23 UseWtmRequestTimeouts per-request 截止期（10.5.0+）
+
+10.4 的 `UseWtmSlowRequestLogging`「**事後**」抓慢，10.5 的 `UseWtmRequestTimeouts`「**進行中**」直接砍。把 `IHttpRequestLifetimeFeature` 換成 deadline-linked `CancellationToken` — EF Core / `HttpClient` / `Task.Delay(_, ct)` 等任何觀察 `HttpContext.RequestAborted` 的 framework 都會合作式取消：
+
+```csharp
+app.UseWtmRequestTimeouts(opt =>
+{
+    opt.DefaultTimeoutMs = 30_000;
+    opt.PathOverrides = new Dictionary<string, int>
+    {
+        ["/api/export"]         = 5  * 60_000,    // 報表慢些
+        ["/api/admin/migrate"]  = 10 * 60_000,    // schema 維護更慢
+        ["/sse"]                = 0,              // SSE 串流，opt-out
+    };
+    opt.PathExclusions = new[] { "/healthz", "/_framework", "/_js", "/_content" };
+});
+```
+
+**Deadline trip 行為：**
+- response 還沒開始送 → 寫 `504 Gateway Timeout` + `application/problem+json`（含 `timeoutMs` / `traceId`）+ Warning log（`RequestTimeout Path={Path} Method={Method} TimeoutMs={Timeout}`）
+- response 已經開始（chunked / SSE）→ abort connection（無法回送 504 over partial body）
+- handler 吞掉 `OperationCanceledException` 還回 200 → middleware 也會把空 200 改成 504（行為不端的 handler 不能藏 deadline）
+- 區分「deadline 砍 handler」vs「client 先放棄」（兩者都是 `OperationCanceledException`），只前者產 504
+
+### 10.24 WtmDataSeeder 冪等資料填充（10.5.0+）
+
+```csharp
+await WtmDataSeeder.SeedAsync(
+    dc,
+    new[]
+    {
+        new Region { Code = "TW", Name = "Taiwan"  },
+        new Region { Code = "JP", Name = "Japan"   },
+        new Region { Code = "US", Name = "America" },
+    },
+    x => x.Code);                              // 業務鍵
+```
+
+回傳 `WtmSeedResult(Added, Skipped)`。重跑同一份 seed — 不論放在 `Program.cs`、test `[TestInitialize]`、migration job 還是 demo 還原 hook — 第二次起 0 inserts，所以「每次啟動 idempotent seed」變成一行。
+
+**內部設計：**
+- 業務鍵存在性檢查 = 一次 `SELECT … WHERE Key IN (…)` 而非 per-item EXISTS — 數百筆 fixture 只一次 round-trip + 一次 `SaveChangesAsync`
+- 完全沒新增才不呼叫 `SaveChangesAsync` — pure-skip re-seed 不會誤觸 audit interceptor / SaveChanges filter
+- 輸入 array 內重複的鍵自動取第一筆（cut-and-paste fixture 不會炸）
+- 純 insert，不更新既有 row（要 upsert 自己包）
+
 ---
 
 ## 11. 多租戶
@@ -3841,3 +4556,12 @@ public class Employee : PersistPoco
 ### B. 版本歷史
 
 詳見 `CHANGELOG.md`。
+
+**10.5.0（2026-04-26）摘要 — 31 個新增能力，零行為破壞：**
+
+| 區塊 | 新增 | 對應章節 |
+|------|------|------|
+| Middleware / 安全 / 可靠度 / 觀測 | `[WtmIpAllowList]` / `[WtmNoCache]` / `[WtmCacheControl]` / `UseWtmMaintenanceMode` / `[WtmDeprecated]` / `UseWtmServerTiming` / `IWtmFeatureFlags` + `[WtmFeatureGate]` / `[WtmIdempotent]` + `UseWtmIdempotency` / `UseWtmETag` / `UseWtmRequestTimeouts` / `WtmDataSeeder` | §10.13–§10.24 |
+| 安全 | `WtmCspMode` 三態 + `FrameAncestors` + `UseWtmCspReport` + `SecureHeadersOptions.Overwrite` | §10.13–§10.14 |
+| Analysis Mode | Sort + TopN / 9 個相對日期 token / DistinctCount / HavingFilters / GrandTotal / AnalysisLimits / CompareWith / Insights / Drill-through / CSV+Excel 總計列 | §7.11–§7.19 |
+| ETL | `LoadMode.Replace` / ColumnMappings / `IEtlSchemaService` / 批次重試 / VM 驗證 / 三步驟精靈 / **可視化儀表板** | §8.11–§8.17 |

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisForecastEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisForecastEngine.cs
@@ -1,0 +1,193 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace WalkingTec.Mvvm.Core.Analysis
+{
+    /// <summary>
+    /// 純 in-memory 預測引擎 — 在實際資料 <see cref="AnalysisQueryResponse.Rows"/>
+    /// 後追加 N 筆預測列。不查 DB、不重算 Insights / GrandTotal / TotalCount；
+    /// 失敗條件（無時間維度、實際列不足、首列無法 parse 期別）下靜默 no-op
+    /// 而非 throw，避免單一邊界情境炸掉整個 dashboard。
+    /// </summary>
+    public static class AnalysisForecastEngine
+    {
+        /// <summary>外推期數上限。超過此值在引擎驗證階段被拒絕。</summary>
+        public const int MaxPeriods = 12;
+
+        /// <summary>移動平均的窗口大小（最後 N 期）。</summary>
+        public const int MovingAverageWindow = 3;
+
+        /// <summary>預測列的旗標 key，前端用以區分實際 vs 預測。</summary>
+        public const string ForecastFlagKey = "_IsForecast";
+
+        /// <summary>
+        /// 對 <paramref name="response"/> 套用預測，將外推列直接 append 到
+        /// <see cref="AnalysisQueryResponse.Rows"/> 並設定
+        /// <see cref="AnalysisQueryResponse.HasForecast"/>。
+        /// </summary>
+        /// <param name="response">已完成所有資料增益的查詢回應（會就地修改）。</param>
+        /// <param name="spec">預測設定。</param>
+        /// <param name="dimensionFields">原請求的維度欄位（依序）— 第一個必須是時間維度才會啟動預測。</param>
+        /// <param name="measureColumns">measure-result 欄位 key（例如 <c>Amount_Sum</c>）。</param>
+        /// <param name="hierarchies">維度的日期階層對照表（無此項則不啟動預測）。</param>
+        public static void ApplyForecast(
+            AnalysisQueryResponse response,
+            ForecastSpec spec,
+            List<string> dimensionFields,
+            List<string> measureColumns,
+            Dictionary<string, DateHierarchy>? hierarchies)
+        {
+            // Guards — 任何不滿足條件靜默 no-op
+            if (response == null || spec == null) { return; }
+            if (response.Rows.Count == 0) { return; }
+            if (dimensionFields.Count == 0) { return; }
+            if (measureColumns.Count == 0) { return; }
+            if (hierarchies == null) { return; }
+
+            var timeDim = dimensionFields[0];
+            if (!hierarchies.TryGetValue(timeDim, out var hierarchy)) { return; }
+
+            // 取最後一筆實際列的時間 label，作為預測起點
+            var lastRow = response.Rows[^1];
+            if (!lastRow.TryGetValue(timeDim, out var lastLabelObj) || lastLabelObj == null) { return; }
+            var lastLabel = lastLabelObj.ToString();
+
+            var periods = spec.Periods;
+            if (periods <= 0) { return; }
+            if (periods > MaxPeriods) { periods = MaxPeriods; }
+
+            // 為每個 measure 產生預測值序列
+            var predictionsByMeasure = new Dictionary<string, double?[]>();
+            foreach (var col in measureColumns)
+            {
+                var series = ExtractNumericSeries(response.Rows, col);
+                predictionsByMeasure[col] = spec.Method == ForecastMethod.MovingAverage
+                    ? PredictMovingAverage(series, periods)
+                    : PredictLinear(series, periods);
+            }
+
+            // 產生 N 筆預測列並 append
+            var any = false;
+            for (int i = 0; i < periods; i++)
+            {
+                var nextLabel = DateTruncator.NextLabel(lastLabel, hierarchy, i + 1);
+                if (nextLabel == null) { break; }
+
+                var row = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    [ForecastFlagKey] = true,
+                };
+                // 時間維度填預測 label；其餘維度填 null（沒有意義的展開）
+                foreach (var dim in dimensionFields)
+                {
+                    row[dim] = dim == timeDim ? (object?)nextLabel : null;
+                }
+                foreach (var col in measureColumns)
+                {
+                    var arr = predictionsByMeasure[col];
+                    row[col] = arr[i].HasValue
+                        ? (object?)System.Math.Round((decimal)arr[i]!.Value, 4)
+                        : null;
+                }
+                response.Rows.Add(row);
+                any = true;
+            }
+
+            if (any) { response.HasForecast = true; }
+        }
+
+        /// <summary>
+        /// 從 rows 抽取一個 measure 欄位為 double 序列（null / 非數值 → null）。
+        /// 順序保留 rows 的順序（已被 Sort 處理過，第一維是時間且升冪
+        /// 是常見場景）。
+        /// </summary>
+        internal static double?[] ExtractNumericSeries(
+            List<Dictionary<string, object?>> rows, string col)
+        {
+            var series = new double?[rows.Count];
+            for (int i = 0; i < rows.Count; i++)
+            {
+                if (!rows[i].TryGetValue(col, out var v) || v == null)
+                {
+                    series[i] = null;
+                    continue;
+                }
+                if (v is double d) { series[i] = d; continue; }
+                if (v is decimal dec) { series[i] = (double)dec; continue; }
+                if (v is int n) { series[i] = n; continue; }
+                if (v is long l) { series[i] = l; continue; }
+                if (v is float f) { series[i] = f; continue; }
+                if (double.TryParse(v.ToString(), NumberStyles.Any,
+                        CultureInfo.InvariantCulture, out var parsed))
+                {
+                    series[i] = parsed;
+                }
+                else { series[i] = null; }
+            }
+            return series;
+        }
+
+        /// <summary>
+        /// 最小平方法線性回歸 — 在去 null 的 (index, value) 點集上擬合
+        /// y = m·x + b，回傳長度 <paramref name="periods"/> 的預測陣列
+        /// （每元素為 <c>null</c> 表示無法預測，例如有效點 &lt; 2）。
+        /// </summary>
+        internal static double?[] PredictLinear(double?[] series, int periods)
+        {
+            var output = new double?[periods];
+            // 取出非 null 點並用其原始 index 為 x
+            var pts = new List<(double X, double Y)>();
+            for (int i = 0; i < series.Length; i++)
+            {
+                if (series[i].HasValue) { pts.Add((i, series[i]!.Value)); }
+            }
+            if (pts.Count < 2) { return output; }
+
+            int n = pts.Count;
+            double sumX = pts.Sum(p => p.X);
+            double sumY = pts.Sum(p => p.Y);
+            double sumXY = pts.Sum(p => p.X * p.Y);
+            double sumXX = pts.Sum(p => p.X * p.X);
+            double denom = n * sumXX - sumX * sumX;
+            if (denom == 0)
+            {
+                // 所有 x 相同（理論上不會發生 — 但防 NaN）— 用平均值常數
+                double avg = sumY / n;
+                for (int i = 0; i < periods; i++) { output[i] = avg; }
+                return output;
+            }
+            double m = (n * sumXY - sumX * sumY) / denom;
+            double b = (sumY - m * sumX) / n;
+
+            // 預測序列接續原 series 索引
+            for (int i = 0; i < periods; i++)
+            {
+                double x = series.Length + i;
+                output[i] = m * x + b;
+            }
+            return output;
+        }
+
+        /// <summary>
+        /// 移動平均 — 取最後 N 期實際值的平均（N = min(<see cref="MovingAverageWindow"/>,
+        /// 有效點數)）。所有外推期都填同一個常數值（適合無趨勢的平穩序列）。
+        /// </summary>
+        internal static double?[] PredictMovingAverage(double?[] series, int periods)
+        {
+            var output = new double?[periods];
+            // 從尾端往前取最多 MovingAverageWindow 個有效點
+            var window = new List<double>();
+            for (int i = series.Length - 1; i >= 0 && window.Count < MovingAverageWindow; i--)
+            {
+                if (series[i].HasValue) { window.Add(series[i]!.Value); }
+            }
+            if (window.Count == 0) { return output; }
+            double avg = window.Average();
+            for (int i = 0; i < periods; i++) { output[i] = avg; }
+            return output;
+        }
+    }
+}

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryEngine.cs
@@ -151,6 +151,16 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 Insights = insights,
             };
 
+            // Forecasting (10.5.0+) — 在所有資料增益完成後外推 N 期。失敗
+            // 條件下 (無時間維度、實際列不足) 靜默 no-op；不影響 TotalCount /
+            // Insights / GrandTotalRow。
+            if (req.Forecast != null)
+            {
+                AnalysisForecastEngine.ApplyForecast(
+                    response, req.Forecast, req.Dimensions,
+                    BuildMeasureColumnNames(req), req.DimensionHierarchies);
+            }
+
             _cache?.Set(queryHash, response, _defaultTtl);
 
             return response;
@@ -256,6 +266,13 @@ namespace WalkingTec.Mvvm.Core.Analysis
                 GrandTotalRow = grandTotal,
                 Insights = insights,
             };
+
+            if (req.Forecast != null)
+            {
+                AnalysisForecastEngine.ApplyForecast(
+                    response, req.Forecast, req.Dimensions,
+                    BuildMeasureColumnNames(req), req.DimensionHierarchies);
+            }
 
             _cache?.Set(queryHash, response, _defaultTtl);
 
@@ -607,6 +624,20 @@ namespace WalkingTec.Mvvm.Core.Analysis
         /// can render the four-column comparison group together rather
         /// than scattering across the row.
         /// </summary>
+        /// <summary>
+        /// 取得每個 measure 的 result column key（<c>{Field}_{Func}</c>）— 預測
+        /// 引擎用來決定要外推哪些欄。不含維度與對比衍生欄。
+        /// </summary>
+        internal static List<string> BuildMeasureColumnNames(AnalysisQueryRequest req)
+        {
+            var cols = new List<string>(req.Measures.Count);
+            foreach (var m in req.Measures)
+            {
+                cols.Add($"{m.Field}_{m.Func}");
+            }
+            return cols;
+        }
+
         internal static List<string> BuildResponseColumns(AnalysisQueryRequest req)
         {
             var cols = new List<string>(req.Dimensions);

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryRequest.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryRequest.cs
@@ -100,6 +100,24 @@ namespace WalkingTec.Mvvm.Core.Analysis
         /// <c>Amount_Sum_ChangePct</c> 做「漲幅前 N 名」）。
         /// </summary>
         public ComparisonRequest? CompareWith { get; set; }
+
+        /// <summary>
+        /// 預測（forecast）設定 — 啟用後引擎會在所有資料增益（HAVING、
+        /// CompareWith、GrandTotal、Sort、TopN、Insights）完成後，依時間
+        /// 序的第一個維度（必須是 <see cref="DimensionHierarchies"/>
+        /// 中宣告為日期階層的維度）外推 <see cref="ForecastSpec.Periods"/>
+        /// 期。每筆預測列以下一期的人類可讀標籤（例如
+        /// <c>"2026-05"</c>）作為維度值，並在每個 measure-result 欄位
+        /// 填入估計值；除原本的欄位外，預測列額外帶一個
+        /// <c>"_IsForecast" = true</c> 的旗標 key，前端用以區分實際 vs
+        /// 預測（例如以虛線繪製預測段）。預測**不**重新計算 Insights /
+        /// GrandTotalRow / TotalCount — 那些反映實際資料；預測純為
+        /// 視覺輔助。<see cref="ForecastMethod.Linear"/> 走最小平方法
+        /// 線性回歸，<see cref="ForecastMethod.MovingAverage"/> 走最後
+        /// 3 期均值（小於 3 期則用全部）。預設 <c>null</c> 完全不影響
+        /// 舊呼叫者。
+        /// </summary>
+        public ForecastSpec? Forecast { get; set; }
     }
 
     /// <summary>
@@ -191,5 +209,31 @@ namespace WalkingTec.Mvvm.Core.Analysis
     {
         Eq, Gt, Gte, Lt, Lte, Contains, In,
         NotEq, NotContains, NotIn
+    }
+
+    /// <summary>
+    /// 預測規格 — 設定外推期數與方法。
+    /// </summary>
+    public class ForecastSpec
+    {
+        /// <summary>
+        /// 要外推的期數。範圍 1..12，超出範圍由引擎驗證階段拒絕。
+        /// 預測長度受實際序列長度限制 — 線性回歸至少需 2 期實際資料，
+        /// 移動平均至少需 1 期；不足則該欄輸出 <c>null</c>（前端可隱藏
+        /// 該段預測線而非 throw）。
+        /// </summary>
+        public int Periods { get; set; } = 1;
+
+        /// <summary>預測方法，預設 <see cref="ForecastMethod.Linear"/>。</summary>
+        public ForecastMethod Method { get; set; } = ForecastMethod.Linear;
+    }
+
+    /// <summary>預測方法列舉。</summary>
+    public enum ForecastMethod
+    {
+        /// <summary>最小平方法線性回歸 — 適合明顯有趨勢的時間序列。</summary>
+        Linear,
+        /// <summary>移動平均 — 適合平穩、無趨勢的時間序列。常數預測。</summary>
+        MovingAverage,
     }
 }

--- a/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryResponse.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/AnalysisQueryResponse.cs
@@ -69,5 +69,14 @@ namespace WalkingTec.Mvvm.Core.Analysis
         /// 篩選後的群組，<see cref="AnalysisQueryRequest.TopN"/> 不影響範圍。
         /// </summary>
         public Dictionary<string, object?>? GrandTotalRow { get; set; }
+
+        /// <summary>
+        /// 為 <c>true</c> 時表示 <see cref="Rows"/> 結尾包含預測列（每筆帶
+        /// <c>"_IsForecast" = true</c> 旗標）。前端可據此將預測段以虛線 /
+        /// 不同色繪製。<see cref="TotalCount"/> 仍只反映實際列數，不含預測。
+        /// 觸發條件：<see cref="AnalysisQueryRequest.Forecast"/> 非 null
+        /// 且預測引擎成功產出至少 1 筆預測列。
+        /// </summary>
+        public bool HasForecast { get; set; }
     }
 }

--- a/src/WalkingTec.Mvvm.Core/Analysis/DateTruncator.cs
+++ b/src/WalkingTec.Mvvm.Core/Analysis/DateTruncator.cs
@@ -127,6 +127,38 @@ namespace WalkingTec.Mvvm.Core.Analysis
             }
         }
 
+        /// <summary>
+        /// 給定一個合法的 hierarchy label（例如 <c>"2026-03"</c>）回傳其
+        /// 「下一期」的 label（<c>"2026-04"</c>）。為預測引擎產生未來
+        /// 期間的維度標籤；label 無法 parse 則回 <c>null</c>。
+        /// </summary>
+        public static string? NextLabel(string? label, DateHierarchy hierarchy, int step = 1)
+        {
+            if (!TryParseLabel(label, hierarchy, out var start, out var endExclusive))
+            {
+                return null;
+            }
+            return hierarchy switch
+            {
+                DateHierarchy.Year =>
+                    FormatKey(start.Year + step, hierarchy),
+                DateHierarchy.Quarter =>
+                    FormatKey(QuarterKey(endExclusive.AddMonths(3 * (step - 1))), hierarchy),
+                DateHierarchy.Month =>
+                    FormatKey(MonthKey(endExclusive.AddMonths(step - 1)), hierarchy),
+                DateHierarchy.Day =>
+                    FormatKey(DayKey(endExclusive.AddDays(step - 1)), hierarchy),
+                _ => null,
+            };
+        }
+
+        private static int QuarterKey(DateTime d) =>
+            d.Year * 10 + ((d.Month - 1) / 3 + 1);
+        private static int MonthKey(DateTime d) =>
+            d.Year * 100 + d.Month;
+        private static int DayKey(DateTime d) =>
+            d.Year * 10000 + d.Month * 100 + d.Day;
+
         private static Expression BuildQuarterKey(Expression dateExpr)
         {
             var year = Expression.Property(dateExpr, nameof(DateTime.Year));

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlExecutionResult.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlExecutionResult.cs
@@ -44,4 +44,19 @@ public class EtlExecutionResult
     /// 來源 / 目標 DB 有持續的轉瞬故障值得調查。
     /// </summary>
     public int RetryAttemptsTotal { get; init; }
+
+    /// <summary>
+    /// 經 <see cref="EtlPipelineConfig.QualityRules"/> 判定為違規的列數累計
+    /// （10.5.1+）。0 = 沒違規或未設定品質規則。<see cref="EtlPipelineConfig.QualityRuleAction"/>
+    /// 為 <see cref="EtlQualityRuleAction.Drop"/> 時，<see cref="LoadedRows"/>
+    /// 不會包含這些列；為 <see cref="EtlQualityRuleAction.Continue"/> 時則會
+    /// （audit-only），可用此值監控資料品質趨勢。
+    /// </summary>
+    public int QualityFailedRows { get; init; }
+
+    /// <summary>
+    /// 違規列的範例（前 20 筆，避免 OOM）— 每筆描述違反的規則 + 欄位 +
+    /// 值的擷取。10.5.1+。空 list = 沒違規或未啟用。
+    /// </summary>
+    public IList<string> QualityFailureSamples { get; init; } = new List<string>();
 }

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineConfig.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineConfig.cs
@@ -104,4 +104,28 @@ public record EtlPipelineConfig
     /// staging table 的 schema 必須對應 mapping value（已改名後的目標欄位）。
     /// </summary>
     public System.Collections.Generic.IDictionary<string, string>? ColumnMappings { get; init; }
+
+    /// <summary>
+    /// 資料品質規則（10.5.1+，opt-in）。在 Transform 與 ColumnMapping 之後、
+    /// BulkLoad 之前依序套用每筆規則檢查每列；違規列依
+    /// <see cref="QualityRuleAction"/> 處理。null / 空 list = 不檢查
+    /// （與 10.5.0 行為完全一致）。常見場景：
+    /// <list type="bullet">
+    /// <item><see cref="EtlQualityRuleType.NotNull"/> — 主鍵 / FK 欄位禁止 null</item>
+    /// <item><see cref="EtlQualityRuleType.Range"/> — 數值在合理區間（如年齡 0..120）</item>
+    /// <item><see cref="EtlQualityRuleType.Regex"/> — Email / 電話 / 身分證號格式</item>
+    /// <item><see cref="EtlQualityRuleType.In"/> — 列舉值白名單（如 OrderStatus 只能 NEW/PAID/SHIPPED）</item>
+    /// </list>
+    /// </summary>
+    public System.Collections.Generic.IList<EtlQualityRule>? QualityRules { get; init; }
+
+    /// <summary>
+    /// 違規列的處理策略。預設 <see cref="EtlQualityRuleAction.Drop"/>
+    /// — 違規列被剔除、合規列正常 BulkLoad，job 整體仍視為成功
+    /// （但 <see cref="EtlExecutionResult.QualityFailedRows"/> 帶出總數）。
+    /// 切到 <see cref="EtlQualityRuleAction.Abort"/> 後任一違規即整個 job
+    /// 失敗、watermark discard，下次重抓。<see cref="QualityRules"/>
+    /// 為 null / 空 list 時此設定無效。
+    /// </summary>
+    public EtlQualityRuleAction QualityRuleAction { get; init; } = EtlQualityRuleAction.Drop;
 }

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlPipelineExecutor.cs
@@ -61,6 +61,8 @@ public class EtlPipelineExecutor
         int totalExtracted = 0;
         int totalLoaded = 0;
         int retryAttempts = 0;
+        int qualityFailedRows = 0;
+        var qualityFailureSamples = new List<string>();
 
         try
         {
@@ -109,6 +111,21 @@ public class EtlPipelineExecutor
                 if (config.ColumnMappings != null && config.ColumnMappings.Count > 0)
                 {
                     transformed = ApplyColumnMappings(transformed, config.ColumnMappings);
+                }
+
+                // Quality rules (10.5.1+) — Drop / Continue / Abort 違規列。
+                // Abort 會 throw 並沿用既有 catch 走 watermark discard 路徑。
+                if (config.QualityRules != null && config.QualityRules.Count > 0)
+                {
+                    transformed = EtlQualityRuleEvaluator.Apply(
+                        transformed, config.QualityRules, config.QualityRuleAction,
+                        out int batchFailed, out var batchSamples);
+                    qualityFailedRows += batchFailed;
+                    foreach (var s in batchSamples)
+                    {
+                        if (qualityFailureSamples.Count >= EtlQualityRuleEvaluator.MaxFailureSamples) { break; }
+                        qualityFailureSamples.Add(s);
+                    }
                 }
 
                 await BulkLoadWithRetryAsync(
@@ -160,6 +177,8 @@ public class EtlPipelineExecutor
                 ElapsedMs = sw.ElapsedMilliseconds,
                 NewWatermarkValue = newWatermark,
                 RetryAttemptsTotal = retryAttempts,
+                QualityFailedRows = qualityFailedRows,
+                QualityFailureSamples = qualityFailureSamples,
             };
         }
         catch (OperationCanceledException)
@@ -175,6 +194,8 @@ public class EtlPipelineExecutor
                 ElapsedMs = sw.ElapsedMilliseconds,
                 ErrorMessage = "Job was aborted",
                 RetryAttemptsTotal = retryAttempts,
+                QualityFailedRows = qualityFailedRows,
+                QualityFailureSamples = qualityFailureSamples,
             };
         }
         catch (Exception ex)
@@ -189,6 +210,8 @@ public class EtlPipelineExecutor
                 ElapsedMs = sw.ElapsedMilliseconds,
                 ErrorMessage = EtlErrorSanitizer.Sanitize(ex),
                 RetryAttemptsTotal = retryAttempts,
+                QualityFailedRows = qualityFailedRows,
+                QualityFailureSamples = qualityFailureSamples,
             };
         }
     }

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlQualityRule.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlQualityRule.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// 單一資料品質規則 — 套用於 Transform / ColumnMapping 之後、
+/// BulkLoad 之前的記憶體 <c>DataTable</c>。違規列依
+/// <see cref="EtlPipelineConfig.QualityRuleAction"/> 設定處理。
+/// </summary>
+public record EtlQualityRule
+{
+    /// <summary>要檢查的欄位名稱（必須存在於 transformed table 中）。</summary>
+    public string Column { get; init; } = string.Empty;
+
+    /// <summary>規則類型。</summary>
+    public EtlQualityRuleType RuleType { get; init; }
+
+    /// <summary>數值範圍下限（<see cref="EtlQualityRuleType.Range"/> 用，含端點）。</summary>
+    public decimal? Min { get; init; }
+
+    /// <summary>數值範圍上限（<see cref="EtlQualityRuleType.Range"/> 用，含端點）。</summary>
+    public decimal? Max { get; init; }
+
+    /// <summary>正規表達式（<see cref="EtlQualityRuleType.Regex"/> 用，必填）。</summary>
+    public string? Pattern { get; init; }
+
+    /// <summary>白名單值（<see cref="EtlQualityRuleType.In"/> 用，必填）。</summary>
+    public IList<string>? Allowed { get; init; }
+
+    /// <summary>違規時的可讀說明（記入 <see cref="EtlExecutionResult.QualityFailureSamples"/>）。</summary>
+    public string? Description { get; init; }
+}
+
+/// <summary>規則類型。</summary>
+public enum EtlQualityRuleType
+{
+    /// <summary>欄位值不可為 <c>DBNull</c> / <c>null</c>。</summary>
+    NotNull,
+    /// <summary>欄位值（轉為 decimal）必須在 [<see cref="EtlQualityRule.Min"/>, <see cref="EtlQualityRule.Max"/>] 之內，端點包含。</summary>
+    Range,
+    /// <summary>欄位字串值必須匹配 <see cref="EtlQualityRule.Pattern"/>（編譯快取）。</summary>
+    Regex,
+    /// <summary>欄位字串值必須在 <see cref="EtlQualityRule.Allowed"/> 列表內（大小寫敏感）。</summary>
+    In,
+}
+
+/// <summary>
+/// 違規列的處理策略。
+/// </summary>
+public enum EtlQualityRuleAction
+{
+    /// <summary>違規列從 batch 中剔除，其他列正常 BulkLoad（預設、最寬鬆）。</summary>
+    Drop,
+    /// <summary>違規列照常 BulkLoad，僅計數不阻擋。適合 audit-only 階段。</summary>
+    Continue,
+    /// <summary>任一列違規即拋例外、整個 job 失敗、watermark discard。</summary>
+    Abort,
+}

--- a/src/WalkingTec.Mvvm.Etl/Pipeline/EtlQualityRuleEvaluator.cs
+++ b/src/WalkingTec.Mvvm.Etl/Pipeline/EtlQualityRuleEvaluator.cs
@@ -1,0 +1,202 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace WalkingTec.Mvvm.Etl.Pipeline;
+
+/// <summary>
+/// 純記憶體規則評估器 — 對 <see cref="DataTable"/> 套用
+/// <see cref="EtlQualityRule"/> 集合，依 <see cref="EtlQualityRuleAction"/>
+/// 決定要剔除違規列、繼續、還是 throw。
+/// </summary>
+public static class EtlQualityRuleEvaluator
+{
+    /// <summary>違規範例累計上限，避免 OOM 與爆量 log。</summary>
+    public const int MaxFailureSamples = 20;
+
+    private static readonly ConcurrentDictionary<string, Regex> _regexCache = new();
+
+    /// <summary>
+    /// 依規則套用至 <paramref name="table"/>，回傳新的 DataTable（或原表，
+    /// 若 Action = Continue 則就地不改）。違規列數量寫到
+    /// <paramref name="failedRows"/>，違規範例（最多 <see cref="MaxFailureSamples"/>
+    /// 筆）寫到 <paramref name="failureSamples"/>。
+    /// </summary>
+    /// <exception cref="EtlQualityRuleViolationException">
+    /// <paramref name="action"/> = <see cref="EtlQualityRuleAction.Abort"/>
+    /// 且至少一筆違規時拋出。
+    /// </exception>
+    public static DataTable Apply(
+        DataTable table,
+        IList<EtlQualityRule> rules,
+        EtlQualityRuleAction action,
+        out int failedRows,
+        out List<string> failureSamples)
+    {
+        if (table == null) { throw new ArgumentNullException(nameof(table)); }
+        if (rules == null) { throw new ArgumentNullException(nameof(rules)); }
+
+        failedRows = 0;
+        failureSamples = new List<string>();
+        if (rules.Count == 0 || table.Rows.Count == 0)
+        {
+            return table;
+        }
+
+        // 預先決定每個規則的欄位 index — 規則欄不存在於表中就丟例外
+        // （表示 mapping / config 對不上，不該悄悄忽略）
+        var ruleColIdx = new int[rules.Count];
+        for (int i = 0; i < rules.Count; i++)
+        {
+            var col = table.Columns[rules[i].Column];
+            if (col == null)
+            {
+                throw new ArgumentException(
+                    $"Quality rule references column '{rules[i].Column}' which is not in the transformed table.",
+                    nameof(rules));
+            }
+            ruleColIdx[i] = col.Ordinal;
+        }
+
+        var keepRows = new List<DataRow>(table.Rows.Count);
+        for (int rowIdx = 0; rowIdx < table.Rows.Count; rowIdx++)
+        {
+            var row = table.Rows[rowIdx];
+            string? violation = null;
+            for (int i = 0; i < rules.Count; i++)
+            {
+                violation = Evaluate(rules[i], row[ruleColIdx[i]]);
+                if (violation != null) { break; }
+            }
+            if (violation == null)
+            {
+                keepRows.Add(row);
+                continue;
+            }
+
+            failedRows++;
+            if (failureSamples.Count < MaxFailureSamples)
+            {
+                failureSamples.Add($"row#{rowIdx}: {violation}");
+            }
+
+            if (action == EtlQualityRuleAction.Abort)
+            {
+                throw new EtlQualityRuleViolationException(
+                    $"Quality rule violated: {violation}");
+            }
+            if (action == EtlQualityRuleAction.Continue)
+            {
+                keepRows.Add(row); // 違規列照樣保留（audit-only）
+            }
+            // Drop → 不加入 keepRows
+        }
+
+        // 沒違規或全保留 → 原表回傳（避免不必要的 Clone）
+        if (failedRows == 0 || action == EtlQualityRuleAction.Continue)
+        {
+            return table;
+        }
+
+        // Drop 模式：建一張只含合規列的新表
+        var clone = table.Clone();
+        foreach (var r in keepRows)
+        {
+            clone.ImportRow(r);
+        }
+        return clone;
+    }
+
+    /// <summary>
+    /// 對單一格子套用規則。回傳違規描述字串，或 <c>null</c> = 通過。
+    /// </summary>
+    internal static string? Evaluate(EtlQualityRule rule, object? value)
+    {
+        switch (rule.RuleType)
+        {
+            case EtlQualityRuleType.NotNull:
+                if (value == null || value == DBNull.Value)
+                {
+                    return $"{rule.Column} is null (rule: NotNull)";
+                }
+                return null;
+
+            case EtlQualityRuleType.Range:
+                if (value == null || value == DBNull.Value) { return null; } // null 不在 Range 規則範圍
+                if (!TryToDecimal(value, out var dec))
+                {
+                    return $"{rule.Column}={Truncate(value)} not numeric (rule: Range)";
+                }
+                if (rule.Min.HasValue && dec < rule.Min.Value)
+                {
+                    return $"{rule.Column}={dec} below Min={rule.Min.Value} (rule: Range)";
+                }
+                if (rule.Max.HasValue && dec > rule.Max.Value)
+                {
+                    return $"{rule.Column}={dec} above Max={rule.Max.Value} (rule: Range)";
+                }
+                return null;
+
+            case EtlQualityRuleType.Regex:
+                if (string.IsNullOrEmpty(rule.Pattern))
+                {
+                    return $"{rule.Column} rule misconfigured: Regex Pattern is empty";
+                }
+                if (value == null || value == DBNull.Value) { return null; }
+                var regex = _regexCache.GetOrAdd(rule.Pattern,
+                    p => new Regex(p, RegexOptions.Compiled, TimeSpan.FromSeconds(1)));
+                var s = value.ToString() ?? string.Empty;
+                if (!regex.IsMatch(s))
+                {
+                    return $"{rule.Column}={Truncate(s)} fails Regex {Truncate(rule.Pattern)}";
+                }
+                return null;
+
+            case EtlQualityRuleType.In:
+                if (rule.Allowed == null || rule.Allowed.Count == 0)
+                {
+                    return $"{rule.Column} rule misconfigured: In Allowed list is empty";
+                }
+                if (value == null || value == DBNull.Value) { return null; }
+                var sv = value.ToString() ?? string.Empty;
+                if (!rule.Allowed.Contains(sv))
+                {
+                    return $"{rule.Column}={Truncate(sv)} not in allow-list (rule: In)";
+                }
+                return null;
+
+            default:
+                return $"{rule.Column} rule misconfigured: unknown RuleType {rule.RuleType}";
+        }
+    }
+
+    private static bool TryToDecimal(object value, out decimal result)
+    {
+        if (value is decimal d) { result = d; return true; }
+        if (value is int i) { result = i; return true; }
+        if (value is long l) { result = l; return true; }
+        if (value is double db) { result = (decimal)db; return true; }
+        if (value is float f) { result = (decimal)f; return true; }
+        return decimal.TryParse(value.ToString(), NumberStyles.Any,
+            CultureInfo.InvariantCulture, out result);
+    }
+
+    private static string Truncate(object? value, int max = 64)
+    {
+        var s = value?.ToString() ?? "";
+        return s.Length <= max ? s : s.Substring(0, max) + "…";
+    }
+}
+
+/// <summary>
+/// <see cref="EtlQualityRuleAction.Abort"/> 模式下，遇到第一個違規列即拋出。
+/// </summary>
+public class EtlQualityRuleViolationException : Exception
+{
+    public EtlQualityRuleViolationException(string message) : base(message) { }
+}

--- a/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisForecastEngineTests.cs
+++ b/test/WalkingTec.Mvvm.Core.Test/Analysis/AnalysisForecastEngineTests.cs
@@ -1,0 +1,246 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Core.Analysis;
+
+namespace WalkingTec.Mvvm.Core.Test.Analysis
+{
+    /// <summary>
+    /// 純記憶體測試 — 驗證 <see cref="AnalysisForecastEngine"/> 的線性回歸 /
+    /// 移動平均預測、邊界條件 (時間維度遺失、實際列不足、無法 parse 期別)
+    /// 都靜默 no-op 而非 throw。
+    /// </summary>
+    [TestClass]
+    public class AnalysisForecastEngineTests
+    {
+        private static AnalysisQueryResponse BuildLinearMonthly()
+        {
+            return new AnalysisQueryResponse
+            {
+                Rows = new List<Dictionary<string, object?>>
+                {
+                    new() { ["Month"] = "2026-01", ["Amount_Sum"] = 100m },
+                    new() { ["Month"] = "2026-02", ["Amount_Sum"] = 200m },
+                    new() { ["Month"] = "2026-03", ["Amount_Sum"] = 300m },
+                    new() { ["Month"] = "2026-04", ["Amount_Sum"] = 400m },
+                },
+            };
+        }
+
+        private static Dictionary<string, DateHierarchy> MonthlyHierarchy() =>
+            new() { ["Month"] = DateHierarchy.Month };
+
+        [TestMethod]
+        public void Linear_appends_3_forecast_rows_with_correct_labels()
+        {
+            var resp = BuildLinearMonthly();
+            AnalysisForecastEngine.ApplyForecast(
+                resp,
+                new ForecastSpec { Periods = 3, Method = ForecastMethod.Linear },
+                new List<string> { "Month" },
+                new List<string> { "Amount_Sum" },
+                MonthlyHierarchy());
+
+            Assert.IsTrue(resp.HasForecast);
+            Assert.AreEqual(7, resp.Rows.Count, "4 actual + 3 forecast");
+            var forecasted = resp.Rows.Where(r =>
+                r.TryGetValue(AnalysisForecastEngine.ForecastFlagKey, out var f) && f is true).ToList();
+            Assert.AreEqual(3, forecasted.Count);
+            Assert.AreEqual("2026-05", forecasted[0]["Month"]);
+            Assert.AreEqual("2026-06", forecasted[1]["Month"]);
+            Assert.AreEqual("2026-07", forecasted[2]["Month"]);
+        }
+
+        [TestMethod]
+        public void Linear_extrapolates_perfect_line_correctly()
+        {
+            var resp = BuildLinearMonthly();
+            AnalysisForecastEngine.ApplyForecast(
+                resp,
+                new ForecastSpec { Periods = 2, Method = ForecastMethod.Linear },
+                new List<string> { "Month" },
+                new List<string> { "Amount_Sum" },
+                MonthlyHierarchy());
+
+            // y = 100x + 100；實際 indices 0..3，下兩期應為 500、600
+            Assert.AreEqual(500m, resp.Rows[4]["Amount_Sum"]);
+            Assert.AreEqual(600m, resp.Rows[5]["Amount_Sum"]);
+        }
+
+        [TestMethod]
+        public void MovingAverage_averages_last_3_periods_constant()
+        {
+            var resp = new AnalysisQueryResponse
+            {
+                Rows = new List<Dictionary<string, object?>>
+                {
+                    new() { ["Month"] = "2026-01", ["Amount_Sum"] = 100m },
+                    new() { ["Month"] = "2026-02", ["Amount_Sum"] = 200m },
+                    new() { ["Month"] = "2026-03", ["Amount_Sum"] = 300m }, // last 3: 100,200,300 → avg=200
+                },
+            };
+            AnalysisForecastEngine.ApplyForecast(
+                resp,
+                new ForecastSpec { Periods = 2, Method = ForecastMethod.MovingAverage },
+                new List<string> { "Month" },
+                new List<string> { "Amount_Sum" },
+                MonthlyHierarchy());
+
+            Assert.IsTrue(resp.HasForecast);
+            Assert.AreEqual(200m, resp.Rows[3]["Amount_Sum"]);
+            Assert.AreEqual(200m, resp.Rows[4]["Amount_Sum"], "MA = constant");
+        }
+
+        [TestMethod]
+        public void MovingAverage_uses_all_when_fewer_than_window()
+        {
+            var resp = new AnalysisQueryResponse
+            {
+                Rows = new List<Dictionary<string, object?>>
+                {
+                    new() { ["Month"] = "2026-01", ["Amount_Sum"] = 100m },
+                    new() { ["Month"] = "2026-02", ["Amount_Sum"] = 200m },
+                },
+            };
+            AnalysisForecastEngine.ApplyForecast(
+                resp,
+                new ForecastSpec { Periods = 1, Method = ForecastMethod.MovingAverage },
+                new List<string> { "Month" },
+                new List<string> { "Amount_Sum" },
+                MonthlyHierarchy());
+
+            Assert.AreEqual(150m, resp.Rows[2]["Amount_Sum"]);
+        }
+
+        [TestMethod]
+        public void NoOp_when_no_hierarchies_provided()
+        {
+            var resp = BuildLinearMonthly();
+            AnalysisForecastEngine.ApplyForecast(
+                resp,
+                new ForecastSpec { Periods = 1 },
+                new List<string> { "Month" },
+                new List<string> { "Amount_Sum" },
+                hierarchies: null);
+            Assert.IsFalse(resp.HasForecast);
+            Assert.AreEqual(4, resp.Rows.Count);
+        }
+
+        [TestMethod]
+        public void NoOp_when_first_dim_not_in_hierarchies()
+        {
+            var resp = new AnalysisQueryResponse
+            {
+                Rows = new List<Dictionary<string, object?>>
+                {
+                    new() { ["Region"] = "北", ["Amount_Sum"] = 100m },
+                    new() { ["Region"] = "南", ["Amount_Sum"] = 200m },
+                },
+            };
+            AnalysisForecastEngine.ApplyForecast(
+                resp,
+                new ForecastSpec { Periods = 1 },
+                new List<string> { "Region" },
+                new List<string> { "Amount_Sum" },
+                MonthlyHierarchy()); // hierarchy 對 "Month" 但維度是 "Region"
+
+            Assert.IsFalse(resp.HasForecast);
+            Assert.AreEqual(2, resp.Rows.Count);
+        }
+
+        [TestMethod]
+        public void Linear_returns_null_when_fewer_than_2_points()
+        {
+            var resp = new AnalysisQueryResponse
+            {
+                Rows = new List<Dictionary<string, object?>>
+                {
+                    new() { ["Month"] = "2026-01", ["Amount_Sum"] = 100m },
+                },
+            };
+            AnalysisForecastEngine.ApplyForecast(
+                resp,
+                new ForecastSpec { Periods = 1, Method = ForecastMethod.Linear },
+                new List<string> { "Month" },
+                new List<string> { "Amount_Sum" },
+                MonthlyHierarchy());
+
+            // 仍 append 預測列（label 可推得），但 measure 為 null
+            Assert.IsTrue(resp.HasForecast);
+            Assert.IsNull(resp.Rows[1]["Amount_Sum"]);
+            Assert.AreEqual("2026-02", resp.Rows[1]["Month"]);
+        }
+
+        [TestMethod]
+        public void Periods_clamped_to_max()
+        {
+            var resp = BuildLinearMonthly();
+            AnalysisForecastEngine.ApplyForecast(
+                resp,
+                new ForecastSpec { Periods = 99, Method = ForecastMethod.Linear },
+                new List<string> { "Month" },
+                new List<string> { "Amount_Sum" },
+                MonthlyHierarchy());
+
+            var forecasted = resp.Rows.Skip(4).ToList();
+            Assert.AreEqual(AnalysisForecastEngine.MaxPeriods, forecasted.Count);
+        }
+
+        [TestMethod]
+        public void Empty_rows_noop()
+        {
+            var resp = new AnalysisQueryResponse();
+            AnalysisForecastEngine.ApplyForecast(
+                resp,
+                new ForecastSpec { Periods = 1 },
+                new List<string> { "Month" },
+                new List<string> { "Amount_Sum" },
+                MonthlyHierarchy());
+            Assert.IsFalse(resp.HasForecast);
+            Assert.AreEqual(0, resp.Rows.Count);
+        }
+
+        [TestMethod]
+        public void Quarter_hierarchy_advances_correctly()
+        {
+            var resp = new AnalysisQueryResponse
+            {
+                Rows = new List<Dictionary<string, object?>>
+                {
+                    new() { ["Quarter"] = "2026 Q1", ["Amount_Sum"] = 100m },
+                    new() { ["Quarter"] = "2026 Q2", ["Amount_Sum"] = 200m },
+                    new() { ["Quarter"] = "2026 Q3", ["Amount_Sum"] = 300m },
+                },
+            };
+            AnalysisForecastEngine.ApplyForecast(
+                resp,
+                new ForecastSpec { Periods = 2, Method = ForecastMethod.Linear },
+                new List<string> { "Quarter" },
+                new List<string> { "Amount_Sum" },
+                new Dictionary<string, DateHierarchy> { ["Quarter"] = DateHierarchy.Quarter });
+
+            Assert.AreEqual("2026 Q4", resp.Rows[3]["Quarter"]);
+            Assert.AreEqual("2027 Q1", resp.Rows[4]["Quarter"]);
+        }
+
+        [TestMethod]
+        public void NextLabel_returns_null_for_unparseable()
+        {
+            Assert.IsNull(DateTruncator.NextLabel("not-a-date", DateHierarchy.Month));
+            Assert.IsNull(DateTruncator.NextLabel(null, DateHierarchy.Year));
+            Assert.IsNull(DateTruncator.NextLabel("2026-99", DateHierarchy.Month));
+        }
+
+        [TestMethod]
+        public void NextLabel_year_quarter_month_day_round_trip()
+        {
+            Assert.AreEqual("2027", DateTruncator.NextLabel("2026", DateHierarchy.Year));
+            Assert.AreEqual("2026 Q2", DateTruncator.NextLabel("2026 Q1", DateHierarchy.Quarter));
+            Assert.AreEqual("2027 Q1", DateTruncator.NextLabel("2026 Q4", DateHierarchy.Quarter));
+            Assert.AreEqual("2026-04", DateTruncator.NextLabel("2026-03", DateHierarchy.Month));
+            Assert.AreEqual("2027-01", DateTruncator.NextLabel("2026-12", DateHierarchy.Month));
+            Assert.AreEqual("2026-03-16", DateTruncator.NextLabel("2026-03-15", DateHierarchy.Day));
+        }
+    }
+}

--- a/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EtlQualityRulesTests.cs
+++ b/test/WalkingTec.Mvvm.Etl.Test/Pipeline/EtlQualityRulesTests.cs
@@ -1,0 +1,253 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WalkingTec.Mvvm.Etl.Pipeline;
+
+namespace WalkingTec.Mvvm.Etl.Test.Pipeline
+{
+    /// <summary>
+    /// 驗證 <see cref="EtlQualityRuleEvaluator"/> 對 NotNull / Range / Regex / In
+    /// 的判定，以及 Drop / Continue / Abort 三種 Action 的行為差異與
+    /// failure-sample 上限。
+    /// </summary>
+    [TestClass]
+    public class EtlQualityRulesTests
+    {
+        private static DataTable Table()
+        {
+            var t = new DataTable("Orders");
+            t.Columns.Add("Email", typeof(string));
+            t.Columns.Add("Age", typeof(int));
+            t.Columns.Add("Status", typeof(string));
+            t.Columns.Add("CustomerId", typeof(string));
+            return t;
+        }
+
+        private static DataRow AddRow(DataTable t, string? email, int? age, string? status, string? cust)
+        {
+            var r = t.NewRow();
+            r["Email"] = (object?)email ?? DBNull.Value;
+            r["Age"] = (object?)age ?? DBNull.Value;
+            r["Status"] = (object?)status ?? DBNull.Value;
+            r["CustomerId"] = (object?)cust ?? DBNull.Value;
+            t.Rows.Add(r);
+            return r;
+        }
+
+        [TestMethod]
+        public void NotNull_drops_null_rows()
+        {
+            var t = Table();
+            AddRow(t, "a@x.com", 30, "PAID", "C1");
+            AddRow(t, "b@x.com", 25, "NEW", null);  // CustomerId null
+            AddRow(t, "c@x.com", 40, "PAID", "C3");
+
+            var rules = new List<EtlQualityRule>
+            {
+                new() { Column = "CustomerId", RuleType = EtlQualityRuleType.NotNull },
+            };
+            var result = EtlQualityRuleEvaluator.Apply(
+                t, rules, EtlQualityRuleAction.Drop, out var failed, out var samples);
+
+            Assert.AreEqual(1, failed);
+            Assert.AreEqual(2, result.Rows.Count);
+            Assert.IsTrue(samples[0].Contains("CustomerId"));
+            Assert.IsTrue(samples[0].Contains("NotNull"));
+        }
+
+        [TestMethod]
+        public void Range_rejects_out_of_bounds()
+        {
+            var t = Table();
+            AddRow(t, "a@x.com", 30, "OK", "C1");
+            AddRow(t, "b@x.com", 200, "OK", "C2"); // out of [0..120]
+            AddRow(t, "c@x.com", -1, "OK", "C3");  // below 0
+
+            var rules = new List<EtlQualityRule>
+            {
+                new() { Column = "Age", RuleType = EtlQualityRuleType.Range, Min = 0, Max = 120 },
+            };
+            var result = EtlQualityRuleEvaluator.Apply(
+                t, rules, EtlQualityRuleAction.Drop, out var failed, out _);
+
+            Assert.AreEqual(2, failed);
+            Assert.AreEqual(1, result.Rows.Count);
+            Assert.AreEqual(30, result.Rows[0]["Age"]);
+        }
+
+        [TestMethod]
+        public void Regex_rejects_invalid_email()
+        {
+            var t = Table();
+            AddRow(t, "a@x.com", 30, "OK", "C1");
+            AddRow(t, "no-at-sign", 30, "OK", "C2");
+            AddRow(t, "x@y.z", 30, "OK", "C3");
+
+            var rules = new List<EtlQualityRule>
+            {
+                new()
+                {
+                    Column = "Email",
+                    RuleType = EtlQualityRuleType.Regex,
+                    Pattern = @"^[^@\s]+@[^@\s]+\.[^@\s]+$",
+                },
+            };
+            var result = EtlQualityRuleEvaluator.Apply(
+                t, rules, EtlQualityRuleAction.Drop, out var failed, out _);
+
+            Assert.AreEqual(1, failed);
+            Assert.AreEqual(2, result.Rows.Count);
+        }
+
+        [TestMethod]
+        public void In_rejects_non_whitelisted_status()
+        {
+            var t = Table();
+            AddRow(t, "a@x.com", 30, "NEW", "C1");
+            AddRow(t, "b@x.com", 30, "EVIL", "C2"); // not in
+            AddRow(t, "c@x.com", 30, "PAID", "C3");
+
+            var rules = new List<EtlQualityRule>
+            {
+                new()
+                {
+                    Column = "Status",
+                    RuleType = EtlQualityRuleType.In,
+                    Allowed = new List<string> { "NEW", "PAID", "SHIPPED" },
+                },
+            };
+            var result = EtlQualityRuleEvaluator.Apply(
+                t, rules, EtlQualityRuleAction.Drop, out var failed, out _);
+
+            Assert.AreEqual(1, failed);
+            Assert.AreEqual(2, result.Rows.Count);
+        }
+
+        [TestMethod]
+        public void Continue_keeps_violating_rows_audit_only()
+        {
+            var t = Table();
+            AddRow(t, "a@x.com", 30, "NEW", "C1");
+            AddRow(t, "b@x.com", 30, "NEW", null);   // violation
+
+            var rules = new List<EtlQualityRule>
+            {
+                new() { Column = "CustomerId", RuleType = EtlQualityRuleType.NotNull },
+            };
+            var result = EtlQualityRuleEvaluator.Apply(
+                t, rules, EtlQualityRuleAction.Continue, out var failed, out _);
+
+            Assert.AreEqual(1, failed);
+            Assert.AreEqual(2, result.Rows.Count, "Continue 模式違規列照樣保留");
+            Assert.AreSame(t, result, "Continue 模式回傳原表，不 clone");
+        }
+
+        [TestMethod]
+        public void Abort_throws_on_first_violation()
+        {
+            var t = Table();
+            AddRow(t, "a@x.com", 30, "NEW", "C1");
+            AddRow(t, "b@x.com", 999, "NEW", "C2"); // out of range
+
+            var rules = new List<EtlQualityRule>
+            {
+                new() { Column = "Age", RuleType = EtlQualityRuleType.Range, Min = 0, Max = 120 },
+            };
+
+            Assert.ThrowsException<EtlQualityRuleViolationException>(() =>
+                EtlQualityRuleEvaluator.Apply(
+                    t, rules, EtlQualityRuleAction.Abort, out _, out _));
+        }
+
+        [TestMethod]
+        public void Multiple_rules_AND_together()
+        {
+            var t = Table();
+            AddRow(t, "a@x.com", 30, "NEW", "C1");      // pass
+            AddRow(t, "b@x.com", 200, "NEW", "C2");     // age fail
+            AddRow(t, "no-at", 30, "NEW", "C3");        // email fail
+            AddRow(t, "c@x.com", 30, "EVIL", "C4");     // status fail
+
+            var rules = new List<EtlQualityRule>
+            {
+                new() { Column = "Age", RuleType = EtlQualityRuleType.Range, Min = 0, Max = 120 },
+                new() { Column = "Email", RuleType = EtlQualityRuleType.Regex, Pattern = @"^[^@\s]+@[^@\s]+\.[^@\s]+$" },
+                new() { Column = "Status", RuleType = EtlQualityRuleType.In, Allowed = new List<string> { "NEW", "PAID" } },
+            };
+            var result = EtlQualityRuleEvaluator.Apply(
+                t, rules, EtlQualityRuleAction.Drop, out var failed, out _);
+
+            Assert.AreEqual(3, failed);
+            Assert.AreEqual(1, result.Rows.Count);
+        }
+
+        [TestMethod]
+        public void Sample_capped_at_MaxFailureSamples()
+        {
+            var t = Table();
+            for (int i = 0; i < EtlQualityRuleEvaluator.MaxFailureSamples + 5; i++)
+            {
+                AddRow(t, "x@y.z", 30, "NEW", null); // 全違規
+            }
+            var rules = new List<EtlQualityRule>
+            {
+                new() { Column = "CustomerId", RuleType = EtlQualityRuleType.NotNull },
+            };
+            var result = EtlQualityRuleEvaluator.Apply(
+                t, rules, EtlQualityRuleAction.Drop, out var failed, out var samples);
+
+            Assert.AreEqual(EtlQualityRuleEvaluator.MaxFailureSamples + 5, failed);
+            Assert.AreEqual(EtlQualityRuleEvaluator.MaxFailureSamples, samples.Count);
+            Assert.AreEqual(0, result.Rows.Count);
+        }
+
+        [TestMethod]
+        public void Missing_column_throws_ArgumentException()
+        {
+            var t = Table();
+            AddRow(t, "a@x.com", 30, "NEW", "C1");
+            var rules = new List<EtlQualityRule>
+            {
+                new() { Column = "NonExistent", RuleType = EtlQualityRuleType.NotNull },
+            };
+            Assert.ThrowsException<ArgumentException>(() =>
+                EtlQualityRuleEvaluator.Apply(
+                    t, rules, EtlQualityRuleAction.Drop, out _, out _));
+        }
+
+        [TestMethod]
+        public void Empty_rules_returns_original_table_unchanged()
+        {
+            var t = Table();
+            AddRow(t, "a@x.com", 30, "NEW", "C1");
+            var result = EtlQualityRuleEvaluator.Apply(
+                t, new List<EtlQualityRule>(), EtlQualityRuleAction.Drop, out var failed, out var samples);
+
+            Assert.AreEqual(0, failed);
+            Assert.AreEqual(0, samples.Count);
+            Assert.AreSame(t, result);
+        }
+
+        [TestMethod]
+        public void Range_skips_null_values_silently()
+        {
+            // 規則只管「有值就在範圍內」；null 由 NotNull 規則處理
+            var t = Table();
+            AddRow(t, "a@x.com", 30, "NEW", "C1");
+            AddRow(t, "b@x.com", null, "NEW", "C2");    // null Age
+
+            var rules = new List<EtlQualityRule>
+            {
+                new() { Column = "Age", RuleType = EtlQualityRuleType.Range, Min = 0, Max = 120 },
+            };
+            var result = EtlQualityRuleEvaluator.Apply(
+                t, rules, EtlQualityRuleAction.Drop, out var failed, out _);
+
+            Assert.AreEqual(0, failed);
+            Assert.AreEqual(2, result.Rows.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three commits on top of mainline:

1. **`docs(manual)`** — documents the 31 features that landed in PR #847.
   Manual: 3,843 → 4,567 lines (+726).
2. **`feat(analysis)`** — `Forecast` linear-regression + moving-average
   projection (~555 lines, 12 tests).
3. **`feat(etl)`** — per-row data-quality rules with Drop / Continue /
   Abort actions (~576 lines, 11 tests).

### Forecast (Analysis Mode)

```csharp
req.Forecast = new ForecastSpec {
    Periods = 3,
    Method  = ForecastMethod.Linear,   // or MovingAverage
};
```

Engine appends `Periods` projected rows to `Rows`. Each carries
`_IsForecast = true` so the front-end can render the projected
segment differently. Activates only when the first dimension is a
date hierarchy; non-date dimensions silently no-op (graceful
fallback for misconfigured boards). `TotalCount` / `Insights` /
`GrandTotalRow` are NOT recomputed — forecasts are visual aid, not
authoritative. New `DateTruncator.NextLabel` helper advances one
period across all four hierarchies.

### Quality Rules (ETL)

```csharp
config = config with {
    QualityRules = new List<EtlQualityRule> {
        new() { Column = "CustomerId", RuleType = NotNull },
        new() { Column = "Age", RuleType = Range, Min = 0, Max = 120 },
        new() { Column = "Email", RuleType = Regex,
                Pattern = @"^[^@\s]+@[^@\s]+\.[^@\s]+$" },
        new() { Column = "Status", RuleType = In,
                Allowed = new() { "NEW", "PAID", "SHIPPED" } },
    },
    QualityRuleAction = EtlQualityRuleAction.Drop,
};
```

Three actions cover the operational lifecycle: `Drop` (default,
clean rows guaranteed), `Continue` (audit-only sizing), `Abort`
(strict — first violation discards watermark). Result surfaces
`QualityFailedRows` count + first 20 `QualityFailureSamples`. Regex
patterns are compiled-cached with a 1-second match timeout (DoS
guard). Missing column at apply-time throws ArgumentException so
config typos surface at first batch, not silently in production.

## Test plan

- [x] **Analysis Mode** targeted regression: 104/104 green
  (QueryEngine, DistinctCount, SortAndTopN, Forecast).
- [x] **ETL Pipeline + Dashboard** targeted regression: 129/134 green
  (5 skipped — Oracle / live-DB integration tests).
- [x] Build clean: 0 errors across Core + Etl projects.
- [ ] Reviewer confirm `_IsForecast` payload shape is what front-end
  charts expect (`Boolean true` literal, separate from numeric
  measure cells).
- [ ] Reviewer confirm `Drop` semantics in production: violating
  rows are excluded from `LoadedRows` count but still appear in
  `QualityFailedRows` total.

https://claude.ai/code/session_01RYTNnjKZxT635weRSQaKPz