### PR TITLE
fix(e2e): TC-04 — explicit visibility sync before analysis-mode click — Closes #851

### DIFF
--- a/test/e2e/wtm_e2e_tests.py
+++ b/test/e2e/wtm_e2e_tests.py
@@ -362,8 +362,11 @@ async def tc_04_analysis_mode_page(page, **_):
     await page.screenshot(path=sc(4, "02-toolbar"))
     assert btn_count > 0, "找不到「分析模式」按鈕！"
 
-    # 點擊切換
-    await analysis_btn.first.click()
+    # 點擊切換 — explicit visibility sync to avoid layout-fade flake (issue #851)
+    first_btn = analysis_btn.first
+    await first_btn.scroll_into_view_if_needed()
+    await first_btn.wait_for(state="visible", timeout=10000)
+    await first_btn.click()
     # 等待 meta API 載入和面板渲染
     try:
         await page.wait_for_selector("[id^='analysis-panel-']", state="visible", timeout=5000)


### PR DESCRIPTION
## Summary

Stabilizes TC-04 against a recurring layout-fade flake that has surfaced on at least three feature-branch CI runs (#809 once, #850 twice). The button is in the DOM by the time the locator resolves, but LayUI's grid toolbar fade-in can leave it `not visible` for longer than Playwright's 20s click-retry budget.

## Change

\`test/e2e/wtm_e2e_tests.py\` TC-04: insert two await points before \`.click()\` —

- \`scroll_into_view_if_needed()\` rules out toolbar-overflow invisibility.
- \`wait_for(state=\"visible\")\` returns exactly when the layout reports the button visible, instead of polling the click verb.

5-line diff. No assertion changes. Real regressions still fail (just at a more informative await).

## Test plan

- [x] CI \`e2e\` job passes on this PR.
- [ ] After merge, rebase PR #850 on latest \`dotnet10\` and confirm its e2e clears too.

## Driver

Blocks PR #850 (OpenTelemetry 1.15.0 → 1.15.3 vuln bump for the 10.5.0 release). Per \`/wtm-release-check\` skill, \"tests fail but it's flaky, retry\" is a hard anti-pattern; the flake must be neutralized in the suite, not paved over with reruns.

Closes #851