### PR TITLE
security: redact tailnet hostname and macOS username from docs

### DIFF
--- a/docs/github-packages.md
+++ b/docs/github-packages.md
@@ -17,7 +17,7 @@ WTM 目前主要發佈以下三個 package：
 - `WalkingTec.Mvvm.Mvc`
 - `WalkingTec.Mvvm.TagHelpers.LayUI`
 
-版本號統一由 [version.props](/Users/openclaw/.openclaw/shared/projects/WTM/version.props) 的 `VersionPrefix` 控制。
+版本號統一由 [version.props](~/.openclaw/shared/projects/WTM/version.props) 的 `VersionPrefix` 控制。
 
 ---
 
@@ -99,7 +99,7 @@ dotnet pack src/WalkingTec.Mvvm.Mvc/WalkingTec.Mvvm.Mvc.csproj -c Release -o nup
 
 ### 穩定版
 
-直接修改 [version.props](/Users/openclaw/.openclaw/shared/projects/WTM/version.props)：
+直接修改 [version.props](~/.openclaw/shared/projects/WTM/version.props)：
 
 ```xml
 <VersionPrefix>8.2.1</VersionPrefix>
@@ -127,7 +127,7 @@ workflow dispatch 時可帶 `version_suffix`，例如：
 
 本 repo 已內建 workflow：
 
-- [`.github/workflows/publish-nuget.yml`](/Users/openclaw/.openclaw/shared/projects/WTM/.github/workflows/publish-nuget.yml)
+- [`.github/workflows/publish-nuget.yml`](~/.openclaw/shared/projects/WTM/.github/workflows/publish-nuget.yml)
 
 它具備以下行為：
 
@@ -140,7 +140,7 @@ workflow dispatch 時可帶 `version_suffix`，例如：
 
 repo 內提供：
 
-- [`scripts/release-github-package.sh`](/Users/openclaw/.openclaw/shared/projects/WTM/scripts/release-github-package.sh)
+- [`scripts/release-github-package.sh`](~/.openclaw/shared/projects/WTM/scripts/release-github-package.sh)
 
 穩定版：
 
@@ -162,7 +162,7 @@ repo 內提供：
 
 這個腳本會：
 
-1. 修改 [version.props](/Users/openclaw/.openclaw/shared/projects/WTM/version.props) 的 `VersionPrefix`
+1. 修改 [version.props](~/.openclaw/shared/projects/WTM/version.props) 的 `VersionPrefix`
 2. 建立 release commit
 3. push 到 `origin/dotnet8`
 4. 觸發 `publish-nuget.yml`
@@ -253,4 +253,4 @@ NuGet package version 應視為不可變。若已發過：
 
 ### 為什麼 workflow 用 tag 觸發，但版本不是 tag 名稱
 
-因為目前 workflow 的版本來源是 [version.props](/Users/openclaw/.openclaw/shared/projects/WTM/version.props) 與 `version_suffix`，不是從 tag 名稱解析。
+因為目前 workflow 的版本來源是 [version.props](~/.openclaw/shared/projects/WTM/version.props) 與 `version_suffix`，不是從 tag 名稱解析。

--- a/docs/superpowers/plans/2026-03-20-dotnet10-package-upgrade.md
+++ b/docs/superpowers/plans/2026-03-20-dotnet10-package-upgrade.md
@@ -70,7 +70,7 @@ gh issue edit NNN --repo cct08311github/WalkingTec.Mvvm --add-label "in-progress
 - [ ] **Step 3: Create feature branch**
 
 ```bash
-cd /Users/openclaw/.openclaw/shared/projects/WTM
+cd ~/.openclaw/shared/projects/WTM
 git checkout dotnet8
 git pull origin dotnet8
 git checkout -b chore/issue-NNN-dotnet10-package-upgrade

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -7,7 +7,7 @@
 - 一般 MVC/API 請求如何流過 Controller、ViewModel、`WTMContext` 與 `DataContext`
 - Analysis Mode 如何在既有 ListVM 上擴充分析能力
 
-如果你要看 Analysis Mode 的 API、欄位標註與安全限制細節，請直接搭配 [docs/analysis-mode.md](/Users/openclaw/.openclaw/shared/projects/WTM/docs/analysis-mode.md) 一起讀。
+如果你要看 Analysis Mode 的 API、欄位標註與安全限制細節，請直接搭配 [docs/analysis-mode.md](~/.openclaw/shared/projects/WTM/docs/analysis-mode.md) 一起讀。
 
 ---
 
@@ -85,7 +85,7 @@ WTM 的啟動分成兩件事：
 
 ### `AddWtmContext(config)` 做了什麼
 
-根據 [src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs](/Users/openclaw/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs)，這個方法會完成以下核心工作：
+根據 [src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs](~/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs)，這個方法會完成以下核心工作：
 
 - 註冊 `HttpContextAccessor`
 - 註冊 `GlobalData`
@@ -206,7 +206,7 @@ sequenceDiagram
 
 #### `WtmMiddleware`
 
-根據 [src/WalkingTec.Mvvm.Mvc/Helper/WtmMiddleware.cs](/Users/openclaw/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/Helper/WtmMiddleware.cs)，它主要做的是框架層級請求預處理：
+根據 [src/WalkingTec.Mvvm.Mvc/Helper/WtmMiddleware.cs](~/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/Helper/WtmMiddleware.cs)，它主要做的是框架層級請求預處理：
 
 - 設定最大 request body size
 - 特殊處理工作流路由
@@ -364,14 +364,14 @@ flowchart LR
 
 如果你要真正進入這套系統，建議照這個順序讀：
 
-1. [src/WalkingTec.Mvvm.Core/BaseVM.cs](/Users/openclaw/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Core/BaseVM.cs)
-2. [src/WalkingTec.Mvvm.Core/WTMContext.cs](/Users/openclaw/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Core/WTMContext.cs)
-3. [src/WalkingTec.Mvvm.Core/BasePagedListVM.cs](/Users/openclaw/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Core/BasePagedListVM.cs)
-4. [src/WalkingTec.Mvvm.Mvc/BaseController.cs](/Users/openclaw/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/BaseController.cs)
-5. [src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs](/Users/openclaw/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs)
-6. [src/WalkingTec.Mvvm.Mvc/Helper/WtmMiddleware.cs](/Users/openclaw/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/Helper/WtmMiddleware.cs)
-7. [src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs](/Users/openclaw/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs)
-8. [docs/analysis-mode.md](/Users/openclaw/.openclaw/shared/projects/WTM/docs/analysis-mode.md)
+1. [src/WalkingTec.Mvvm.Core/BaseVM.cs](~/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Core/BaseVM.cs)
+2. [src/WalkingTec.Mvvm.Core/WTMContext.cs](~/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Core/WTMContext.cs)
+3. [src/WalkingTec.Mvvm.Core/BasePagedListVM.cs](~/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Core/BasePagedListVM.cs)
+4. [src/WalkingTec.Mvvm.Mvc/BaseController.cs](~/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/BaseController.cs)
+5. [src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs](~/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs)
+6. [src/WalkingTec.Mvvm.Mvc/Helper/WtmMiddleware.cs](~/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/Helper/WtmMiddleware.cs)
+7. [src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs](~/.openclaw/shared/projects/WTM/src/WalkingTec.Mvvm.Mvc/_AnalysisController.cs)
+8. [docs/analysis-mode.md](~/.openclaw/shared/projects/WTM/docs/analysis-mode.md)
 
 ---
 

--- a/progress.md
+++ b/progress.md
@@ -30,7 +30,7 @@ Current HEAD: `bfc58961` (`docs: reconcile progress handoff with verified repo s
 - `Extensions/ListVMExtension.cs` is still `#nullable disable`
 - only 2 Core files remain explicitly disabled, but the nullable cleanup is not functionally done because many enabled files still warn
 - current forced rebuild baseline:
-  - `/Users/openclaw/.dotnet/dotnet build src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj -c Release -t:Rebuild`
+  - `~/.dotnet/dotnet build src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj -c Release -t:Rebuild`
   - result: `56 warnings / 0 errors`
 - do not claim "only WTMContext remains" unless `PropertyHelper.cs`, `Utils.cs`, `ExcelPropety.cs`, and other enabled files are brought back to a stable warning target
 
@@ -51,10 +51,10 @@ The previously separate `feature/8.1.15-testing` work is now merged into `dotnet
 
 ## Verified Commands
 
-- `/Users/openclaw/.dotnet/dotnet build src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj -c Release -t:Rebuild`
+- `~/.dotnet/dotnet build src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj -c Release -t:Rebuild`
   - PASS
   - `56 warnings / 0 errors`
-- `/Users/openclaw/.dotnet/dotnet test WalkingTec.Mvvm.sln -c Release`
+- `~/.dotnet/dotnet test WalkingTec.Mvvm.sln -c Release`
   - PASS
   - Core.Tests `61/61`
   - Mvc.Tests `24/24`


### PR DESCRIPTION
Closes #858

## Summary

Redact 21 references to internal infrastructure across 4 documentation files. All 4 are markdown — no runtime impact.

## Files changed
- `docs/github-packages.md` (6 hits)
- `docs/system-architecture.md` (11 hits)
- `docs/superpowers/plans/2026-03-20-dotnet10-package-upgrade.md` (1 hit)
- `progress.md` (3 hits)