### PR TITLE
fix(security): bump OpenTelemetry 1.15.0 → 1.15.3 to clear src/* transitive vulns — Closes #849

### DIFF
--- a/common.props
+++ b/common.props
@@ -51,7 +51,7 @@
     <SystemTextJsonVersion>10.0.4</SystemTextJsonVersion>
     <!-- Third-party packages -->
     <SwashbuckleVersion>10.1.5</SwashbuckleVersion>
-    <OpenTelemetryVersion>1.15.0</OpenTelemetryVersion>
+    <OpenTelemetryVersion>1.15.3</OpenTelemetryVersion>
     <SerilogAspNetCoreVersion>10.0.0</SerilogAspNetCoreVersion>
     <QuartzVersion>3.16.1</QuartzVersion>
     <NPOIVersion>2.7.6</NPOIVersion>

--- a/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
+++ b/src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj
@@ -92,8 +92,8 @@
     <PackageReference Include="DUWENINK.Captcha" Version="0.8.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="$(ImageSharpVersion)" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="$(ImageSharpDrawingVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(AspNetCoreVersion)" />


### PR DESCRIPTION
## Summary

Eliminates 3 Moderate `OpenTelemetry.*` transitive vulnerabilities surfacing on `src/WalkingTec.Mvvm.Mvc` and `src/WalkingTec.Mvvm.Etl` (via project reference) after PR #847 introduced 1.15.0 transitives. Required to unblock the `/wtm-release-check` §8 gate for the upcoming 10.5.0 release.

| Advisory | Package | Vulnerable | Patched |
|----------|---------|------------|---------|
| [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) | `OpenTelemetry.Api` | `< 1.15.3` | **1.15.3** |
| [GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933) | `OpenTelemetry.Exporter.OpenTelemetryProtocol` | `< 1.15.2` | **1.15.2** |
| [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p) | `OpenTelemetry.Exporter.OpenTelemetryProtocol` | `< 1.15.3` | **1.15.3** |

## Changes

- `common.props`: `<OpenTelemetryVersion>` `1.15.0` → `1.15.3` (Api/Exporter/Extensions.Hosting all have 1.15.3)
- `src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj`:
  - `OpenTelemetry.Instrumentation.Http` `$(OpenTelemetryVersion)` → hardcoded `1.15.1` (NuGet has no `1.15.3` of this package; no advisory affects it; pinning explicitly so future `OpenTelemetryVersion` bumps don't break the build again).
  - `OpenTelemetry.Instrumentation.AspNetCore` `1.15.1` → `1.15.2` (latest available; no advisory; refresh).

## Test plan

- [x] `dotnet build WalkingTec.Mvvm.sln -c Release` — 0 errors, 261 warnings (baseline)
- [x] `dotnet list WalkingTec.Mvvm.sln package --vulnerable --include-transitive` — all 4 packable src projects clean (`Core` / `Mvc` / `Etl` / `TagHelpers.LayUI`); demo/test projects also clean now (NuGet resolves transitives to the bumped versions)
- [x] CI-scope tests: 2035 passed / 17 skipped / 0 failed (`Mvc.Tests` 38, `Admin.Test` 75, `Api.Test` 20, `Etl.Test` 255+17, `Core.Test` 1647)
- [x] No public API change; pure dependency bump

Closes #849